### PR TITLE
[WIP][#30] Fix i14y querying

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -171,6 +171,7 @@ class ApplicationController < ActionController::Base
       @search_params.merge!(tbs: @search.tbs) if @search.tbs
       @search_params.merge!(since_date: @search.since.strftime(I18n.t(:cdr_format))) if permitted_params[:since_date].present? && @search.since
       @search_params.merge!(until_date: @search.until.strftime(I18n.t(:cdr_format))) if permitted_params[:until_date].present? && @search.until
+      @search_params.merge!(dc: permitted_params[:dc]) if permitted_params[:dc].present?
       @search_params.merge!(permitted_params.slice(:contributor, :publisher, :sort_by, :subject))
     end
   end

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -115,7 +115,11 @@ class SearchesController < ApplicationController
   end
 
   def set_docs_search_options
-    @search_options = search_options_from_params :dc
+    @search_options = search_options_from_params :dc,
+                                                 :since_date,
+                                                 :sort_by,
+                                                 :tbs,
+                                                 :until_date
     document_collection = @affiliate.document_collections.find_by_id(@search_options[:dc])
     @search_options.merge!(document_collection: document_collection)
   end

--- a/app/helpers/searches/paths_helper.rb
+++ b/app/helpers/searches/paths_helper.rb
@@ -22,11 +22,11 @@ module Searches::PathsHelper
   end
 
   def path_for_i14y_search(search, search_params, extra_params = {})
-    i14y_params = search_params.slice(:affiliate, :m)
+    i14y_params = search_params.slice(:affiliate, :m, :dc)
     i14y_params[:query] = search.query
     i14y_params.merge! extract_current_search_filter_params(search)
     i14y_params.merge! extra_params
-    search_path i14y_params
+    docs_search_path i14y_params
   end
 
   def path_for_blended_search(search, search_params, extra_params = {})

--- a/app/models/search.rb
+++ b/app/models/search.rb
@@ -39,7 +39,6 @@ class Search
   def run
     @error_message = (I18n.translate :too_long) and return false if @query.length > MAX_QUERYTERM_LENGTH
     @error_message = (I18n.translate :empty_query) and return false unless query_present_or_blank_ok? and !query_blacklisted?
-
     response = search
     handle_response(response)
     populate_additional_results

--- a/spec/helpers/searches/paths_helper_spec.rb
+++ b/spec/helpers/searches/paths_helper_spec.rb
@@ -11,11 +11,37 @@ describe Searches::PathsHelper do
                                         sort_by: 'date',
                                         tbs: 'm',
                                         per_page: 20,
+                                        dc: 1,
                                         query: 'test query') }
 
-      it 'returns the correct search path' do 
+      it 'returns the correct search path' do
+        expected_params = { affiliate: affiliate, query: 'test query', sort_by: 'date', tbs: 'm', dc: 1 }
+        expect(helper.path_for_filterable_search(i14y_search, {affiliate: affiliate, dc: 1}, {})).to eq(docs_search_path expected_params)
+      end
+    end
+
+    context 'Blended search' do
+      let(:blended_search) { BlendedSearch.new(affiliate: affiliate,
+                                               sort_by:   'date',
+                                               tbs:       'm',
+                                               query:     'test query') }
+
+      it 'returns the correct search path' do
         expected_params = { affiliate: affiliate, query: 'test query', sort_by: 'date', tbs: 'm' }
-        expect(helper.path_for_filterable_search(i14y_search, {affiliate: affiliate}, {})).to eq(search_path expected_params)
+        expect(helper.path_for_filterable_search(blended_search, {affiliate: affiliate}, {})).to eq(search_path expected_params)
+      end
+    end
+
+
+    context 'News search' do
+      let(:news_search) { NewsSearch.new(affiliate: affiliate,
+                                         sort_by:   'date',
+                                         tbs:       'm',
+                                         query:     'test query') }
+
+      it 'returns the correct search path' do
+        expected_params = { affiliate: affiliate, query: 'test query', sort_by: 'date', tbs: 'm' }
+        expect(helper.path_for_filterable_search(news_search, {affiliate: affiliate}, {})).to eq(news_search_path expected_params)
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -105,6 +105,9 @@ RSpec.configure do |config|
       options[:re_record_interval] = nil if /bing.?v5/i === name
       options[:re_record_interval] = nil if /google|gss/i === name
 
+      # disable re-recording application_document_title cassettes which relies on tika server.
+      options[:re_record_interval] = nil if /application_document_title/ === name
+
       VCR.use_cassette(name, options, &example)
     end
   end


### PR DESCRIPTION
Fix https://github.com/GSA/search-gov/issues/30.

- Use `/search/docs` as the path for `I14ySearch`.
- Includes `tbs` and `sort_by` into `@search_options`. This will be used to send to i14y service.
- Disable re-recording of `application_document_title` cassettes. Why do these need to be rerecorded every 2 months anyway?

@nickmarden 