### PR TITLE
[#158173466] Add sort_by=date support to /api/v2/search/i14y

### DIFF
--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -129,9 +129,8 @@ module Api
         when :azure_web then Api::AzureCompositeWebSearchOptions
         when :azure_image then Api::AzureCompositeImageSearchOptions
         when :bing then Api::SecretAPISearchOptions
-        when :blended, :video then Api::NonCommercialSearchOptions
+        when :blended, :i14y, :video then Api::NonCommercialSearchOptions
         when :gss then Api::GssSearchOptions
-        when :i14y then Api::SearchOptions
         when :docs then Api::DocsSearchOptions
         end
       end

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -378,7 +378,7 @@
 
 
 
-    It uses the same required parameters. All optional parameters except the `sort_by` are supported.
+    It uses the same required parameters. All optional parameters are supported.
 
 
 

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -13,7 +13,8 @@ describe Api::V2::SearchesController do
       query_or: 'alternative',
       query_quote: 'barack obama',
       filetype: 'pdf',
-      filter: '2'
+      filter: '2',
+      sort_by: 'date',
     }
   end
   let(:query_params) do
@@ -349,7 +350,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiI14ySearch, as_json: { foo: 'bar'}, modules: %w(I14Y)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiI14ySearch).to receive(:new).with(hash_including(:query => 'api')).and_return(search)
@@ -363,16 +363,23 @@ describe Api::V2::SearchesController do
       end
 
       it { is_expected.to respond_with :success }
-    end
 
-    context 'when the search options include sort_by' do
-      it 'includes sort_by in the options it provides to its ApiI14ySearch object' do
-        get :i14y,
-            affiliate: 'usagov',
-            format: 'json',
-            query: 'api',
-            sort_by: 'date'
-        expect(assigns(:search_options).sort_by).to eq('date')
+      it 'passes the correct options to its ApiI4ySearch object' do
+        expect(assigns(:search_options).attributes).to include({
+          access_key: 'usagov_key',
+          affiliate: affiliate,
+          enable_highlighting: true,
+          file_type: 'pdf',
+          filter: '2',
+          limit: 20,
+          next_offset_within_limit: true,
+          offset: 0,
+          query: 'api',
+          query_not: 'excluded',
+          query_or: 'alternative',
+          query_quote: 'barack obama',
+          sort_by: 'date',
+        })
       end
     end
 

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -365,6 +365,17 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
     end
 
+    context 'when the search options include sort_by' do
+      it 'includes sort_by in the options it provides to its ApiI14ySearch object' do
+        get :i14y,
+            affiliate: 'usagov',
+            format: 'json',
+            query: 'api',
+            sort_by: 'date'
+        expect(assigns(:search_options).sort_by).to eq('date')
+      end
+    end
+
     context 'when the search options are not valid and the routed flag is enabled' do
       let(:affiliate) { affiliates(:usagov_affiliate) }
 


### PR DESCRIPTION
@MothOnMars it turns out that when the `/api/v2/search/i14y` endpoint was originally created, it was wired up to the wrong search options validator class. The `Api::NonCommercialSearchOptions` is just like the `Api::SearchOptions` class except that it adds the `sort_by` option which `I14yApiSearch` already knows how to properly consume.