### PR TITLE
[#155989343] Use original i14y query instead of spelling suggestion for govbox searches

### DIFF
--- a/app/models/i14y_search.rb
+++ b/app/models/i14y_search.rb
@@ -69,7 +69,7 @@ class I14ySearch < FilterableSearch
   end
 
   def populate_additional_results
-    @govbox_set = GovboxSet.new(@spelling_suggestion || query,
+    @govbox_set = GovboxSet.new(query,
                                 affiliate,
                                 @options[:geoip_info],
                                 @highlight_options) if first_page?

--- a/app/models/i14y_search.rb
+++ b/app/models/i14y_search.rb
@@ -69,10 +69,7 @@ class I14ySearch < FilterableSearch
   end
 
   def populate_additional_results
-    @govbox_set = GovboxSet.new(query,
-                                affiliate,
-                                @options[:geoip_info],
-                                @highlight_options) if first_page?
+    @govbox_set = GovboxSet.new(query, affiliate, @options[:geoip_info], @highlight_options) if first_page?
   end
 
 

--- a/spec/models/api_i14y_search_spec.rb
+++ b/spec/models/api_i14y_search_spec.rb
@@ -21,7 +21,7 @@ describe ApiI14ySearch do
       end
 
       before do
-        expect(GovboxSet).to receive(:new).with('marketplace',
+        expect(GovboxSet).to receive(:new).with('marketplase',
                                             affiliate,
                                             nil,
                                             highlighting: true,
@@ -64,7 +64,7 @@ describe ApiI14ySearch do
       end
 
       before do
-        expect(GovboxSet).to receive(:new).with('marketplace',
+        expect(GovboxSet).to receive(:new).with('marketplase',
                                             affiliate,
                                             nil,
                                             highlighting: false,


### PR DESCRIPTION
The fact that we do a govbox search using i14y's spelling suggestion for the user's original search term instead of doing a govbox search using the user's original search term is causing trouble. The fix is to just use the user's original search term for the govbox search (and update the appropriate expectations in the specs, of course).