### PR TITLE
include searchgov domain in domain error

### DIFF
--- a/app/models/searchgov_url.rb
+++ b/app/models/searchgov_url.rb
@@ -41,7 +41,7 @@ class SearchgovUrl < ActiveRecord::Base
   class DomainError < StandardError; end
 
   def fetch
-    raise DomainError.new(searchgov_domain.status) if !searchgov_domain.available?
+    raise DomainError.new("#{searchgov_domain.domain}: #{searchgov_domain.status}") if !searchgov_domain.available?
     self.update_attributes(last_crawled_at: Time.now)
     self.load_time = Benchmark.realtime do
       DocumentFetchLogger.new(url, 'searchgov_url').log

--- a/spec/models/searchgov_url_spec.rb
+++ b/spec/models/searchgov_url_spec.rb
@@ -569,18 +569,20 @@ describe SearchgovUrl do
 
     context 'when the domain is unavailable' do
       let(:unavailable_domain) do
-        instance_double(SearchgovDomain, :available? => false, status: '403')
+        instance_double(
+          SearchgovDomain, domain: 'unavailable.gov', :available? => false, status: '403'
+        )
       end
       before do
         allow(searchgov_url).to receive(:searchgov_domain).and_return(unavailable_domain)
       end
 
-      it 'raises an error' do
-        expect{ fetch }.to raise_error(SearchgovUrl::DomainError, '403')
+      it 'raises an error, including the domain' do
+        expect{ fetch }.to raise_error(SearchgovUrl::DomainError, 'unavailable.gov: 403')
       end
 
       it 'does not fetch the url' do
-        expect{ fetch }.to raise_error(SearchgovUrl::DomainError, '403')
+        expect{ fetch }.to raise_error(SearchgovUrl::DomainError, 'unavailable.gov: 403')
         expect(stub_request(:get, url)).not_to have_been_requested
       end
     end


### PR DESCRIPTION
@noremmie , this change is intended to make it easier to separate domain errors in Airbrake. Currently, all domains with a '403' are lumped into the same Airbrake error, which means I can't mark an error as "resolved". (See https://usasearch.airbrake.io/projects/8947/groups/2240096797637687266?tab=overview .) 

This will also make it easier to see which domains are blocking us in Airbrake alerts.