### PR TITLE
[#158131076] follow client-side redirects for searchgov urls

### DIFF
--- a/app/models/html_document.rb
+++ b/app/models/html_document.rb
@@ -19,8 +19,8 @@ class HtmlDocument < WebDocument
   def redirect_url
     refresh = html.css('meta[http-equiv]').detect{|node| /refresh/i === node['http-equiv'] }
     if refresh
-      new_path = refresh['content'].match(/.*URL=('|")?(?<path>[^('|")]*)/i)[:path]
-      URI.join(url, new_path).to_s
+      new_path = refresh['content'].match(/.*URL=['"]?(?<path>[^'"]*)/i)[:path]
+      URI.join(url, URI.encode(new_path)).to_s
     end
   end
 

--- a/app/models/html_document.rb
+++ b/app/models/html_document.rb
@@ -20,7 +20,7 @@ class HtmlDocument < WebDocument
     refresh = html.css('meta[http-equiv]').detect{|node| /refresh/i === node['http-equiv'] }
     if refresh
       new_path = refresh['content'].match(/.*URL=['"]?(?<path>[^'"]*)/i)[:path]
-      URI.join(url, URI.encode(new_path)).to_s
+      URI.join(url, Addressable::URI.encode(new_path)).to_s
     end
   end
 

--- a/app/models/html_document.rb
+++ b/app/models/html_document.rb
@@ -18,8 +18,10 @@ class HtmlDocument < WebDocument
   # Returns client-side redirect url
   def redirect_url
     refresh = html.css('meta[http-equiv]').detect{|node| /refresh/i === node['http-equiv'] }
-    new_path = refresh.try(:[],'content')&.gsub(/.*url=/i,'')
-    URI(url).merge(URI(new_path)).to_s if new_path
+    if refresh
+      new_path = refresh['content'].match(/.*URL=('|")?(?<path>[^('|")]*)/i)[:path]
+      URI.join(url, new_path).to_s
+    end
   end
 
   private

--- a/app/models/searchgov_url.rb
+++ b/app/models/searchgov_url.rb
@@ -94,15 +94,14 @@ class SearchgovUrl < ActiveRecord::Base
 
   def validate_response
     searchgov_domain.check_status if response.code == 403
-    handle_redirection if self.url != response.uri.to_s
+    handle_redirection(response.uri.to_s) if self.url != response.uri.to_s
     raise SearchgovUrlError.new(response.code) unless response.code == 200
     validate_size
     raise SearchgovUrlError.new('Noindex per X-Robots-Tag header') if noindex?
   end
 
-  def handle_redirection
-    raise SearchgovUrlError.new("Redirection forbidden to #{response.uri}") if redirected_outside_domain?
-    new_url = response.uri.to_s
+  def handle_redirection(new_url)
+    raise SearchgovUrlError.new("Redirection forbidden to #{new_url}") if redirected_outside_domain?(new_url)
     SearchgovUrl.create(url: new_url)
     raise SearchgovUrlError.new("Redirected to #{new_url}")
   end
@@ -115,6 +114,7 @@ class SearchgovUrl < ActiveRecord::Base
   end
 
   def validate_document
+    handle_redirection(document.redirect_url) if document.redirect_url
     raise SearchgovUrlError.new(404) if /page not found|404 error/i === document.title
     raise SearchgovUrlError.new('Noindex per HTML metadata') if document.noindex?
   end
@@ -169,8 +169,8 @@ class SearchgovUrl < ActiveRecord::Base
     end
   end
 
-  def redirected_outside_domain?
-    URI(url).host != response.uri.host
+  def redirected_outside_domain?(new_url)
+    URI(url).host != URI(new_url).host
   end
 
   def robots_directives

--- a/app/models/web_document.rb
+++ b/app/models/web_document.rb
@@ -30,6 +30,10 @@ class WebDocument
     false
   end
 
+  def redirect_url
+    nil
+  end
+
   private
 
   def parse_content

--- a/spec/models/application_document_spec.rb
+++ b/spec/models/application_document_spec.rb
@@ -103,4 +103,10 @@ describe ApplicationDocument do
       end
     end
   end
+
+  describe 'redirect_url' do
+    subject(:redirect_url) { application_document.redirect_url }
+
+    it { is_expected.to be nil }
+  end
 end

--- a/spec/models/html_document_spec.rb
+++ b/spec/models/html_document_spec.rb
@@ -332,6 +332,12 @@ describe HtmlDocument do
         expect(redirect_url).to eq 'https://foo.gov/new.html'
       end
 
+      context 'when the new URL is in quotes' do
+        let(:raw_document) { %(<html><meta http-equiv="refresh" content="0; URL='./new.html'"></html>) }
+
+        it { is_expected.to eq 'https://foo.gov/new.html' }
+      end
+
       context 'case-sensitivity' do
         let(:raw_document) { '<html><META http-equiv="REFRESH" content="0; URL=/new"></html>' }
 

--- a/spec/models/html_document_spec.rb
+++ b/spec/models/html_document_spec.rb
@@ -326,24 +326,49 @@ describe HtmlDocument do
     it { is_expected.to eq nil }
 
     context 'when the HTML sets a redirection' do
-      let(:raw_document) { '<html><meta http-equiv="refresh" content="0; URL=/new.html"></html>' }
+      let(:raw_document) do
+        '<html><meta http-equiv="refresh" content="0; URL=/new.html"></html>'
+      end
 
       it 'returns the new url' do
         expect(redirect_url).to eq 'https://foo.gov/new.html'
       end
 
-      context 'when the new URL is in quotes' do
-        let(:raw_document) { %(<html><meta http-equiv="refresh" content="0; URL='./new.html'"></html>) }
+      context 'when the new URL is in double quotes' do
+        let(:raw_document) do
+          %(<html><meta http-equiv="refresh" content="0; URL='./new.html'"></html>)
+        end
+
+        it { is_expected.to eq 'https://foo.gov/new.html' }
+      end
+
+      context 'when the new URL is in single quotes' do
+        let(:raw_document) do
+          %(<html><meta http-equiv='refresh' content='0; URL="./new.html"'></html>)
+        end
 
         it { is_expected.to eq 'https://foo.gov/new.html' }
       end
 
       context 'case-sensitivity' do
-        let(:raw_document) { '<html><META http-equiv="REFRESH" content="0; URL=/new"></html>' }
+        let(:raw_document) do
+          '<html><META http-equiv="REFRESH" content="0; URL=/new"></html>'
+        end
 
         it 'is not case-sensitive' do
           expect(redirect_url).to eq 'https://foo.gov/new'
         end
+      end
+
+      context 'when the URL contains special characters' do
+        let(:raw_document) do
+          '<html><meta http-equiv="refresh" content="0; URL=https://www.foo.gov/my|url’s_weird?!"></html>'
+        end
+
+        it 'encodes the characters' do
+          expect(redirect_url).to eq 'https://www.foo.gov/my%7Curl%E2%80%99s_weird?!'
+        end
+
       end
     end
   end


### PR DESCRIPTION
- fix HtmlDocument#redirect_url method for quoted paths