### PR TITLE
add timestamp to lastmod spec

### DIFF
--- a/spec/models/sitemap_indexer_spec.rb
+++ b/spec/models/sitemap_indexer_spec.rb
@@ -32,7 +32,7 @@ describe SitemapIndexer do
 
     context 'when the sitemap specifies a lastmod value' do
       let(:sitemap_entries) do
-        '<url><loc>http://agency.gov/doc1</loc><lastmod>2018-01-01</lastmod></url>'
+        '<url><loc>http://agency.gov/doc1</loc><lastmod>2018-01-01T12:00:00+00:00</lastmod></url>'
       end
 
       it 'sets the lastmod attribute' do


### PR DESCRIPTION
@noremmie , this change is intended to prevent this spec from breaking when it's run in a different timezone, such as:
```
1) SitemapIndexer#index when the sitemap specifies a lastmod value sets the lastmod attribute
     Failure/Error: expect(SearchgovUrl.last.lastmod.to_s).to match(/^2018-01-01/)

       expected "2017-12-31 16:00:00 UTC" to match /^2018-01-01/
       Diff:
       @@ -1,2 +1,2 @@
       -/^2018-01-01/
       +"2017-12-31 16:00:00 UTC"

     # ./spec/models/sitemap_indexer_spec.rb:40:in `block (4 levels) in <top (required)>'
     # ./spec/spec_helper.rb:107:in `block (2 levels) in <top (required)>' 
```