### PR TITLE
Fixes spec order dependencies.

### DIFF
--- a/spec/models/site_cloner_spec.rb
+++ b/spec/models/site_cloner_spec.rb
@@ -321,7 +321,7 @@ describe SiteCloner do
         end
 
         it 're-enables the routed_query_keyword_observer' do
-          expect(ActiveRecord::Base.observers).to receive(:enable).with(:routed_query_keyword_observer)
+          expect(ActiveRecord::Base.observers).to receive(:enable).with(:routed_query_keyword_observer).and_call_original
           expect{cloner.clone}.to raise_error
         end
       end


### PR DESCRIPTION
Ensures that RoutedQueryKeywordObserver is enabled, and that `ActiveRecord::Base.observers.enable :routed_query_keyword_observer` does not return nil.