### PR TITLE
configure rspec to run with random order

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,6 +94,7 @@ jobs:
 
   rspec:
     working_directory: ~/search-gov
+    parallelism: 2
     docker:
       - image: circleci/ruby:2.3.5-browsers
         environment:
@@ -148,12 +149,12 @@ jobs:
                               --format progress \
                               $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
 
-            ./cc-test-reporter format-coverage --output coverage/codeclimate.rspec.json
+            ./cc-test-reporter format-coverage --output coverage/codeclimate.rspec.$CIRCLE_NODE_INDEX.json
 
       - persist_to_workspace:
           root: ~/search-gov/coverage
           paths:
-          - codeclimate.rspec.json
+          - codeclimate.rspec.*.json
 
       # collect reports
       - store_test_results:
@@ -257,7 +258,7 @@ jobs:
       - run:
           name: Report coverage to Code Climate
           command: |
-            ./cc-test-reporter sum-coverage --parts 7 coverage/codeclimate.*.json --output coverage/codeclimate_full_report.json
+            ./cc-test-reporter sum-coverage --parts 8 coverage/codeclimate.*.json --output coverage/codeclimate_full_report.json
             ./cc-test-reporter upload-coverage --input coverage/codeclimate_full_report.json
 
             ruby scripts/check_coverage.rb ${PWD}/coverage/codeclimate_full_report.json

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -42,6 +42,18 @@ if $LOADED_FEATURES.grep(/spec\/spec_helper\.rb/).any?
 end
 
 RSpec.configure do |config|
+  # Run specs in random order to surface order dependencies. If you find an
+  # order dependency and want to debug it, you can fix the order by providing
+  # the seed, which is printed after each run.
+  #     --seed 1234
+  config.order = :random
+
+  # Seed global randomization in this process using the `--seed` CLI option.
+  # Setting this allows you to use `--seed` to deterministically reproduce
+  # test failures related to randomization by passing the same `--seed` value
+  # as the one that triggered the failure.
+  Kernel.srand config.seed
+
   config.mock_with :rspec
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true


### PR DESCRIPTION
Changes spec_helper.rb config to run rspec tests in random order.