### PR TITLE
Remove nutshell columns

### DIFF
--- a/app/controllers/admin/affiliates_controller.rb
+++ b/app/controllers/admin/affiliates_controller.rb
@@ -66,7 +66,38 @@ class Admin::AffiliatesController < Admin::AdminController
       config.columns[c].form_ui = :textarea
     end
 
-    update_columns = attribute_columns.reject { |column| column =~ /\A(api_access_key|created_at|external_css_url|favicon_url|has_staged_content|id|nutshell_id|theme|updated_at)\z/i }
+    update_columns = %i[
+                         active
+                         agency
+                         bing_v5_key
+                         dap_enabled
+                         display_name
+                         domain_control_validation_code
+                         fetch_concurrency
+                         force_mobile_format
+                         ga_web_property_id
+                         gets_blended_results
+                         gets_commercial_results_on_blended_search
+                         gets_i14y_results
+                         google_cx
+                         google_key
+                         i14y_date_stamp_enabled
+                         is_bing_image_search_enabled
+                         is_federal_register_document_govbox_enabled
+                         is_medline_govbox_enabled
+                         is_photo_govbox_enabled
+                         is_related_searches_enabled
+                         is_rss_govbox_enabled
+                         is_sayt_enabled
+                         is_video_govbox_enabled
+                         jobs_enabled
+                         locale
+                         name
+                         raw_log_access_enabled
+                         search_consumer_search_enabled
+                         search_engine
+                         website
+                       ]
     config.update.columns = []
     enable_disable_column_regex = /^(is\_|dap_enabled|force_mobile_format|gets_blended_results|gets_commercial_results_on_blended_search|jobs_enabled|raw_log_access_enabled|search_consumer_search_enabled|gets_i14y_results)/.freeze
 

--- a/db/migrate/20181025225740_remove_nutshell_columns.rb
+++ b/db/migrate/20181025225740_remove_nutshell_columns.rb
@@ -1,6 +1,6 @@
 class RemoveNutshellColumns < ActiveRecord::Migration
   def change
-    remove_index :users, :nutshell_id
+    remove_index :users, column: :nutshell_id
     remove_column :users, :nutshell_id, :integer
     remove_column :affiliates, :nutshell_id, :integer
   end

--- a/db/migrate/20181025225740_remove_nutshell_columns.rb
+++ b/db/migrate/20181025225740_remove_nutshell_columns.rb
@@ -1,0 +1,7 @@
+class RemoveNutshellColumns < ActiveRecord::Migration
+  def change
+    remove_index :users, :nutshell_id
+    remove_column :users, :nutshell_id, :integer
+    remove_column :affiliates, :nutshell_id, :integer
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.13  Distrib 5.6.41, for osx10.13 (x86_64)
+-- MySQL dump 10.13  Distrib 5.6.42, for osx10.12 (x86_64)
 --
 -- Host: localhost    Database: usasearch_development
 -- ------------------------------------------------------
--- Server version	5.6.41
+-- Server version	5.6.42
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -136,7 +136,6 @@ CREATE TABLE `affiliates` (
   `google_cx` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `google_key` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   `api_access_key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
-  `nutshell_id` int(11) DEFAULT NULL,
   `gets_commercial_results_on_blended_search` tinyint(1) NOT NULL DEFAULT '1',
   `gets_i14y_results` tinyint(1) NOT NULL DEFAULT '0',
   `rackspace_header_tagline_logo_file_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
@@ -1461,15 +1460,13 @@ CREATE TABLE `users` (
   `requires_manual_approval` tinyint(1) DEFAULT '0',
   `default_affiliate_id` int(11) DEFAULT NULL,
   `sees_filtered_totals` tinyint(1) NOT NULL DEFAULT '1',
-  `nutshell_id` int(11) DEFAULT NULL,
   `failed_login_count` int(11) NOT NULL DEFAULT '0',
   `password_updated_at` datetime DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_api_key` (`api_key`),
   UNIQUE KEY `index_users_on_email_verification_token` (`email_verification_token`),
-  KEY `index_users_on_perishable_token` (`perishable_token`),
-  KEY `index_users_on_nutshell_id` (`nutshell_id`)
+  KEY `index_users_on_perishable_token` (`perishable_token`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -1563,7 +1560,7 @@ CREATE TABLE `youtube_profiles` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2018-11-16  9:52:13
+-- Dump completed on 2018-11-21 16:13:19
 INSERT INTO schema_migrations (version) VALUES ('20090818003200');
 
 INSERT INTO schema_migrations (version) VALUES ('20090827135344');
@@ -3003,6 +3000,8 @@ INSERT INTO schema_migrations (version) VALUES ('20180608190543');
 INSERT INTO schema_migrations (version) VALUES ('20180611171416');
 
 INSERT INTO schema_migrations (version) VALUES ('20180621213347');
+
+INSERT INTO schema_migrations (version) VALUES ('20181025225740');
 
 INSERT INTO schema_migrations (version) VALUES ('20181109212904');
 

--- a/spec/controllers/admin/affiliates_controller_spec.rb
+++ b/spec/controllers/admin/affiliates_controller_spec.rb
@@ -194,7 +194,6 @@ describe Admin::AffiliatesController do
             locale
             mobile_logo_url
             name
-            nutshell_id
             raw_log_access_enabled
             recent_user_activity
             related_sites_dropdown_label


### PR DESCRIPTION
SRCH-21 migration to remove nutshell_id columns
- database migration to remove nutshell_id columns from the `users` and `affiliates` tables