### PR TITLE
SRCH-94 - fix more jobs search to not return 404

### DIFF
--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -94,7 +94,7 @@ module JobsHelper
 
   def more_federal_jobs_title_and_url
     title = t :'searches.more_federal_job_openings'
-    url = 'https://www.usajobs.gov/Search/Results?hp=public&p=1'
+    url = 'https://www.usajobs.gov/Search/Results?hp=public'
     [title, url]
   end
 
@@ -102,7 +102,7 @@ module JobsHelper
     case job_id
     when /^usajobs/
       organization_codes = agency.joined_organization_codes.gsub(/\;/,"&a=")
-      "https://www.usajobs.gov/Search/Results?a=#{organization_codes}&p=1"
+      "https://www.usajobs.gov/Search/Results?a=#{organization_codes}"
     when /^ng:/
       ng_agency = job_id.split(':')[1]
       "http://agency.governmentjobs.com/#{ng_agency}/default.cfm"

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -101,7 +101,7 @@ module JobsHelper
   def url_for_more_agency_jobs(agency, job_id)
     case job_id
     when /^usajobs/
-      organization_codes = agency.joined_organization_codes.gsub(/\;/,"&a=")
+      organization_codes = agency.joined_organization_codes('&a=')
       "https://www.usajobs.gov/Search/Results?a=#{organization_codes}"
     when /^ng:/
       ng_agency = job_id.split(':')[1]

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -64,7 +64,12 @@ module JobsHelper
 
   def legacy_link_to_more_jobs(search)
     title, url = more_jobs_title_and_url search
-    job_link_with_click_tracking title, url, search.affiliate, search.query, agency_jobs_link_index = -1, @search_vertical
+    job_link_with_click_tracking title,
+                                 url,
+                                 search.affiliate,
+                                 search.query,
+                                 agency_jobs_link_index = -1,
+                                 @search_vertical
   end
 
   def more_jobs_title_and_url(search)
@@ -89,15 +94,15 @@ module JobsHelper
 
   def more_federal_jobs_title_and_url
     title = t :'searches.more_federal_job_openings'
-    url = 'https://www.usajobs.gov/JobSearch/Search/GetResults?PostingChannelID=USASearch'
+    url = 'https://www.usajobs.gov/Search/Results?hp=public&p=1'
     [title, url]
   end
 
   def url_for_more_agency_jobs(agency, job_id)
     case job_id
     when /^usajobs/
-      organization_codes = agency.joined_organization_codes
-      "https://www.usajobs.gov/JobSearch/Search/GetResults?organizationid=#{organization_codes}&PostingChannelID=USASearch&ApplicantEligibility=all"
+      organization_codes = agency.joined_organization_codes.gsub(/\;/,"&a=")
+      "https://www.usajobs.gov/Search/Results?a=#{organization_codes}&p=1"
     when /^ng:/
       ng_agency = job_id.split(':')[1]
       "http://agency.governmentjobs.com/#{ng_agency}/default.cfm"

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -102,7 +102,7 @@ module JobsHelper
     case job_id
     when /^usajobs/
       organization_codes = agency.joined_organization_codes('&a=')
-      "https://www.usajobs.gov/Search/Results?a=#{organization_codes}"
+      "https://www.usajobs.gov/Search/Results?a=#{organization_codes}&hp=public"
     when /^ng:/
       ng_agency = job_id.split(':')[1]
       "http://agency.governmentjobs.com/#{ng_agency}/default.cfm"

--- a/features/mobile_searches.feature
+++ b/features/mobile_searches.feature
@@ -456,7 +456,7 @@ Feature: Searches using mobile device
     Then I should see "Federal Job Openings"
     And I should see 10 job postings
     And I should see an image link to "USAJobs.gov" with url for "https://www.usajobs.gov/"
-    And I should see a link to "More federal job openings on USAJobs.gov" with url for "https://www.usajobs.gov/JobSearch/Search/GetResults?PostingChannelID=USASearch"
+    And I should see a link to "More federal job openings on USAJobs.gov" with url for "https://www.usajobs.gov/Search/Results?hp=public&p=1"
 
   Scenario: When using tablet device
     Given I am using a mobile device

--- a/features/mobile_searches.feature
+++ b/features/mobile_searches.feature
@@ -456,7 +456,7 @@ Feature: Searches using mobile device
     Then I should see "Federal Job Openings"
     And I should see 10 job postings
     And I should see an image link to "USAJobs.gov" with url for "https://www.usajobs.gov/"
-    And I should see a link to "More federal job openings on USAJobs.gov" with url for "https://www.usajobs.gov/Search/Results?hp=public&p=1"
+    And I should see a link to "More federal job openings on USAJobs.gov" with url for "https://www.usajobs.gov/Search/Results?hp=public"
 
   Scenario: When using tablet device
     Given I am using a mobile device

--- a/spec/helpers/jobs_helper_spec.rb
+++ b/spec/helpers/jobs_helper_spec.rb
@@ -67,7 +67,7 @@ describe JobsHelper do
       it 'should render an organization specific link to usajobs.gov' do
         expect(helper).to receive(:job_link_with_click_tracking).with(
             'More GSA job openings on USAJobs.gov',
-            'https://www.usajobs.gov/Search/Results?a=GS&a=HI',
+            'https://www.usajobs.gov/Search/Results?a=GS&a=HI&hp=public',
             search.affiliate, 'gov', -1, nil)
         helper.legacy_link_to_more_jobs(search)
       end
@@ -79,7 +79,7 @@ describe JobsHelper do
         it 'should render an organization specific link to usajobs in Spanish' do
           expect(helper).to receive(:job_link_with_click_tracking).with(
               'Más trabajos en GSA en USAJobs.gov',
-              'https://www.usajobs.gov/Search/Results?a=GS&a=HI',
+              'https://www.usajobs.gov/Search/Results?a=GS&a=HI&hp=public',
               search.affiliate, 'gov', -1, nil)
           helper.legacy_link_to_more_jobs(search)
         end

--- a/spec/helpers/jobs_helper_spec.rb
+++ b/spec/helpers/jobs_helper_spec.rb
@@ -44,7 +44,7 @@ describe JobsHelper do
         allow(search).to receive_message_chain(:affiliate, :agency).and_return(nil)
         expect(helper).to receive(:job_link_with_click_tracking).with(
             'More federal job openings on USAJobs.gov',
-            'https://www.usajobs.gov/Search/Results?hp=public&p=1',
+            'https://www.usajobs.gov/Search/Results?hp=public',
             search.affiliate, 'gov', -1, nil)
         helper.legacy_link_to_more_jobs(search)
       end
@@ -67,7 +67,7 @@ describe JobsHelper do
       it 'should render an organization specific link to usajobs.gov' do
         expect(helper).to receive(:job_link_with_click_tracking).with(
             'More GSA job openings on USAJobs.gov',
-            'https://www.usajobs.gov/Search/Results?a=GS&a=HI&p=1',
+            'https://www.usajobs.gov/Search/Results?a=GS&a=HI',
             search.affiliate, 'gov', -1, nil)
         helper.legacy_link_to_more_jobs(search)
       end
@@ -79,7 +79,7 @@ describe JobsHelper do
         it 'should render an organization specific link to usajobs in Spanish' do
           expect(helper).to receive(:job_link_with_click_tracking).with(
               'Más trabajos en GSA en USAJobs.gov',
-              'https://www.usajobs.gov/Search/Results?a=GS&a=HI&p=1',
+              'https://www.usajobs.gov/Search/Results?a=GS&a=HI',
               search.affiliate, 'gov', -1, nil)
           helper.legacy_link_to_more_jobs(search)
         end

--- a/spec/helpers/jobs_helper_spec.rb
+++ b/spec/helpers/jobs_helper_spec.rb
@@ -44,7 +44,7 @@ describe JobsHelper do
         allow(search).to receive_message_chain(:affiliate, :agency).and_return(nil)
         expect(helper).to receive(:job_link_with_click_tracking).with(
             'More federal job openings on USAJobs.gov',
-            'https://www.usajobs.gov/JobSearch/Search/GetResults?PostingChannelID=USASearch',
+            'https://www.usajobs.gov/Search/Results?hp=public&p=1',
             search.affiliate, 'gov', -1, nil)
         helper.legacy_link_to_more_jobs(search)
       end
@@ -67,7 +67,7 @@ describe JobsHelper do
       it 'should render an organization specific link to usajobs.gov' do
         expect(helper).to receive(:job_link_with_click_tracking).with(
             'More GSA job openings on USAJobs.gov',
-            'https://www.usajobs.gov/JobSearch/Search/GetResults?organizationid=GS;HI&PostingChannelID=USASearch&ApplicantEligibility=all',
+            'https://www.usajobs.gov/Search/Results?a=GS&a=HI&p=1',
             search.affiliate, 'gov', -1, nil)
         helper.legacy_link_to_more_jobs(search)
       end
@@ -79,7 +79,7 @@ describe JobsHelper do
         it 'should render an organization specific link to usajobs in Spanish' do
           expect(helper).to receive(:job_link_with_click_tracking).with(
               'Más trabajos en GSA en USAJobs.gov',
-              'https://www.usajobs.gov/JobSearch/Search/GetResults?organizationid=GS;HI&PostingChannelID=USASearch&ApplicantEligibility=all',
+              'https://www.usajobs.gov/Search/Results?a=GS&a=HI&p=1',
               search.affiliate, 'gov', -1, nil)
           helper.legacy_link_to_more_jobs(search)
         end

--- a/spec/views/searches/index.html.haml_spec.rb
+++ b/spec/views/searches/index.html.haml_spec.rb
@@ -176,7 +176,7 @@ describe "searches/index.html.haml" do
 
         expect(rendered).not_to have_content('Zero Money Research Job')
 
-        expect(rendered).to have_selector('a[href="https://www.usajobs.gov/Search/Results?hp=public&p=1"]',
+        expect(rendered).to have_selector('a[href="https://www.usajobs.gov/Search/Results?hp=public"]',
                                           text: 'More federal job openings on USAJobs.gov')
       end
 
@@ -186,7 +186,7 @@ describe "searches/index.html.haml" do
 
         it 'should show links with Spanish translations' do
           render
-          expect(rendered).to have_selector('a[href="https://www.usajobs.gov/Search/Results?hp=public&p=1"]',
+          expect(rendered).to have_selector('a[href="https://www.usajobs.gov/Search/Results?hp=public"]',
                                             text: 'Más trabajos en el gobierno federal en USAJobs.gov')
         end
       end

--- a/spec/views/searches/index.html.haml_spec.rb
+++ b/spec/views/searches/index.html.haml_spec.rb
@@ -176,7 +176,7 @@ describe "searches/index.html.haml" do
 
         expect(rendered).not_to have_content('Zero Money Research Job')
 
-        expect(rendered).to have_selector('a[href="https://www.usajobs.gov/JobSearch/Search/GetResults?PostingChannelID=USASearch"]',
+        expect(rendered).to have_selector('a[href="https://www.usajobs.gov/Search/Results?hp=public&p=1"]',
                                           text: 'More federal job openings on USAJobs.gov')
       end
 
@@ -186,7 +186,7 @@ describe "searches/index.html.haml" do
 
         it 'should show links with Spanish translations' do
           render
-          expect(rendered).to have_selector('a[href="https://www.usajobs.gov/JobSearch/Search/GetResults?PostingChannelID=USASearch"]',
+          expect(rendered).to have_selector('a[href="https://www.usajobs.gov/Search/Results?hp=public&p=1"]',
                                             text: 'Más trabajos en el gobierno federal en USAJobs.gov')
         end
       end


### PR DESCRIPTION
Update code so that the More jobs link no longer returns a 404 error and directs user to the correct USAJOBS page with the agencies selected.  