### PR TITLE
SRCH-140 - Cleanup Neogov jobs- related code

### DIFF
--- a/app/views/sites/displays/_govboxes.html.haml
+++ b/app/views/sites/displays/_govboxes.html.haml
@@ -23,7 +23,7 @@
     - if @site.agency.present?
       %tr
         %td Job openings
-        %td.cell-1x USAJobs/NeoGov
+        %td.cell-1x USAJOBS
         = switch_cell f, :jobs_enabled
 
       - if @site.agency.federal_register_agency.present?


### PR DESCRIPTION
SRCH-140 - Remove all references to Neogov
- the code is free of references to "Neogov" jobs
- the site admin display page doesn't mention Neogov jobs as a source
