### PR TITLE
SRCH-210 - update rack to address security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -472,7 +472,7 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.2)
-    rack (1.6.10)
+    rack (1.6.11)
     rack-accept (0.4.5)
       rack (>= 0.4)
     rack-contrib (1.8.0)


### PR DESCRIPTION
CVE-2018-16471 More information
moderate severity
Vulnerable versions: < 1.6.11
Patched version: 1.6.11