### PR TITLE
SRCH-246 filter USAJOBS secrets from VCR cassettes

### DIFF
--- a/config/secrets.yml.dev
+++ b/config/secrets.yml.dev
@@ -38,6 +38,8 @@ secret_keys: &SECRET_KEYS
   hosted_azure:
     account_key: hosted_azure_bing_v6_account_key
     v5_account_key: abcdef0123456789abcdef0123456789
+  jobs:
+    <<: *JOBS_SECRETS
   newrelic_secrets:
     <<: *NEWRELIC_SECRETS
   twitter:


### PR DESCRIPTION
The inclusion of the jobs secrets in the `secret_keys` section is necessary to ensure that those values will be filtered out of our VCR cassettes during test runs. (Note: there is a companion PR to update the `secrets.yml` file in `usasearch-cookbooks`: https://github.com/GSA/usasearch-cookbooks/pull/321)