### PR TITLE
SRCH-286 retain unknown HTML tags

### DIFF
--- a/app/models/html_document.rb
+++ b/app/models/html_document.rb
@@ -41,8 +41,19 @@ class HtmlDocument < WebDocument
     # it to html, then running it through Loofah again, it's because Loofah's 'to_text' method is
     # much smarter about whitespace than Nokogiri, but you can't run `to_text` on the Nokogiri
     # elements extracted by "html.at('main')". Hence the jumping through hoops.
-    plain_text = Loofah.fragment(main_html).scrub!(:whitewash).to_text(encode_special_chars: false)
+    plain_text = Loofah.fragment(main_html).
+      scrub!(tag_scrubber).
+      scrub!(:whitewash).
+      to_text(encode_special_chars: false)
     plain_text.gsub(/[ \t]+/,' ' ).gsub(/[\n\r]+/, "\n").chomp.lstrip
+  end
+
+  def tag_scrubber
+    # convert custom tags to plain 'ol divs to ensure they are not
+    # stripped out during HTML sanitization
+    Loofah::Scrubber.new do |node|
+      node.name = 'div' if /-/ === node.name
+    end
   end
 
   def html_attributes

--- a/app/models/html_document.rb
+++ b/app/models/html_document.rb
@@ -52,7 +52,7 @@ class HtmlDocument < WebDocument
     # convert custom tags to plain 'ol divs to ensure they are not
     # stripped out during HTML sanitization
     Loofah::Scrubber.new do |node|
-      node.name = 'div' if /-/ === node.name
+      node.name = 'div' if /-/.match(node.name)
     end
   end
 

--- a/spec/models/html_document_spec.rb
+++ b/spec/models/html_document_spec.rb
@@ -240,7 +240,9 @@ describe HtmlDocument do
     end
 
     context 'when the html contains a script' do
-      let(:raw_document) { "no script<script>alert('OHAI')</script>" }
+      let(:raw_document) do
+        '<html><body>no script<script>alert("OHAI")</script></body></html>'
+      end
 
       it 'removes the script' do
         expect(parsed_content).to eq 'no script'
@@ -248,7 +250,9 @@ describe HtmlDocument do
     end
 
     context 'when the html contains style tags' do
-      let(:raw_document) { "<style>h1 {color:red;}</style>no style" }
+      let(:raw_document) do
+        '<html><body><style>h1 {color:red;}</style>no style</body></html>'
+      end
 
       it 'removes the style' do
         expect(parsed_content).to eq 'no style'
@@ -325,6 +329,12 @@ describe HtmlDocument do
       let(:raw_document) { '<html></html>' }
 
       it { is_expected.to eq '' }
+    end
+
+    context 'when the html contains custom tags' do
+      let(:raw_document) { '<custom-tag>content</custom-tag>' }
+
+      it { is_expected.to eq 'content' }
     end
   end
 

--- a/spec/vcr_cassettes/searchgov_url_fetch/when_the_response_is_a_403_when_the_url_has_already_been_indexed_when_the_domain_is_unavailable.yml
+++ b/spec/vcr_cassettes/searchgov_url_fetch/when_the_response_is_a_403_when_the_url_has_already_been_indexed_when_the_domain_is_unavailable.yml
@@ -1,0 +1,45 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.agency.gov/robots.txt
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - usasearch
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Server:
+      - nginx
+      Date:
+      - Fri, 21 Dec 2018 19:40:09 GMT
+      Content-Type:
+      - text/html; charset=utf-8
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - close
+      Expires:
+      - Fri, 21 Dec 2018 19:50:09 GMT
+      Cache-Control:
+      - max-age=600
+      X-Frame-Options:
+      - DENY
+    body:
+      encoding: UTF-8
+      string: <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html><head><meta
+        http-equiv="refresh" content="0;url=http://searchassist.verizon.com/main?ParticipantID=euekiz39ksg8nwp7iqj2fp5wzfwi5q76&FailedURI=http%3A%2F%2Fwww.agency.gov%2Frobots.txt&FailureMode=1&Implementation=&AddInType=4&Version=pywr1.0&ClientLocation=us"/><script
+        type="text/javascript">url="http://searchassist.verizon.com/main?ParticipantID=euekiz39ksg8nwp7iqj2fp5wzfwi5q76&FailedURI=http%3A%2F%2Fwww.agency.gov%2Frobots.txt&FailureMode=1&Implementation=&AddInType=4&Version=pywr1.0&ClientLocation=us";if(top.location!=location){var
+        w=window,d=document,e=d.documentElement,b=d.body,x=w.innerWidth||e.clientWidth||b.clientWidth,y=w.innerHeight||e.clientHeight||b.clientHeight;url+="&w="+x+"&h="+y;}window.location.replace(url);</script></head><body></body></html>
+    http_version: 
+  recorded_at: Fri, 21 Dec 2018 19:40:09 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
This change allows us to parse the content from custom HTML tags, which we had previously been stripping out. 