### PR TITLE
SRCH-207 omit nav & footer elements when parsing HTML

### DIFF
--- a/app/models/html_document.rb
+++ b/app/models/html_document.rb
@@ -52,7 +52,7 @@ class HtmlDocument < WebDocument
     Loofah::Scrubber.new do |node|
       # convert custom tags to plain 'ol divs to ensure they are not
       # stripped out during HTML sanitization
-      node.name = 'div' if /-/.match(node.name)
+      node.name = 'div' if node.name =~ /-/
 
       # omit common elements
       node.remove if %w[footer nav].include?(node.name)

--- a/app/models/html_document.rb
+++ b/app/models/html_document.rb
@@ -49,10 +49,13 @@ class HtmlDocument < WebDocument
   end
 
   def tag_scrubber
-    # convert custom tags to plain 'ol divs to ensure they are not
-    # stripped out during HTML sanitization
     Loofah::Scrubber.new do |node|
+      # convert custom tags to plain 'ol divs to ensure they are not
+      # stripped out during HTML sanitization
       node.name = 'div' if /-/.match(node.name)
+
+      # omit common elements
+      node.remove if %w[footer nav].include?(node.name)
     end
   end
 

--- a/spec/models/html_document_spec.rb
+++ b/spec/models/html_document_spec.rb
@@ -336,6 +336,26 @@ describe HtmlDocument do
 
       it { is_expected.to eq 'content' }
     end
+
+    context 'when the HTML includes a nav element' do
+      let(:raw_document) do
+        '<html><body><nav>Menu</nav>content</body></html>'
+      end
+
+      it 'omits the nav bar content' do
+        expect(parsed_content).to eq 'content'
+      end
+    end
+
+    context 'when the HTML includes a footer element' do
+      let(:raw_document) do
+        '<html><body>content<footer>footer</footer></body></html>'
+      end
+
+      it 'omits the footer content' do
+        expect(parsed_content).to eq 'content'
+      end
+    end
   end
 
   describe '#redirect_url' do
@@ -386,7 +406,6 @@ describe HtmlDocument do
         it 'encodes the characters' do
           expect(redirect_url).to eq 'https://www.foo.gov/my%7Curl%E2%80%99s_weird?!'
         end
-
       end
     end
   end


### PR DESCRIPTION
This change prevents us from indexing content that is likely to be the same on the majority of pages on a website.