### PR TITLE
SRCH-300 - JOBS whitelist

### DIFF
--- a/lib/jobs.rb
+++ b/lib/jobs.rb
@@ -14,7 +14,9 @@ module Jobs
     projection survey forecast figure report verification record
     authorization card classification form hazard poster fair board
     outlook grant funding factor other cut
-    application
+    application creating agreement certificate changes denial
+    earnings income participation change loss offer
+    qualifications requirement statement
   ].freeze
   BLOCKED_PHRASES = '(job|employment) (contract|law|training|safety)s?'
   BLOCKED_KEYWORDS =

--- a/spec/lib/jobs_spec.rb
+++ b/spec/lib/jobs_spec.rb
@@ -90,17 +90,29 @@ describe Jobs do
 
     context 'when the search phrase is blocked' do
       it 'should return false' do
-        ["employment data", "employment statistics", "employment numbers", "employment levels", "employment rate",
-         "employment trends", "employment growth", "employment projections", "employment #{Date.current.year.to_s}",
-         "employment survey", "employment forecasts", "employment figures", "employment report", "employment law",
-         "employment at will", "equal employment opportunity", "employment verification", "employment status",
-         "employment record", "employment history", "employment eligibility", "employment authorization", "employment card",
-         "job classification", "job analysis", "posting 300 log", "employment forms", "job hazard", "job safety",
-         "job poster", "job training", "employment training", "job fair", "job board", "job outlook", "grant opportunities",
-         "funding opportunities", "vacancy factor", "vacancy rates", "delayed opening", "opening others mail", "job corps cuts",
-         "job application", "job safety and health poster", "job safety analysis standard", "job safety analysis", "employment contract",
-         "application for employment"
-        ].each { |phrase| expect(Jobs.query_eligible?(phrase)).to be_falsey }
+        ['employment data', 'employment statistics', 'employment numbers',
+         'employment levels', 'employment rate', 'employment trends',
+         'employment growth', 'employment projections',
+         "employment #{Date.current.year}", 'employment survey',
+         'employment forecasts', 'employment figures', 'employment report',
+         'employment law', 'employment at will', 'equal employment opportunity',
+         'employment verification', 'employment status', 'employment record',
+         'employment history', 'employment eligibility',
+         'employment authorization', 'employment card', 'job classification',
+         'job analysis', 'posting 300 log', 'employment forms',
+         'job hazard', 'job safety', 'job poster', 'job training',
+         'employment training', 'job fair', 'job board', 'job outlook',
+         'grant opportunities', 'funding opportunities', 'vacancy factor',
+         'vacancy rates', 'delayed opening', 'opening others mail',
+         'job corps cuts', 'job application', 'job safety and health poster',
+         'job safety analysis standard', 'job safety analysis',
+         'employment contract', 'application for employment',
+         'Creating jobs', 'Employment agreement', 'Employment certificate',
+         'Employment changes', 'Employment denial', 'Employment earnings',
+         'Employment income', 'Employment participation', 'job change',
+         'job loss', 'job offer', 'job qualifications', 'opening statement',
+         'job requirement'].
+          each { |phrase| expect(Jobs.query_eligible?(phrase)).to be_falsey }
       end
     end
 


### PR DESCRIPTION
Add to the list whitelist of words that triggers the jobs trigger words when it should not. Such as 
Job statement should not trigger USAJOBS while nursing jobs should.

Looking through the production log files the following words have been added:
application creating agreement certificate changes denial
earnings income participation change loss offer
qualifications requirement statement

