### PR TITLE
SRCH-400 update click counts for popular URLs

### DIFF
--- a/app/jobs/click_counter_job.rb
+++ b/app/jobs/click_counter_job.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+# Update click counts for popular URLs for a given domain
+class ClickCounterJob < ActiveJob::Base
+  queue_as :searchgov
+
+  def perform(domain:)
+    ClickCounter.new(domain: domain).update_click_counts
+  end
+end

--- a/app/jobs/click_monitor_job.rb
+++ b/app/jobs/click_monitor_job.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# Enqueues a ClickCounterJob for each SearchgovDomain
+class ClickMonitorJob < ActiveJob::Base
+  queue_as :searchgov
+
+  def perform
+    SearchgovDomain.find_each do |searchgov_domain|
+      ClickCounterJob.perform_later(domain: searchgov_domain.domain)
+    end
+  end
+end

--- a/app/models/click_counter.rb
+++ b/app/models/click_counter.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+# Updates I14yDocuments in the searchgov index with click_count data
+# to be used for relevancy ranking
+class ClickCounter
+  SIGNIFICANT_PERCENTAGE = 75
+
+  attr_reader :domain
+
+  def initialize(domain:)
+    @domain = domain
+  end
+
+  def update_click_counts
+    statistically_significant_clicks.each do |click|
+      update_click_count(url: click[0], count: click[1])
+    end
+  end
+
+  private
+
+  def statistically_significant_clicks
+    query = DateRangeTopNFieldQuery.new(nil,
+                                        1.month.ago,
+                                        Time.current,
+                                        'click_domain',
+                                        domain,
+                                        field: 'params.url', size: 0)
+
+    RtuTopClicks.new(query.body, true).
+      top_n_to_percentage(SIGNIFICANT_PERCENTAGE)
+  end
+
+  def update_click_count(url:, count:)
+    searchgov_url = SearchgovUrl.find_by!(url: url)
+    I14yDocument.update(document_id: searchgov_url.document_id,
+                        click_count: count,
+                        handle: 'searchgov')
+  rescue ActiveRecord::RecordNotFound
+    Rails.logger.error("SearchgovUrl not found for clicked URL: #{url}")
+  end
+end

--- a/app/models/rtu_top_clicks.rb
+++ b/app/models/rtu_top_clicks.rb
@@ -1,7 +1,8 @@
-class RtuTopClicks < RtuTopN
+# frozen_string_literal: true
 
+# Top clicks by count in a specified time period
+class RtuTopClicks < RtuTopN
   def initialize(query_body, filter_bots, day = nil)
     super(query_body, 'click', filter_bots, day)
   end
-
 end

--- a/app/models/rtu_top_n.rb
+++ b/app/models/rtu_top_n.rb
@@ -14,4 +14,18 @@ class RtuTopN
     term_buckets.collect { |hash| [hash["key"], hash["doc_count"]] }
   end
 
+  # Results representing a given percentage of all results by doc_count
+  def top_n_to_percentage(percent)
+    top = top_n
+    total = top.map(&:last).sum
+    cumulative_count = 0.0
+    top_to_percentage = []
+
+    while (cumulative_count / total) * 100 < percent
+      result = top.shift
+      top_to_percentage << result
+      cumulative_count += result[1]
+    end
+    top_to_percentage
+  end
 end

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -1,3 +1,5 @@
 production:
   SitemapMonitorJob:
     cron: "0 9 * * *"
+  ClickMonitorJob:
+    cron: "0 7 * * 0"

--- a/spec/fixtures/json/rtu_dashboard/top_clicks_one_domain.json
+++ b/spec/fixtures/json/rtu_dashboard/top_clicks_one_domain.json
@@ -1,0 +1,555 @@
+{
+  "took": 291,
+  "timed_out": false,
+  "_shards": {
+    "total": 440,
+    "successful": 440,
+    "failed": 0
+  },
+  "hits": {
+    "total": 83,
+    "max_score": 1.0,
+    "hits": [
+      {
+        "_index": "logstash-2019.01.20",
+        "_type": "click",
+        "_id": "AWhtA2RVeTV50iYQ5v0q",
+        "_score": 1.0,
+        "_source": {
+          "@version": "1",
+          "@timestamp": "2019-01-20T20:46:04.000Z",
+          "host": "app2.us-east-1.prod.infr.search.usa.gov",
+          "clientip": "155.95.90.245",
+          "request": "/clicked?a=usasearch&l=en&q=news&t=1548017143&v=i14y&u=https%3A%2F%2Fsearch.gov%2Fquote%2Flabor.html&p=15&s=I14Y&i=",
+          "referrer": "https://find.search.gov/search/?utf8=%E2%9C%93&affiliate=usasearch&query=news",
+          "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64; Trident/7.0; rv:11.0) like Gecko",
+          "useragent": {
+            "name": "IE",
+            "os": "Windows 10",
+            "device": "Other"
+          },
+          "geoip": {
+            "country_code": 225,
+            "country_code2": "US"
+          },
+          "params": {
+            "query": "news",
+            "url": "https://search.gov/quote/labor.html",
+            "position": 15,
+            "affiliate": "usasearch"
+          },
+          "modules": "I14Y",
+          "vertical": "i14y",
+          "type": "click",
+          "click_domain": "search.gov"
+        }
+      },
+      {
+        "_index": "logstash-2019.01.22",
+        "_type": "click",
+        "_id": "AWh29CGvqdVOfjGO-8Wd",
+        "_score": 1.0,
+        "_source": {
+          "@version": "1",
+          "@timestamp": "2019-01-22T19:05:36.000Z",
+          "host": "app2.us-east-1.prod.infr.search.usa.gov",
+          "clientip": "67.170.115.191",
+          "request": "/clicked?v=i14y&t=1548183925&q=api&l=en&a=usasearch&u=https%3A%2F%2Fsearch.gov%2Fmanual%2Fsearch-results-api.html&p=4&s=I14Y&i=",
+          "referrer": "https://find.search.gov/search/?utf8=%E2%9C%93&affiliate=usasearch&query=api",
+          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+          "useragent": {
+            "name": "Chrome",
+            "os": "Mac OS X 10.14.0",
+            "device": "Other"
+          },
+          "geoip": {
+            "country_code": 225,
+            "country_code2": "US"
+          },
+          "params": {
+            "query": "api",
+            "url": "https://search.gov/manual/search-results-api.html",
+            "position": 4,
+            "affiliate": "usasearch"
+          },
+          "modules": "I14Y",
+          "vertical": "i14y",
+          "type": "click",
+          "click_domain": "search.gov"
+        }
+      },
+      {
+        "_index": "logstash-2019.01.22",
+        "_type": "click",
+        "_id": "AWh3UXP2E4Eio8jUzY_s",
+        "_score": 1.0,
+        "_source": {
+          "@version": "1",
+          "@timestamp": "2019-01-22T20:47:33.000Z",
+          "host": "app1.us-east-1.prod.infr.search.usa.gov",
+          "clientip": "156.40.209.194",
+          "request": "/clicked?v=i14y&t=1548190049&q=main%20element&l=en&a=usasearch&u=https%3A%2F%2Fsearch.gov%2Fblog%2Fhow-search-engines-index-content-better-discoverability.html&p=1&s=I14Y&i=",
+          "referrer": "https://find.search.gov/search/?utf8=%E2%9C%93&affiliate=usasearch&query=main+element",
+          "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+          "useragent": {
+            "name": "Chrome",
+            "os": "Windows 10",
+            "device": "Other"
+          },
+          "geoip": {
+            "country_code": 225,
+            "country_code2": "US"
+          },
+          "params": {
+            "query": "main element",
+            "url": "https://search.gov/blog/how-search-engines-index-content-better-discoverability.html",
+            "position": 1,
+            "affiliate": "usasearch"
+          },
+          "modules": "I14Y",
+          "vertical": "i14y",
+          "type": "click",
+          "click_domain": "search.gov"
+        }
+      },
+      {
+        "_index": "logstash-2019.01.23",
+        "_type": "click",
+        "_id": "AWh6YC-YqdVOfjGOYqqJ",
+        "_score": 1.0,
+        "_source": {
+          "@version": "1",
+          "@timestamp": "2019-01-23T11:02:27.000Z",
+          "host": "app4.us-east-1.prod.infr.search.usa.gov",
+          "clientip": "103.81.33.236",
+          "request": "/clicked?v=i14y&t=1548241341&q=p&l=en&a=usasearch&u=https%3A%2F%2Fsearch.gov%2Fpdf%2Fseo-joe-pagano.pdf&p=1&s=I14Y&i=",
+          "referrer": "https://find.search.gov/search?utf8=%E2%9C%93&affiliate=usasearch&sort_by=&query=p",
+          "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.102 Safari/537.36 OPR/57.0.3098.116",
+          "useragent": {
+            "name": "Opera",
+            "os": "Windows 10",
+            "device": "Other"
+          },
+          "geoip": {
+            "country_code": 0,
+            "country_code2": "--"
+          },
+          "params": {
+            "query": "p",
+            "url": "https://search.gov/pdf/seo-joe-pagano.pdf",
+            "position": 1,
+            "affiliate": "usasearch"
+          },
+          "modules": "I14Y",
+          "vertical": "i14y",
+          "type": "click",
+          "click_domain": "search.gov"
+        }
+      },
+      {
+        "_index": "logstash-2019.01.23",
+        "_type": "click",
+        "_id": "AWh4UgWHeTV50iYQ79l6",
+        "_score": 1.0,
+        "_source": {
+          "@version": "1",
+          "@timestamp": "2019-01-23T01:27:47.000Z",
+          "host": "app3.us-east-1.prod.infr.search.usa.gov",
+          "clientip": "177.249.212.64",
+          "request": "/clicked?v=i14y&t=1548206858&q=top%20reasons%20for%20immigration%20into%20the%20us&l=en&a=usasearch&u=https%3A%2F%2Fsearch.gov%2Fmanual%2Fsite-overview.html&p=1&s=I14Y&i=",
+          "referrer": "https://find.search.gov/search/?utf8=%E2%9C%93&affiliate=usasearch&query=top+reasons+for+immigration+into+the+us",
+          "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+          "useragent": {
+            "name": "Chrome",
+            "os": "Windows 10",
+            "device": "Other"
+          },
+          "geoip": {
+            "country_code": 0,
+            "country_code2": "--"
+          },
+          "params": {
+            "query": "top reasons for immigration into the us",
+            "url": "https://search.gov/manual/site-overview.html",
+            "position": 1,
+            "affiliate": "usasearch"
+          },
+          "modules": "I14Y",
+          "vertical": "i14y",
+          "type": "click",
+          "click_domain": "search.gov"
+        }
+      },
+      {
+        "_index": "logstash-2019.01.23",
+        "_type": "click",
+        "_id": "AWh87LJFeTV50iYQ9DNZ",
+        "_score": 1.0,
+        "_source": {
+          "@version": "1",
+          "@timestamp": "2019-01-23T22:55:12.000Z",
+          "host": "app1.us-east-1.prod.infr.search.usa.gov",
+          "clientip": "128.193.154.61",
+          "request": "/clicked?v=i14y&t=1548284109&q=developer%20jobs&l=en&a=usasearch&u=https%3A%2F%2Fsearch.gov%2Fdeveloper%2Fjobs.html&p=1&s=I14Y&i=",
+          "referrer": "https://find.search.gov/search?utf8=%E2%9C%93&affiliate=usasearch&sort_by=&query=developer+jobs",
+          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+          "useragent": {
+            "name": "Chrome",
+            "os": "Mac OS X 10.14.2",
+            "device": "Other"
+          },
+          "geoip": {
+            "country_code": 225,
+            "country_code2": "US"
+          },
+          "params": {
+            "query": "developer jobs",
+            "url": "https://search.gov/developer/jobs.html",
+            "position": 1,
+            "affiliate": "usasearch"
+          },
+          "modules": "I14Y",
+          "vertical": "i14y",
+          "type": "click",
+          "click_domain": "search.gov"
+        }
+      },
+      {
+        "_index": "logstash-2019.01.23",
+        "_type": "click",
+        "_id": "AWh86kra4pMsH3WUuDj5",
+        "_score": 1.0,
+        "_source": {
+          "@version": "1",
+          "@timestamp": "2019-01-23T22:52:34.000Z",
+          "host": "app2.us-east-1.prod.infr.search.usa.gov",
+          "clientip": "128.193.154.61",
+          "request": "/clicked?v=i14y&t=1548283951&q=jobs&l=en&a=usasearch&u=https%3A%2F%2Fsearch.gov%2Fdeveloper%2Fjobs.html&p=1&s=I14Y&i=",
+          "referrer": "https://find.search.gov/search/?utf8=%E2%9C%93&affiliate=usasearch&query=jobs",
+          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+          "useragent": {
+            "name": "Chrome",
+            "os": "Mac OS X 10.14.2",
+            "device": "Other"
+          },
+          "geoip": {
+            "country_code": 225,
+            "country_code2": "US"
+          },
+          "params": {
+            "query": "jobs",
+            "url": "https://search.gov/developer/jobs.html",
+            "position": 1,
+            "affiliate": "usasearch"
+          },
+          "modules": "I14Y",
+          "vertical": "i14y",
+          "type": "click",
+          "click_domain": "search.gov"
+        }
+      },
+      {
+        "_index": "logstash-2019.01.24",
+        "_type": "click",
+        "_id": "AWiAq4ztqdVOfjGOIKCx",
+        "_score": 1.0,
+        "_source": {
+          "@version": "1",
+          "@timestamp": "2019-01-24T16:22:31.000Z",
+          "host": "app2.us-east-1.prod.infr.search.usa.gov",
+          "clientip": "68.134.14.6",
+          "request": "/clicked?v=i14y&t=1548346946&q=nurse&l=en&a=usasearch&u=https%3A%2F%2Fsearch.gov%2Fdeveloper%2Fjobs.html&p=1&s=I14Y&i=",
+          "referrer": "https://find.search.gov/search/?utf8=%E2%9C%93&affiliate=usasearch&query=nurse",
+          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+          "useragent": {
+            "name": "Chrome",
+            "os": "Mac OS X 10.13.6",
+            "device": "Other"
+          },
+          "geoip": {
+            "country_code": 225,
+            "country_code2": "US"
+          },
+          "params": {
+            "query": "nurse",
+            "url": "https://search.gov/developer/jobs.html",
+            "position": 1,
+            "affiliate": "usasearch"
+          },
+          "modules": "I14Y",
+          "vertical": "i14y",
+          "type": "click",
+          "click_domain": "search.gov"
+        }
+      },
+      {
+        "_index": "logstash-2019.01.24",
+        "_type": "click",
+        "_id": "AWiAq89gE4Eio8jU1Yd3",
+        "_score": 1.0,
+        "_source": {
+          "@version": "1",
+          "@timestamp": "2019-01-24T16:22:49.000Z",
+          "host": "app1.us-east-1.prod.infr.search.usa.gov",
+          "clientip": "68.134.14.6",
+          "request": "/clicked?v=i14y&t=1548346962&q=nursing%20jobs&l=en&a=usasearch&u=https%3A%2F%2Fsearch.gov%2Fdeveloper%2Fjobs.html&p=1&s=I14Y&i=",
+          "referrer": "https://find.search.gov/search/?utf8=%E2%9C%93&affiliate=usasearch&query=nursing+jobs",
+          "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_13_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36",
+          "useragent": {
+            "name": "Chrome",
+            "os": "Mac OS X 10.13.6",
+            "device": "Other"
+          },
+          "geoip": {
+            "country_code": 225,
+            "country_code2": "US"
+          },
+          "params": {
+            "query": "nursing jobs",
+            "url": "https://search.gov/developer/jobs.html",
+            "position": 1,
+            "affiliate": "usasearch"
+          },
+          "modules": "I14Y",
+          "vertical": "i14y",
+          "type": "click",
+          "click_domain": "search.gov"
+        }
+      },
+      {
+        "_index": "logstash-2019.01.24",
+        "_type": "click",
+        "_id": "AWiA4-hb4pMsH3WUuxCn",
+        "_score": 1.0,
+        "_source": {
+          "@version": "1",
+          "@timestamp": "2019-01-24T17:24:05.000Z",
+          "host": "app1.us-east-1.prod.infr.search.usa.gov",
+          "clientip": "158.59.146.29",
+          "request": "/clicked?v=i14y&t=1548350624&q=Air%20Quality%20Index&l=en&a=usasearch&u=https%3A%2F%2Fsearch.gov%2Fquote%2Fdefense.html&p=4&s=I14Y&i=",
+          "referrer": "https://find.search.gov/search/?utf8=%E2%9C%93&affiliate=usasearch&query=Air+Quality+Index",
+          "user_agent": "Mozilla/5.0 (iPad; CPU OS 12_1_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/12.0 Mobile/15E148 Safari/604.1",
+          "useragent": {
+            "name": "Mobile Safari",
+            "os": "iOS 12.1.1",
+            "device": "iPad"
+          },
+          "geoip": {
+            "country_code": 225,
+            "country_code2": "US"
+          },
+          "params": {
+            "query": "air quality index",
+            "url": "https://search.gov/quote/defense.html",
+            "position": 4,
+            "affiliate": "usasearch"
+          },
+          "modules": "I14Y",
+          "vertical": "i14y",
+          "type": "click",
+          "click_domain": "search.gov"
+        }
+      }
+    ]
+  },
+  "aggregations": {
+    "agg": {
+      "doc_count_error_upper_bound": 0,
+      "sum_other_doc_count": 0,
+      "buckets": [
+        {
+          "key": "https://search.gov/developer/jobs.html",
+          "doc_count": 8
+        },
+        {
+          "key": "https://search.gov/developer/",
+          "doc_count": 4
+        },
+        {
+          "key": "https://search.gov/files/GSA_%20VPAT_DigitalGovSearch.pdf",
+          "doc_count": 4
+        },
+        {
+          "key": "https://search.gov/manual/domains.html",
+          "doc_count": 4
+        },
+        {
+          "key": "https://search.gov/manual/collections.html",
+          "doc_count": 3
+        },
+        {
+          "key": "https://search.gov/manual/search-results-api.html",
+          "doc_count": 3
+        },
+        {
+          "key": "https://search.gov/pdf/seo-joe-pagano.pdf",
+          "doc_count": 3
+        },
+        {
+          "key": "https://search.gov/",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/blog/cache.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/blog/how-search-engines-index-content-better-discoverability.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/blog/power-users-recap.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/blog/searchgov-blog.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/blog/searchgov-faqs-indexing.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/blog/sitemaps.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/files/HowSearchEnginesIndexYourWebsite.pdf",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/manual/color-codes.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/manual/govbox-jobs.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/quote/defense.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/quote/dhs.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/releases/january-2018.html",
+          "doc_count": 2
+        },
+        {
+          "key": "https://search.gov/blog/hadoop-bigger-ox.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/blog/robotstxt.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/blog/seo-joe-pagano.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/blog/serp-redesign.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/blog/six-months-in.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/developer/i14y.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/files/Webinar.pdf",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/add-site.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/cname.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/content-overview.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/filter-tags.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/i14y-drawers.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/module-codes.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/routed-queries.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/site-overview.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/training.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/typeahead-api.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/manual/youtube.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/pdf/2014-04-11-search-big-data.pdf",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/quote/agriculture.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/quote/labor.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/releases/december-2013.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/releases/january-2013.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/releases/january-2019.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/releases/july-2012.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/releases/november-2016.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/releases/september-2012.html",
+          "doc_count": 1
+        },
+        {
+          "key": "https://search.gov/tos.html",
+          "doc_count": 1
+        }
+      ]
+    }
+  }
+}

--- a/spec/fixtures/json/rtu_dashboard/top_urls.json
+++ b/spec/fixtures/json/rtu_dashboard/top_urls.json
@@ -18,7 +18,7 @@
         "doc_count": 9
       },
       {
-        "key": "http://cs.cpsc.gov/ConceptDemo/SearchCPSC.aspx?SearchCategory=Recalls+-+Home+Maintenance+and+Structures&category=995%2c1098&subcategory=308&query=kenmore+35+pint+dehumidifiers",
+        "key": "http://cs.cpsc.gov/ConceptDemo/SearchCPSC.aspx",
         "doc_count": 8
       },
       {

--- a/spec/jobs/click_counter_job_spec.rb
+++ b/spec/jobs/click_counter_job_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+describe ClickCounterJob do
+  subject(:perform) { ClickCounterJob.perform_now(args) }
+
+  let(:counter) { instance_double(ClickCounter) }
+  let(:args) do
+    { domain: 'www.agency.gov' }
+  end
+
+  it_behaves_like 'a searchgov job'
+
+  it "updates the click counts for each domain's URLs" do
+    allow(ClickCounter).to receive(:new).with(domain: 'www.agency.gov').
+      and_return(counter)
+    expect(counter).to receive(:update_click_counts)
+    perform
+  end
+end

--- a/spec/jobs/click_monitor_job_spec.rb
+++ b/spec/jobs/click_monitor_job_spec.rb
@@ -1,0 +1,20 @@
+require 'spec_helper'
+
+describe ClickMonitorJob do
+  subject(:perform) { ClickMonitorJob.perform_now }
+
+  let(:searchgov_domain) do
+    instance_double(SearchgovDomain, domain: 'agency.gov')
+  end
+
+  before do
+    allow(SearchgovDomain).to receive(:find_each).and_yield(searchgov_domain)
+  end
+
+  it_behaves_like 'a searchgov job'
+
+  it 'enqueues ClickCounterJobs for each SearchgovDomain' do
+    expect{ perform }.to have_enqueued_job(ClickCounterJob).
+      with(domain: 'agency.gov')
+  end
+end

--- a/spec/jobs/sitemap_monitor_job_spec.rb
+++ b/spec/jobs/sitemap_monitor_job_spec.rb
@@ -1,7 +1,6 @@
 require 'spec_helper'
 
 describe SitemapMonitorJob do
-  let(:args) { nil }
   let(:searchgov_domain) { instance_double(SearchgovDomain) }
   subject(:perform) { SitemapMonitorJob.perform_now }
 

--- a/spec/models/click_counter_spec.rb
+++ b/spec/models/click_counter_spec.rb
@@ -1,0 +1,73 @@
+require 'spec_helper'
+
+describe ClickCounter do
+  let(:counter) { ClickCounter.new(domain: 'agency.gov') }
+
+  describe '#update_click_counts' do
+    subject(:update_click_counts) { counter.update_click_counts }
+
+    context 'when clicks are available' do
+      let(:url) { 'http://agency.gov/' }
+
+      before do
+        allow(counter).to receive(:statistically_significant_clicks).
+          and_return([[url, 1000]])
+      end
+
+      context 'when a SearchgovUrl record exists for that URL' do
+        let!(:searchgov_url) { SearchgovUrl.create!(url: url) }
+
+        it 'updates the click counts for the popular URLs' do
+          expect(I14yDocument).to receive(:update).with(
+            document_id: searchgov_url.document_id,
+            click_count: 1000,
+            handle: 'searchgov'
+          )
+          update_click_counts
+        end
+      end
+
+      context 'when no SearchgovUrl record exists for that URL' do
+        it 'logs the missing URL' do
+          expect(Rails.logger).to receive(:error).
+            with('SearchgovUrl not found for clicked URL: http://agency.gov/')
+          update_click_counts
+        end
+      end
+    end
+  end
+
+  describe '#statistically_significant_clicks' do
+    subject(:clicks) { counter.send(:statistically_significant_clicks) }
+
+    before { Timecop.freeze }
+
+    after { Timecop.return }
+
+    it "generates a query for the last month's significant clicks" do
+      expect(DateRangeTopNFieldQuery).to receive(:new).
+        with(nil,
+             1.month.ago,
+             Time.now,
+             'click_domain',
+             'agency.gov',
+             { field: 'params.url', size: 0 }).
+        and_call_original
+      clicks
+    end
+
+    context 'when click data is available' do
+      let(:json) do
+        JSON.parse(read_fixture_file('/json/rtu_dashboard/top_clicks_one_domain.json'))
+      end
+
+      before do
+        allow(ES::ELK.client_reader).to receive(:search).and_return json
+      end
+
+      it 'returns the statistically significant clicks' do
+        expect(clicks.last).to eq ['https://search.gov/manual/add-site.html', 1]
+      end
+    end
+  end
+end

--- a/spec/models/i14y_document_spec.rb
+++ b/spec/models/i14y_document_spec.rb
@@ -11,7 +11,8 @@ describe I14yDocument do
       path: url,
       created: Time.now.to_s,
       description: 'My fascinating document',
-      handle: 'searchgov'
+      handle: 'searchgov',
+      click_count: 1000
     }
   end
   let(:document) { I14yDocument.new(valid_attributes) }

--- a/spec/models/rtu_top_clicks_spec.rb
+++ b/spec/models/rtu_top_clicks_spec.rb
@@ -1,32 +1,32 @@
 require 'spec_helper'
 
 describe RtuTopClicks do
-  let(:rtu_top_clicks) { RtuTopClicks.new("some ES query body", true) }
+  let(:rtu_top_clicks) { RtuTopClicks.new('some ES query body', true) }
 
-  describe "computing top N stats" do
+  shared_context 'when statistics are available' do
+    let(:json_response) { JSON.parse(File.read("#{Rails.root}/spec/fixtures/json/rtu_dashboard/top_urls.json")) }
 
-    context "when stats available" do
-      let(:json_response) { JSON.parse(File.read("#{Rails.root}/spec/fixtures/json/rtu_dashboard/top_urls.json")) }
+    before do
+      allow(ES::ELK.client_reader).to receive(:search).and_return json_response
+    end
+  end
 
-      before do
-        allow(ES::ELK.client_reader).to receive(:search).and_return json_response
-      end
+  describe 'computing top N stats' do
+    include_context 'when statistics are available'
 
-      it 'should return an array of [url, count] sorted by desc url count' do
-        expect(rtu_top_clicks.top_n).to eq(
-          [["http://appropriations.house.gov/subcommittees/subcommittee/?IssueID=34776", 10],
-           ["http://assembly.ca.gov/legislativebranch", 9],
-           ["http://cs.cpsc.gov/ConceptDemo/SearchCPSC.aspx?SearchCategory=Recalls+-+Home+Maintenance+and+Structures&category=995%2c1098&subcategory=308&query=kenmore+35+pint+dehumidifiers", 8],
-           ["http://livertox.nih.gov/AloeVera.htm", 7],
-           ["https://search.usa.gov/search?affiliate=usagov&m=true&query=%2Bhigher+ratingfor+prostate+cancer+jan2014+feb2014+site%3Ava.gov", 6],
-           ["http://www.americaslibrary.gov/aa/twain/aa_twain_huckfinn_1.html", 5],
-           ["http://www.dol.gov/ebsa/faqs/faq_911_2.html", 4],
-           ["http://www.dot.ca.gov/", 3],
-           ["http://www.fbi.gov/stats-services/publications/law-enforcement-bulletin/february2011/february-2011-leb.pdf", 2],
-           ["http://www.marines.mil/Portals/59/Publications/FMFRP%2012-18%20%20Mao%20Tse-tung%20on%20Guerrilla%20Warfare.pdf", 1]]
-        )
-      end
-
+    it 'should return an array of [url, count] sorted by desc url count' do
+      expect(rtu_top_clicks.top_n).to eq(
+        [['http://appropriations.house.gov/subcommittees/subcommittee/?IssueID=34776', 10],
+         ['http://assembly.ca.gov/legislativebranch', 9],
+         ['http://cs.cpsc.gov/ConceptDemo/SearchCPSC.aspx', 8],
+         ['http://livertox.nih.gov/AloeVera.htm', 7],
+         ['https://search.usa.gov/search?affiliate=usagov&m=true&query=%2Bhigher+ratingfor+prostate+cancer+jan2014+feb2014+site%3Ava.gov', 6],
+         ['http://www.americaslibrary.gov/aa/twain/aa_twain_huckfinn_1.html', 5],
+         ['http://www.dol.gov/ebsa/faqs/faq_911_2.html', 4],
+         ['http://www.dot.ca.gov/', 3],
+         ['http://www.fbi.gov/stats-services/publications/law-enforcement-bulletin/february2011/february-2011-leb.pdf', 2],
+         ['http://www.marines.mil/Portals/59/Publications/FMFRP%2012-18%20%20Mao%20Tse-tung%20on%20Guerrilla%20Warfare.pdf', 1]]
+      )
     end
 
     context 'when stats unavailable' do
@@ -37,6 +37,32 @@ describe RtuTopClicks do
       it 'should return an empty array' do
         expect(rtu_top_clicks.top_n).to eq([])
       end
+    end
+  end
+
+  describe '#top_n_to_percentage' do
+    subject(:top_n_to_percentage) do
+      rtu_top_clicks.top_n_to_percentage(50)
+    end
+
+    include_context 'when statistics are available'
+
+    it 'returns the top N percent of all clicks' do
+      expect(top_n_to_percentage).to eq ([
+        ['http://appropriations.house.gov/subcommittees/subcommittee/?IssueID=34776', 10],
+        ['http://assembly.ca.gov/legislativebranch', 9],
+        ['http://cs.cpsc.gov/ConceptDemo/SearchCPSC.aspx', 8],
+        ['http://livertox.nih.gov/AloeVera.htm', 7],
+      ])
+    end
+
+    context 'when the result set is small' do
+      before do
+        allow(rtu_top_clicks).to receive(:top_n).
+          and_return([['http://foo.gov/',5]])
+      end
+
+      it { is_expected.to eq [['http://foo.gov/',5]] }
     end
   end
 end

--- a/spec/support/searchgov_job_behavior.rb
+++ b/spec/support/searchgov_job_behavior.rb
@@ -1,4 +1,6 @@
 shared_examples_for 'a searchgov job' do
+  let(:args) { nil }
+
   it 'uses the "searchgov" queue' do
     expect{
       described_class.perform_later(args)


### PR DESCRIPTION
Adds classes to calculate popular URLs for SearchgovDomains, and update the `click_count` for those URLs in the ES documents.