### PR TITLE
SRCH-438, SRCH-431 - fix the css so magnifying glass glyphicon displays properly and sayt works on main pages

### DIFF
--- a/app/assets/stylesheets/searches/custom_bootstrap/_sprites.less
+++ b/app/assets/stylesheets/searches/custom_bootstrap/_sprites.less
@@ -16,8 +16,8 @@
 
 // Sprite icons path
 // -------------------------
-@iconSpritePath:          asset-url('bootstrap/glyphicons-halflings.png');
-@iconWhiteSpritePath:     asset-url('bootstrap/glyphicons-halflings-white.png');
+@iconSpritePath:          'bootstrap/glyphicons-halflings.png';
+@iconWhiteSpritePath:     'bootstrap/glyphicons-halflings-white.png';
 
 .icon {
   display: inline-block;

--- a/deploy/before_symlink.rb
+++ b/deploy/before_symlink.rb
@@ -7,17 +7,16 @@ dgsearch_rails_database :usasearch do
   group 'www-data'
 end
 
-# Compiled assets always end with 32 hex characters.
-# Bash sux and doesn't support [0-9a-f]{32}, and if
-# you type [0-9a=f] 32 times you get "File name too long",
-# so we'll match using any 32 characters. Meh.
-TTHC = "?"*32
-
 # Pre-compile assets. Also, a very small subset of the assets
 # need to be available without digest fingerprints in their
 # filenames - assets that live "in the wild" and can't be
 # updated whenever our asset fingerprints change.
 run <<COMPILE
   cd #{release_path} && \
-  RAILS_ENV=#{rails_env} bundle exec rake assets:precompile
+  RAILS_ENV=#{rails_env} bundle exec rake assets:precompile && \
+  cd #{release_path}/public/assets && \
+  for js in sayt_loader_libs sayt_loader stats; do cp ${js}-*.js ${js}.js && cp ${js}-*.js.gz ${js}.js.gz; done && \
+  for css in sayt; do cp ${css}-*.css ${css}.css && cp ${css}-*.css.gz ${css}.css.gz; done && \
+  for png in bootstrap/glyphicons-halflings bootstrap/glyphicons-halflings-white; do cp ${png}-*.png ${png}.png; done && \
+  find . -type f -perm 600 | xargs --no-run-if-empty chmod 644
 COMPILE


### PR DESCRIPTION
SRCH-438 - Search magnifying glass was not displaying properly
SRCH-431 - sayt compiled assets prevents users from outside using js in their landing page. 