### PR TITLE
SRCH-104 fix SearchgovDomain#domain validation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -88,7 +88,6 @@ gem 'robotex', git: 'https://github.com/MothOnMars/robotex'
 # Using custom branch until https://github.com/lygaret/sitemaps/pull/4 is merged,
 # and https://github.com/lygaret/sitemaps/issues/5 and https://github.com/lygaret/sitemaps/issues/6 are resolved
 gem 'sitemaps_parser', require: 'sitemaps', git: 'https://github.com/MothOnMars/sitemaps', branch: 'discovery_fixes'
-gem 'public_suffix', '~> 3.0.2'
 gem 'counter_culture', '~> 2.0.0'
 gem 'aasm', '~> 4.12'
 gem 'active_scheduler', '~> 0.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -810,7 +810,6 @@ DEPENDENCIES
   poltergeist (~> 1.18.1)
   pry-byebug (~> 3.5)
   pry-rails (~> 0.3.6)
-  public_suffix (~> 3.0.2)
   rack-contrib (~> 1.8.0)
   rack-cors (~> 1.0.2)
   rails (= 4.2.11)

--- a/app/models/searchgov_domain.rb
+++ b/app/models/searchgov_domain.rb
@@ -1,14 +1,19 @@
+# frozen_string_literal: true
+
+# Domains whose pages are indexed into the 'searchgov' I14y drawer
+# for searching via the SearchGov search engine
 class SearchgovDomain < ActiveRecord::Base
   include AASM
   class DomainError < StandardError; end
 
-  OK_STATUS = '200 OK'.freeze
+  OK_STATUS = '200 OK'
 
-  before_validation(on: :create) { self.domain = self.domain&.downcase&.strip }
+  before_validation(on: :create) { self.domain = domain&.downcase&.strip }
 
-  validate :valid_domain?, on: :create
-  validates_inclusion_of :scheme, in: %w(http https)
-  validates_uniqueness_of :domain, on: :create
+  validates :scheme, inclusion: %w[http https]
+  validates :domain, uniqueness: true, on: :create
+  validates :domain, presence: true,
+                     format: { with: /\A([a-z0-9]+(-[a-z0-9]+)*\.)+[a-z]{2,}\Z/ }
 
   after_create { SearchgovDomainPreparerJob.perform_later(searchgov_domain: self) }
 
@@ -34,7 +39,7 @@ class SearchgovDomain < ActiveRecord::Base
   end
 
   def index_sitemaps
-    sitemap_urls.each{ |url| SitemapIndexerJob.perform_later(sitemap_url: url) }
+    sitemap_urls.each { |url| SitemapIndexerJob.perform_later(sitemap_url: url) }
   end
 
   def available?
@@ -66,29 +71,26 @@ class SearchgovDomain < ActiveRecord::Base
   def sitemap_urls
     urls = sitemaps.pluck(:url)
     urls += robotex.sitemaps(url).uniq.
-             reject{ |url| URI(url).host != domain }.
-             map{ |url| UrlParser.update_scheme(url, scheme) }
+              select { |url| URI(url).host == domain }.
+              map { |url| UrlParser.update_scheme(url, scheme) }
     urls.presence || ["#{url}sitemap.xml"]
   end
 
   private
 
   def robotex
-    @robotex ||= Robotex.new 'usasearch'
-  end
-
-  def valid_domain?
-    errors.add(:domain, 'is invalid') unless PublicSuffix.valid?(domain)
+    @robotex ||= Robotex.new('usasearch')
   end
 
   def response
     @response ||= begin
       Retriable.retriable(base_interval: delay) do
         DocumentFetchLogger.new(url, 'searchgov_domain').log
-        HTTP.headers(user_agent: DEFAULT_USER_AGENT).timeout(connect: 20, read: 60).follow.get url
+        HTTP.headers(user_agent: DEFAULT_USER_AGENT).
+          timeout(connect: 20, read: 60).follow.get(url)
       end
-    rescue => error
-      self.update_attributes(status: error.message.strip)
+    rescue StandardError => error
+      update(status: error.message.strip)
       raise DomainError.new("#{domain}: #{error}")
     end
   end

--- a/spec/models/searchgov_domain_spec.rb
+++ b/spec/models/searchgov_domain_spec.rb
@@ -60,9 +60,26 @@ describe SearchgovDomain do
   end
 
   describe 'validations' do
-    it 'validates the domain format' do
-      expect(SearchgovDomain.new(domain: 'foo')).not_to be_valid
-      expect(SearchgovDomain.new(domain: 'search.gov')).to be_valid
+    it { is_expected.to validate_presence_of :domain }
+
+    context 'when the domain is valid' do
+      let(:valid_domains) { %w[search.gov foo.bar.gov foo.bar.baz.museum] }
+
+      it 'is valid' do
+        valid_domains.each do |domain|
+          expect(SearchgovDomain.new(domain: domain)).to be_valid
+        end
+      end
+    end
+
+    context 'when the domain is invalid' do
+      let(:invalid_domains) { ['foo', 'foo.gov.', 'foo.gov/bar', 'foo.gov bar'] }
+
+      it 'is invalid' do
+        invalid_domains.each do |domain|
+          expect(SearchgovDomain.new(domain: domain)).not_to be_valid
+        end
+      end
     end
 
     it { is_expected.to validate_inclusion_of(:scheme).in_array %w(http https) }


### PR DESCRIPTION
SRCH-104 fix SearchgovDomain#domain validation
- remove explicit dependency on PublicSuffix gem
- clean up SearchgovDomain code per Rubocop