### PR TITLE
Release/es56 upgrade

### DIFF
--- a/app/models/elastic_federal_register_document.rb
+++ b/app/models/elastic_federal_register_document.rb
@@ -17,7 +17,7 @@ class ElasticFederalRegisterDocument
         federal_register_agency_ids: { type: 'integer' },
         title: { type: 'string', term_vector: 'with_positions_offsets', analyzer: 'en_analyzer' },
         significant: { type: 'boolean' },
-        id: { type: 'integer', index: :not_analyzed, include_in_all: false }
+        id: { type: 'integer', index: :not_analyzed }
       }
     }
   }

--- a/app/models/elastic_news_item.rb
+++ b/app/models/elastic_news_item.rb
@@ -22,7 +22,7 @@ class ElasticNewsItem
         publisher: { type: 'string', analyzer: 'keyword' },
         bigram: { type: 'string', analyzer: 'bigram_analyzer'},
         tags: { type: 'string', analyzer: 'keyword' },
-        id: { type: 'integer', index: :not_analyzed, include_in_all: false } }
+        id: { type: 'integer', index: :not_analyzed } }
     }
   }
 

--- a/app/models/elastic_tweet.rb
+++ b/app/models/elastic_tweet.rb
@@ -6,13 +6,14 @@ class ElasticTweet
   self.mappings = {
     index_type => {
       dynamic: :strict,
-      _analyzer: { path: "language" },
+      _analyzer: { path: 'language' },
       properties: {
-        language: { type: "string", index: :not_analyzed },
+        language: { type: 'string', index: :not_analyzed },
         twitter_profile_id: { type: 'long' },
         tweet_text: { type: 'string', term_vector: 'with_positions_offsets' },
         published_at: { type: 'date' },
-        id: { type: 'long', index: :not_analyzed, include_in_all: false } }
+        id: { type: 'long', index: :not_analyzed }
+      }
     }
   }
 

--- a/lib/elastic_mappings.rb
+++ b/lib/elastic_mappings.rb
@@ -5,7 +5,8 @@ module ElasticMappings
     properties: {
       language: { type: "string", index: :not_analyzed },
       affiliate_id: { type: 'integer' },
-      id: { type: 'integer', index: :not_analyzed, include_in_all: false } }
+      id: { type: 'integer', index: :not_analyzed }
+    }
   }.freeze
 
   BEST_BET = COMMON.deep_merge(
@@ -14,7 +15,9 @@ module ElasticMappings
       publish_start_on: { type: 'date', format: 'YYYY-MM-dd' },
       publish_end_on: { type: 'date', format: 'YYYY-MM-dd', null_value: '9999-12-31' },
       title: { type: 'string', term_vector: 'with_positions_offsets' },
-      match_keyword_values_only: { type: 'boolean', index: :not_analyzed, include_in_all: false, null_value: 'false' },
+      match_keyword_values_only: { type: 'boolean',
+                                   index: :not_analyzed,
+                                   null_value: 'false' },
       keyword_values: ElasticSettings::KEYWORD }
   ).freeze
 


### PR DESCRIPTION
Upgrade Elasticsearch from 1.7 to 5.x 
SRCH-418 - include_in_all is not allowed for indices and is deprecated