### PR TITLE
SRCH-455 ClickCounter logs errors for missing I14y documents

### DIFF
--- a/app/models/click_counter.rb
+++ b/app/models/click_counter.rb
@@ -38,5 +38,7 @@ class ClickCounter
                         handle: 'searchgov')
   rescue ActiveRecord::RecordNotFound
     Rails.logger.error("SearchgovUrl not found for clicked URL: #{url}")
+  rescue I14yDocument::I14yDocumentError
+    Rails.logger.error("I14yDocument not found for clicked URL: #{url}")
   end
 end

--- a/app/models/click_counter.rb
+++ b/app/models/click_counter.rb
@@ -38,7 +38,9 @@ class ClickCounter
                         handle: 'searchgov')
   rescue ActiveRecord::RecordNotFound
     Rails.logger.error("SearchgovUrl not found for clicked URL: #{url}")
-  rescue I14yDocument::I14yDocumentError
-    Rails.logger.error("I14yDocument not found for clicked URL: #{url}")
+  rescue I14yDocument::I14yDocumentError => error
+    Rails.logger.error(
+      "Unable to update I14yDocument click_count for #{url}: #{error}"
+    )
   end
 end

--- a/spec/models/click_counter_spec.rb
+++ b/spec/models/click_counter_spec.rb
@@ -34,6 +34,20 @@ describe ClickCounter do
           update_click_counts
         end
       end
+
+      context 'when the URL has not been indexed' do
+        let!(:searchgov_url) { SearchgovUrl.create!(url: url) }
+
+        before do
+          allow(I14yDocument).to receive(:update).and_raise(I14yDocument::I14yDocumentError)
+        end
+
+        it 'logs the unindexed URL' do
+          expect(Rails.logger).to receive(:error).
+            with('I14yDocument not found for clicked URL: http://agency.gov/')
+          update_click_counts
+        end
+      end
     end
   end
 

--- a/spec/models/click_counter_spec.rb
+++ b/spec/models/click_counter_spec.rb
@@ -39,12 +39,14 @@ describe ClickCounter do
         let!(:searchgov_url) { SearchgovUrl.create!(url: url) }
 
         before do
-          allow(I14yDocument).to receive(:update).and_raise(I14yDocument::I14yDocumentError)
+          allow(I14yDocument).to receive(:update).
+            and_raise(I14yDocument::I14yDocumentError, 'fail')
         end
 
         it 'logs the unindexed URL' do
-          expect(Rails.logger).to receive(:error).
-            with('I14yDocument not found for clicked URL: http://agency.gov/')
+          expect(Rails.logger).to receive(:error).with(
+            'Unable to update I14yDocument click_count for http://agency.gov/: fail'
+          )
           update_click_counts
         end
       end


### PR DESCRIPTION
This fixes a bug that I discovered when I started updating click counts in production. For URLs that have clicks but are not indexed (such as clicks from URLs that had been indexed, but are no longer available), the `ClickCounter` should log an error rather than dying completely.