### PR TITLE
SRCH-457 run Elasticsearch 5.6 in CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,6 +26,7 @@ executors:
           http.port: 9256
           cluster.name: es56
           xpack.security.enabled: false
+          ES_JAVA_OPTS: '-Xms750m -Xmx750m'
 
 commands:
   prepare_database:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ executors:
 
     docker:
       # using custom image, see .circleci/images/primary/Dockerfile
-      - image: searchgov/circleci:20190313
+      - image: searchgov/circleci:20190320
         environment:
           RAILS_ENV: test
 
@@ -20,6 +20,12 @@ executors:
           MYSQL_ROOT_HOST: "%"
 
       - image: redis:3.2
+
+      - image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16
+        environment:
+          http.port: 9256
+          cluster.name: es56
+          xpack.security.enabled: false
 
 commands:
   prepare_database:
@@ -36,6 +42,10 @@ jobs:
 
     steps:
       - checkout
+
+      - run:
+          name: Wait for Elasticsearch
+          command: dockerize -wait tcp://localhost:9256 -timeout 1m
 
       - run:
           name: Use developer secrets

--- a/.circleci/images/primary/Dockerfile
+++ b/.circleci/images/primary/Dockerfile
@@ -8,4 +8,11 @@ RUN apt-get update && apt-get install -y \
   libprotobuf-dev \
   protobuf-compiler
 
+# Install Dockerize to ensure services are started before test runs
+# https://support.circleci.com/hc/en-us/articles/360006773953-Race-Conditions-Wait-For-Database
+ENV DOCKERIZE_VERSION v0.6.1
+RUN wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && tar -C /usr/local/bin -xzvf dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+  && rm dockerize-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+
 USER circleci


### PR DESCRIPTION
This PR adds an Elasticsearch 5.6 image to CircleCi, and runs Elasticsearch on port 9256. This will enable us to test the Logstash and custom index upgrades against a 5.6 cluster. 