### PR TITLE
SRCH-560 - fix hover highlight

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -617,7 +617,7 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
-    scrypt (3.0.5)
+    scrypt (3.0.6)
       ffi-compiler (>= 1.0, < 2.0)
     select2-rails (4.0.3)
       thor (~> 0.14)

--- a/app/assets/stylesheets/searches/_main_menu.less
+++ b/app/assets/stylesheets/searches/_main_menu.less
@@ -120,6 +120,7 @@
 
   &:hover {
     text-decoration: underline;
+    background: transparent;
   }
   &:focus {
     text-decoration: none;


### PR DESCRIPTION
This PR fixes an issue where hovering over a link in the SERP "Browse" menu resulted in the link text becoming obscured by the hover highlighting. It also bumps the `scrypt` gem, which was necessary to get `bundle install` working.