### PR TITLE
SRCH-586 update RSS feed URLs in cucumber tests

### DIFF
--- a/features/admin_center_manage_content.feature
+++ b/features/admin_center_manage_content.feature
@@ -562,22 +562,22 @@ Feature: Manage Content
     And I follow "RSS" within the Admin Center content
     And I follow "Add RSS Feed"
     When I fill in the following:
-      | Name  | Recalls                                                                          |
-      | URL 1 | http://www.fda.gov/AboutFDA/ContactFDA/StayInformed/RSSFeeds/HealthFraud/rss.xml |
+      | Name  | Recalls                                                                                |
+      | URL 1 | https://www.fda.gov/about-fda/contact-fda/stay-informed/rss-feeds/health-fraud/rss.xml |
     And I choose "RSS"
     And I add the following RSS Feed URLs:
-      | url                                                                                |
-      | http://www.fda.gov/AboutFDA/ContactFDA/StayInformed/RSSFeeds/FoodAllergies/rss.xml |
+      | url                                                                                      |
+      | https://www.fda.gov/about-fda/contact-fda/stay-informed/rss-feeds/food-allergies/rss.xml |
     And I submit the form by pressing "Add"
     Then I should see "You have added Recalls to this site"
     When I follow "Edit"
     Then the "Name" field should contain "Recalls"
-    And the "URL 1" field should contain "http://www.fda.gov/AboutFDA/ContactFDA/StayInformed/RSSFeeds/FoodAllergies/rss.xml"
-    And the "URL 2" field should contain "http://www.fda.gov/AboutFDA/ContactFDA/StayInformed/RSSFeeds/HealthFraud/rss.xml"
+    And the "URL 1" field should contain "https://www.fda.gov/about-fda/contact-fda/stay-informed/rss-feeds/food-allergies/rss.xml"
+    And the "URL 2" field should contain "https://www.fda.gov/about-fda/contact-fda/stay-informed/rss-feeds/health-fraud/rss.xml"
     When I fill in "Name" with "Food, Safety and Pet Health Recalls"
     And I add the following RSS Feed URLs:
-      | url                                                                            |
-      | http://www.fda.gov/AboutFDA/ContactFDA/StayInformed/RSSFeeds/PetHealth/rss.xml |
+      | url                                                                               |
+      | https://www.fda.gov/about-fda/contact-fda/stay-informed/rss-feeds/recalls/rss.xml |
     And I submit the form by pressing "Save"
     Then I should see "You have updated Food, Safety and Pet Health Recalls"
     When I press "Remove"

--- a/features/vcr_cassettes/Manage_Content/Add/edit/remove_RSS_Feed.yml
+++ b/features/vcr_cassettes/Manage_Content/Add/edit/remove_RSS_Feed.yml
@@ -1,0 +1,523 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://www.fda.gov/AboutFDA/ContactFDA/StayInformed/RSSFeeds/PetHealth/rss.xml
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers: {}
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Server:
+      - AkamaiGHost
+      - Apache
+      Content-Length:
+      - '0'
+      - '38863'
+      Location:
+      - https://www.fda.gov/AboutFDA/ContactFDA/StayInformed/RSSFeeds/PetHealth/rss.xml
+      Date:
+      - Wed, 08 May 2019 20:19:06 GMT
+      - Wed, 08 May 2019 20:19:06 GMT
+      Connection:
+      - keep-alive
+      - keep-alive
+      Strict-Transport-Security:
+      - max-age=31536000
+      - max-age=31536000
+      X-Content-Type-Options:
+      - nosniff
+      - nosniff
+      X-Powered-By:
+      - PHP/7.1.8
+      X-Drupal-Dynamic-Cache:
+      - UNCACHEABLE
+      Link:
+      - </about-fda/page-not-found>; rel="canonical"
+      - </about-fda/page-not-found>; rel="canonical"
+      - </about-fda/page-not-found>; rel="revision"
+      - </about-fda/page-not-found>; rel="revision"
+      - </node/388334>; rel="shortlink"
+      - </node/388334>; rel="shortlink"
+      - <http://www.fda.gov/about-fda/page-not-found>; rel="alternate"; hreflang="en"
+      - <http://www.fda.gov/about-fda/page-not-found>; rel="alternate"; hreflang="en"
+      X-Ua-Compatible:
+      - IE=edge
+      Content-Language:
+      - en
+      X-Frame-Options:
+      - SAMEORIGIN
+      Last-Modified:
+      - Wed, 08 May 2019 20:15:48 GMT
+      Etag:
+      - '"1557346548"'
+      X-Generator:
+      - Drupal 8 (https://www.drupal.org)
+      X-Drupal-Cache:
+      - HIT
+      Content-Type:
+      - text/html; charset=UTF-8
+      Cache-Control:
+      - public, max-age=31535976
+      Expires:
+      - Thu, 07 May 2020 20:18:42 GMT
+    body:
+      encoding: UTF-8
+      string: "<!DOCTYPE html>\n<html  lang=\"en\" dir=\"ltr\" prefix=\"content: http://purl.org/rss/1.0/modules/content/
+        \ dc: http://purl.org/dc/terms/  foaf: http://xmlns.com/foaf/0.1/  og: http://ogp.me/ns#
+        \ rdfs: http://www.w3.org/2000/01/rdf-schema#  schema: http://schema.org/
+        \ sioc: http://rdfs.org/sioc/ns#  sioct: http://rdfs.org/sioc/types#  skos:
+        http://www.w3.org/2004/02/skos/core#  xsd: http://www.w3.org/2001/XMLSchema#
+        \">\n  <head>\n    <meta charset=\"utf-8\" />\n<script>(function(i,s,o,g,r,a,m){i[\"GoogleAnalyticsObject\"]=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new
+        Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,\"script\",\"https://www.google-analytics.com/analytics.js\",\"ga\");ga(\"create\",
+        \"UA-22737364-1\", {\"cookieDomain\":\"auto\"});ga(\"set\", \"anonymizeIp\",
+        true);ga(\"set\", \"page\", \"/404.html?page=\" + document.location.pathname
+        + document.location.search + \"&from=\" + document.referrer);ga(\"send\",
+        \"pageview\");</script>\n<meta name=\"title\" content=\"Page Not Found\" />\n<meta
+        name=\"dcterms.title\" content=\"Page Not Found\" />\n<meta name=\"twitter:card\"
+        content=\"summary_large_image\" />\n<meta property=\"og:type\" content=\"Article\"
+        />\n<meta name=\"twitter:title\" content=\"Page Not Found\" />\n<meta name=\"dcterms.creator\"
+        content=\"Office of the Commissioner\" />\n<meta name=\"dcterms.description\"
+        content=\"We’re sorry. The page you are looking for is not available for one
+        of the following reasons: the link to this page may not be correct or is out-of-date,
+        or you have bookmarked a page that has moved.\" />\n<meta property=\"og:title\"
+        content=\"Page Not Found\" />\n<meta name=\"dcterms.publisher\" content=\"FDA\"
+        />\n<meta name=\"dcterms.type\" content=\"Article\" />\n<meta name=\"dcterms.source\"
+        content=\"FDA\" />\n<meta property=\"og:updated_time\" content=\"Mon, 04/01/2019
+        - 00:00\" />\n<meta property=\"article:publisher\" content=\"FDA\" />\n<meta
+        property=\"article:published_time\" content=\"Fri, 04/26/2019 - 13:46\" />\n<meta
+        property=\"article:modified_time\" content=\"Mon, 04/01/2019 - 00:00\" />\n<meta
+        name=\"MobileOptimized\" content=\"width\" />\n<meta name=\"HandheldFriendly\"
+        content=\"true\" />\n<meta name=\"viewport\" content=\"width=device-width,
+        initial-scale=1.0\" />\n<script type=\"application/ld+json\">{\n    \"@context\":
+        \"https://schema.org\",\n    \"@graph\": [\n        {\n            \"@type\":
+        \"Article\",\n            \"name\": \"Page Not Found\",\n            \"headline\":
+        \"Page Not Found\",\n            \"description\": \"We’re sorry. The page
+        you are looking for is not available for one of the following reasons: the
+        link to this page may not be correct or is out-of-date, or you have bookmarked
+        a page that has moved.\",\n            \"image\": {\n                \"@type\":
+        \"ImageObject\",\n                \"representativeOfPage\": \"True\"\n            },\n
+        \           \"datePublished\": \"Fri, 04/26/2019 - 13:46\",\n            \"dateModified\":
+        \"Mon, 04/01/2019 - 00:00\",\n            \"author\": {\n                \"@type\":
+        \"Organization\",\n                \"name\": \"Office of the Commissioner\"\n
+        \           },\n            \"publisher\": {\n                \"@type\": \"Organization\",\n
+        \               \"name\": \"FDA\"\n            }\n        },\n        {\n
+        \           \"@type\": \"WebSite\"\n        }\n    ]\n}</script>\n<link rel=\"shortcut
+        icon\" href=\"/themes/custom/preview/favicon.ico\" type=\"image/vnd.microsoft.icon\"
+        />\n<link rel=\"alternate\" hreflang=\"en\" href=\"http://www.fda.gov/about-fda/page-not-found\"
+        />\n<link rel=\"canonical\" href=\"/about-fda/page-not-found\" />\n<link rel=\"shortlink\"
+        href=\"/node/388334\" />\n<link rel=\"revision\" href=\"/about-fda/page-not-found\"
+        />\n\n    <title>Page Not Found | FDA</title>\n    <link rel=\"stylesheet\"
+        href=\"/files/css/css_PWgPnRTESiPZ9Va0eXOMCBuIg9Q0NWCGz7xUfjCetJU.css?pr5zbs\"
+        media=\"all\" />\n<link rel=\"stylesheet\" href=\"/files/css/css_IySZOrb-tMuAReraAWAV1pv70ZkEE4QSf1mJyj5sdls.css?pr5zbs\"
+        media=\"all\" />\n\n    \n<!--[if lte IE 8]>\n<script src=\"/files/js/js_VtafjXmRvoUgAzqzYTA3Wrjkx9wcWhjP0G4ZnnqRamA.js\"></script>\n<![endif]-->\n<script
+        src=\"https://script.crazyegg.com/pages/scripts/0024/3700.js\" async></script>\n<script
+        src=\"https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=HHS&amp;subagency=FDA&amp;sdor=fda.gov&amp;dclink=true\"
+        language=\"javascript\" id=\"_fed_an_ua_tag\"></script>\n\n  </head>\n  <body
+        class=\"role-anonymous path-aboutfda page-node-type-article has-glyphicons\">\n
+        \     <div id=\"quicklinks\" class=\"sr-only\">\n        <ul>\n          <li><a
+        href=\"#main-content\" class=\"sr-only sr-only-focusable\" tabindex=\"1\">Skip
+        to main content</a></li>\n          <li><a href=\"#search-form\" class=\"sr-only
+        sr-only-focusable\" tabindex=\"1\">Skip to FDA Search</a></li>\n          <li><a
+        href=\"#section-nav\" class=\"sr-only sr-only-focusable\" tabindex=\"1\">Skip
+        to in this section menu</a></li>\n        </ul>   \n      </div><!-- bootstrap
+        class to make content visually hidden but readable by assistive technology
+        -->\n    \n      <div class=\"dialog-off-canvas-main-canvas\" data-off-canvas-main-canvas>\n
+        \   <!-- start main block -->\n\n  <div class=\"main-container container-fluid\"><!--
+        start container-fluid wrapper-->\n    <div class=\"row\"><!-- start row wrapper-->\n\n
+        \                                                              \n\n\n\n\t\n\t<header
+        class=\"lcds-header container-fluid\" role=\"header\"><!--start header. Start
+        container-fluid. This is needed or the content will not bleed to the screen
+        edge. -->\n\n\t\t\t<div class=\"row us-masthead\"><!-- start us-masthead -->\n\n\n\t\t\t\t<div
+        class=\"usa-banner col-xs-12\">\n\n\t\t\t\t\t<img class=\"usa-banner__us-flag\"
+        src=\"/themes/custom/preview/assets/images/US_Flag.png\" alt=\"U.S. flag\"
+        />\n\n\t\t\t\t\t<span>An official website of the United States government</span>\n\n\t\t\t\t\t<a
+        id=\"USMenuButton\" class=\"collapsed\" data-toggle=\"collapse\" data-target=\"#USABannerMenu\"
+        aria-expanded=\"false\" aria-controls=\"USABannerMenu\">Here’s how you know
+        <span class=\"toggle-indicator\"> </span></a>\n          \t\t\t<div class=\"col-xs-12
+        collapse usa-banner__menu\" id=\"USABannerMenu\" aria-labelledby=\"USMenuButton\">\n\n\n\t\t\t\t\t\t<div
+        id=\"gov-banner\" class=\"row usa-banner-content usa-grid usa-accordion-content\"
+        aria-hidden=\"true\">\n\t\t\t\t\t\t\t      <div class=\"col-xs-12 col-sm-6
+        col-md-3\">\n\t\t\t\t\t\t\t        <img class=\"usa-banner-icon usa-media_block-img\"
+        src=\"/themes/custom/preview/assets/images/icon-dot-gov.svg\" alt=\"Dot gov\"
+        style=\"width:3em;\">\n\t\t\t\t\t\t\t\t\t<div class=\"usa-media_block-body\">\n\t\t\t\t\t\t\t\t
+        \     <p><strong>The .gov means it’s official.</strong><br>Federal government
+        websites often end in .gov or .mil. Before sharing sensitive information,
+        make sure you're on a federal government site.</p>\n\t\t\t\t\t\t\t\t    </div>\n\t\t\t\t\t\t\t
+        \     </div>\n\t\t\t\t\t\t\t      <div class=\"col-xs-12 col-sm-6 col-md-3\">\n\t\t\t\t\t\t\t
+        \       <img class=\"usa-banner-icon usa-media_block-img\" src=\"/themes/custom/preview/assets/images/icon-https.svg\"
+        alt=\"SSL\" style=\"width:3em;\">\n\t\t\t\t\t\t\t        <div class=\"usa-media_block-body\">\n\t\t\t\t\t\t\t\t
+        \        <p><strong>The site is secure.</strong><br> The <strong>https://</strong>
+        ensures that you are connecting to the official website and that any information
+        you provide is encrypted and transmitted securely.</p>\n\t\t\t\t\t\t\t        </div>\n\t\t\t\t\t\t\t
+        \     </div>\n\t\t\t\t\t\t</div>\n\t\t\t\t\t</div>\n\n\t\t\t\t\t<!-- Login
+        for anonymous users on the home page -->\n\t\t\t\t\t<!-- Hide the user login
+        link to restrict the access to user from consumption site-->\n\t\t           \n\t\t\t\t</div>\n\t\t\t</div><!--
+        end us-masthead -->\n\n\t\t\t<div class=\"row fda-masthead\"><!-- start fda-masthead
+        -->\n\n\t\t\t<!-- There is a jQuery effect here that changes the title from
+        'Menu' to 'Close' when this is clicked. See file /themes/custom/preview/js/custom.js
+        -->\n\t\t\t\t<div class=\"col-xs-4 col-md-8\"> \n\t\t\t\t\t<a href=\"/\" title=\"FDA
+        Homepage\">\n\t\t\t\t\t\t<h1 class=\"fda-masthead__fda-logo\">U.S. Food and
+        Drug Administration</h1>\n\t\t\t\t\t</a>\n       \t</div>\n\t\t\t\t\n        <div
+        class=\"col-xs-8 col-md-4\">\n          <ul class='fda-masthead__item-list'>\n
+        \           <li><a title=\"\" id=\"btn-search\" class=\"btn btn-default btn-sm
+        fda-masthead__btn-search\">\n              <span class=\"fa fa-search\" aria-hidden=\"true\">&nbsp;</span>\n
+        \             <span class=\"fda-masthead__btn-label\">Search</span>\n            </a></li>\n
+        \           <li><a id=\"menu-btn\" class=\"btn btn-default btn-sm fda-masthead__btn-menu
+        collapsed\" href=\"#primary-nav\" data-toggle=\"collapse\" aria-expanded=\"true\">\n
+        \             <span class=\"fa fa-bars\" aria-hidden=\"true\">&nbsp;</span>\n
+        \             <span class='fda-masthead__btn-label'>Menu</span>\n            </a></li>\n
+        \         </ul>\n\t\t\t\t</div>\n\t\t\t\t\t\t\t\n\t\t\t\t\t\t<form class=\"fda-masthead__search
+        sr-only\" role=\"search\" action=\"https://search.usa.gov/search\" method=\"GET\"
+        name=\"searchForm\" id=\"search-form\" accept-charset=\"UTF-8\" >\n\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t<div
+        class=\"search-popover\" id=\"search-popover\">\n\t\t\t\t\t\t\t\t<div class=\"input-group
+        pull-right\" id=\"search-group\">\n\t\t\t\t\t\t\t\t\t<label class=\"sr-only\"
+        for=\"search\">Search FDA</label>\n\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t<input
+        accesskey=\"4\" class=\"form-control search-input\" id=\"search-query\" name=\"query\"
+        aria-autocomplete=\"list\" aria-haspopup=\"true\" title=\"Enter the terms
+        you wish to search for.\" placeholder=\"Search FDA\"  type=\"text\" /> \n\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t<span
+        class=\"input-group-btn\" id=\"input-group-btn\">\n\t\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t\t\t\t<button
+        type=\"submit\" class=\"btn btn-danger search-btn\" id=\"search-btn\" title=\"Search\"><span
+        class=\"fa fa-search\" aria-hidden=\"true\"><span class=\"sr-only\">Submit
+        search</span></span></button>\n\n\t\t\t\t\t\t\t\t\t</span>\n\n\t\t\t\t\t\t\t\t</div>\n\t\t\t\t\t\t\t</div>\n\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n\t\t\t\t\t\t\t<input
+        name=\"affiliate\" value=\"fda1\" type=\"hidden\">\t\t\t\t\t\t\t\n\t\t\t\t\t\t</form>\t\t\t\t\t\n\n\t\t\t</div><!--
+        end fda-masthead -->\n\n\t\t<nav id=\"primary-nav\" class=\"lcds-primary-nav
+        row collapse\"><!--start of primary navigation-->\n\t\t\t\t\t<div class=\"col-md-5
+        col-lg-4\">\n\t\t\t\t\t\t<section class=\"lcds-primary-nav__group lcds-primary-nav__group--bordered\">\n\t\t\t\t\t\t\t<h2
+        class=\"lcds-primary-nav__group-heading\">Featured</h2>\n\t\t\t\t\t\t\t<ul
+        class=\"lcds-primary-nav__list lcds-primary-nav__list--featured\">\n\t                <li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/about-fda/contact-fda\">Contact
+        FDA</a></li>\n\t                <li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/regulatory-information/search-fda-guidance-documents\">FDA Guidance
+        Documents</a></li>\n\t                <li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/safety/recalls-market-withdrawals-safety-alerts\">Recalls, Market
+        Withdrawals and Safety Alerts</a></li>\n\t                <li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/news-events/newsroom/press-announcements\">Press Announcements</a></li>\n\t
+        \               <li class=\"lcds-primary-nav__list-item\"><a href=\"/inspections-compliance-enforcement-and-criminal-investigations/compliance-actions-and-activities/warning-letters\">Warning
+        Letters</a></li>\n\t                <li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/advisory-committees\">Advisory Committees</a></li>\n\t                <li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/about-fda/en-espanol\">En
+        Espa&#241ol</a></li>\n\t\t\t\t\t\t\t</ul>\n\t\t\t\t\t\t</section>\n\t\t\t\t\t</div>\n\n\t\t\t\t\t<div
+        class=\"col-md-7 col-lg-8\">\n          <section class=\"lcds-primary-nav__group
+        lcds-primary-nav__group--bordered\">\n            <h2 class=\"lcds-primary-nav__group-heading\">Products</h2>\n
+        \           <ul class=\"lcds-primary-nav__list\">\n\t\t\t\t\t\t\t<li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/food\">Food</a></li>\n\t\t\t\t\t\t\t<li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/drugs\">Drugs</a></li>\n\t\t\t\t\t\t\t<li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/medical-devices\">Medical Devices</a></li>\n\t\t\t\t\t\t\t<li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/radiation-emitting-products\">Radiation-Emitting Products</a></li>\n\t\t\t\t\t\t\t<li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/vaccines-blood-biologics\">Vaccines,
+        Blood, and Biologics</a></li>\n\t\t\t\t\t\t\t<li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/animal-veterinary\">Animal and Veterinary</a></li>\n\t\t\t\t\t\t\t<li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/cosmetics\">Cosmetics</a></li>\n\t\t\t\t\t\t\t<li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/tobacco-products\">Tobacco
+        Products</a></li>\n            </ul>\n          </section>\n          <section
+        class=\"lcds-primary-nav__group lcds-primary-nav__group--bordered\">\n            <h2
+        class=\"lcds-primary-nav__group-heading\">Topics</h2>\n            <ul class=\"lcds-primary-nav__list\">\n\t\t\t\t\t\t\t<li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/about-fda\">About FDA</a></li>\n\t\t\t\t\t\t\t<li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/combination-products\">Combination
+        Products</a></li>\n\t\t\t\t\t\t\t<li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/regulatory-information\">Regulatory Information</a></li>\n\t\t\t\t\t\t\t<li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/safety\">Safety</a></li>\n\t\t\t\t\t\t\t<li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/emergency-preparedness-and-response\">Emergency
+        Preparedness</a></li>\n\t\t\t\t\t\t\t<li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/international-programs\">International Programs</a></li>\n\t\t\t\t\t\t\t<li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/news-events\">News and Events</a></li>\n\t\t\t\t\t\t\t<li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/training-and-continuing-education\">Training
+        and Continuing Education</a></li>\n\t\t\t\t\t\t\t<li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/inspections-compliance-enforcement-and-criminal-investigations\">Inspections
+        and Compliance</a></li>\n\t\t\t\t\t\t\t<li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/science-research\">Science and Research</a></li>\n            </ul>\n
+        \         </section>\n          <section class=\"lcds-primary-nav__group lcds-primary-nav__group--bordered\">\n
+        \           <h2 class=\"lcds-primary-nav__group-heading\">Information For</h2>\n
+        \           <ul class=\"lcds-primary-nav__list\">\n\t            <li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/consumers\">Consumers</a></li>\n\t            <li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/patients\">Patients</a></li>\n\t            <li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/industry\">Industry</a></li>\n\t            <li class=\"lcds-primary-nav__list-item\"><a
+        href=\"/health-professionals\">Health Professionals</a></li>\n\t            <li
+        class=\"lcds-primary-nav__list-item\"><a href=\"/federal-state-local-tribal-and-territorial-officials\">Federal,
+        State and Local Officials</a></li>\n            </ul>\n          </section>\n\t\t\t\t\t</div>\n\t
+        \     </nav><!--end of primary navigation-->\n\n    </header><!-- end header
+        .End container-fluid. This is needed or the content will not bleed to the
+        screen edge. -->\n\n\n<div class=\"col-xs-12\">\n\t\n\n</div>\n\n                              \n
+        \                                                                    <section
+        id=\"block-entityviewcontent\" data-block-plugin-id=\"entity_view:node\" class=\"block
+        block-ctools block-entity-viewnode clearfix\">\n  \n    \n\n      \n<!-- This
+        is the template for the In this section breadcrumbs nav above the page title
+        for a few content types, This does not print the alternate section breadcrumb
+        that appears in the left sidebar on large screens. This section will appear
+        above the page title on a small screen and on large screen it apears in the
+        left sidebar. -->\n\n<a class=\"lcds-button--expandable collapsed hidden-md
+        hidden-lg\" data-toggle=\"collapse\" href=\"#section-nav\" >In this section<span
+        class=\"visible-sm-inline-block\">:\n\n    <!-- Print the site structure field
+        first node title -->\n            About FDA\n    \n    </span>\n</a>\n\n<nav
+        id=\"section-nav\" class=\"lcds-card lcds-section-nav lcds-section-nav hidden-md
+        hidden-lg collapse\">\n\n    <ul class=\"lcds-section-nav__list\">\n\n      <li>\n\n
+        \     <!-- For the href link below the this is getting the aliased path to
+        the term reference field called: field_site_structure. -->\n        <a href=\"/about-fda\"
+        title=\"About FDA\" class=\"lcds-section-nav__section-link lcds-section-nav__link
+        lcds-section-nav__parent-link visible-xs-block visible-sm-block\">\n            <!--
+        Print the site structure field first node title -->\n                            About
+        FDA\n                    </a>\n\n            <!-- OEA asked that we not display
+        the breadcrumbs now. See template: breadcrumb.html.twig. drupal_block('preview_breadcrumbs')
+        -->\n\n                        <div class=\"views-element-container form-group\"><div
+        class=\"view view-in-this-section view-id-in_this_section view-display-id-block_5
+        js-view-dom-id-bba9f55908032a84e978961938261934740afed258a870a2c49ec4cfc8645db6\">\n
+        \ \n    \n      \n  \n          </div>\n</div>\n\n\n                        <div
+        class=\"views-element-container form-group\"><div class=\"view view-in-this-section-sub
+        view-id-in_this_section_sub view-display-id-block_2 js-view-dom-id-9dfc0cf8cf699ded518e0d3fb6f0f1d54f17951d13d5437a64e0529145d99d14\">\n
+        \ \n    \n      \n      <div class=\"view-content\">\n      <div>\n  \n  <ul
+        class=\"lcds-section-nav__list\">\n\n          <li><a href=\"/about-fda/transparency\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link\">Transparency</a></li>\n
+        \         <li><a href=\"/about-fda/about-website\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link\">About This Website</a></li>\n          <li><a href=\"/about-fda/contact-fda\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link\">Contact FDA</a></li>\n
+        \         <li><a href=\"/about-fda/doing-business-fda\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link\">Doing Business With FDA</a></li>\n          <li><a
+        href=\"/about-fda/fda-acronyms-abbreviations\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link\">FDA Acronyms &amp; Abbreviations</a></li>\n          <li><a
+        href=\"/about-fda/fda-commissioner\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link\">FDA Commissioner</a></li>\n          <li><a href=\"/about-fda/fda-en-espanol\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link\">FDA en Español</a></li>\n
+        \         <li><a href=\"/about-fda/fda-organization\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link\">FDA Organization</a></li>\n          <li><a href=\"/about-fda/innovation-fda\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link\">Innovation
+        at FDA</a></li>\n          <li><a href=\"/about-fda/jobs-and-training-fda\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link\">Jobs and Training
+        at FDA</a></li>\n          <li><a href=\"/about-fda/partnerships-enhancing-science-through-collaborations-fda\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link\">Partnerships:
+        Enhancing Science Through Collaborations With FDA</a></li>\n          <li><a
+        href=\"/about-fda/plain-writing-its-law\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link\">Plain Writing: It&#039;s the Law!</a></li>\n          <li><a
+        href=\"/about-fda/reports-manuals-forms\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link\">Reports, Manuals, &amp; Forms</a></li>\n          <li><a
+        href=\"/about-fda/history-fdas-fight-consumer-protection-and-public-health\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link\">The History
+        of FDA&#039;s Fight for Consumer Protection and Public Health</a></li>\n          <li><a
+        href=\"/about-fda/what-we-do\" class=\"lcds-section-nav__section-link lcds-section-nav__link\">What
+        We Do</a></li>\n    \n  </ul>\n\n</div>\n\n    </div>\n  \n          </div>\n</div>\n\n\n
+        \     </li>\n\n    </ul>\n\n</nav>\n\n  </section>\n\n<section id=\"block-entityviewcontent-15\"
+        data-block-plugin-id=\"entity_view:node\" class=\"block block-ctools block-entity-viewnode
+        clearfix\">\n  \n    \n\n      \n    <ol class=\"lcds-breadcrumb visible-md
+        visible-lg\">\n          <li >\n                  <a href=\"/\">Home</a>\n
+        \             </li>\n          <li >\n                  <a href=\"/about-fda\">About
+        FDA</a>\n              </li>\n          <li >\n                  <a class=\"current-link\">Page
+        Not Found</a>\n              </li>\n      </ol>\n\n\n\n\n<ol class=\"lcds-breadcrumb
+        visible-sm visible-xs\">\n  <li>\n    <a href=\"/\" title=\"Home\">\n     Home\n
+        \   </a>\n  </li>\n</ol>\n\n  </section>\n\n\n\n\n\n\n                                \n
+        \     <main>\n\n          <!-- Change the main content wrapper class depending
+        on if user logged in and the url path, this will affect the css styling of
+        the page. The style from /core/_typography.scss is called article p -->\n
+        \                     <article id=\"main-content\" class=\"article main-content
+        container-fluid\" role=\"article\">\n          \n                                                                <header
+        class=\"row content-header\" role=\"heading\">\n                         <section
+        id=\"block-entityviewcontent-2\" data-block-plugin-id=\"entity_view:node\"
+        class=\"block block-ctools block-entity-viewnode clearfix\">\n  \n    \n\n
+        \     \n<div class=\"col-sm-12 col-md-8 col-md-offset-2\">\n\n  <h1 class=\"content-title
+        text-center\">Page Not Found</h1>\n  \n  \t\n    <div class=\"lcds-toolbar
+        lcds-toolbar--social\">\n      <ul class=\"lcds-share lcds-share--default\">\n
+        \   <li class=\"lcds-share__item\">\n      <a href=\"https://www.facebook.com/sharer/sharer.php?u=\"
+        class=\"lcds-share__btn lcds-share--default__btn-facebook js-share\" id=\"fb-share\"
+        target=\"_blank\"><span class=\"fa icon-facebook\" aria-hidden=\"true\"></span>Share</a>\n
+        \   </li>\n    <li class=\"lcds-share__item\">\n      <a href=\"https://twitter.com/intent/tweet/?text=&amp;url=\"
+        target=\"_blank\" class=\"lcds-share__btn lcds-share--default__btn-twitter
+        js-share\" id=\"twitter-share\"><span class=\"fa icon-twitter\" aria-hidden=\"true\"></span>Tweet</a>\n
+        \   </li>\n    <li class=\"lcds-share__item hidden-xs\">\n      <a href=\"https://www.linkedin.com/shareArticle?mini=true&amp;url=&amp;title=&amp;source=FDA\"
+        class=\"lcds-share__btn lcds-share--default__btn-linkedin js-share\" id=\"linkedin-share\"
+        target=\"_blank\"><span class=\"fa icon-linkedin\" aria-hidden=\"true\"></span>Linkedin</a>\n
+        \   </li>\n    <!--<li class=\"hidden-more-share hidden-sm hidden-md hidden-lg\">\n
+        \     <a id=\"more-share-btn\" href=\"#more-shares\" class=\"share-btn more-share
+        collapsed-more\"><span class=\"fa icon-plus\" aria-hidden=\"true\"></span><span
+        class=\"sr-only\">More sharing options</span></a>\n      <ul>\n        <li
+        class=\"share-li hide\">\n          <a href=\"https://www.linkedin.com/shareArticle?mini=true&amp;url=&amp;title=&amp;source=FDA\"
+        class=\"share-btn linkedin-share js-share\" id=\"linkedin-share-sm\" target=\"_blank\"><span
+        class=\"fa icon-linkedin\" aria-hidden=\"true\"></span><span class=\"sr-only\">Linkedin</span></a>\n
+        \       </li>\n      </ul>\n    </li>-->\n    <li class=\"lcds-share__item\">\n
+        \     <a href=\"mailto:?subject=&amp;body=\" class=\"lcds-share__btn lcds-share--default__btn-mail\"><span
+        class=\"fa icon-envelope\" aria-hidden=\"true\"></span>Email</a>\n      </li>\n
+        \   <li class=\" lcds-share__item hidden-xs\">\n      <a href=\"javascript:window.print();\"
+        title=\"Print this page\" class=\"lcds-share__btn lcds-share--default__btn-print\"><span
+        class=\"fa icon-print\" aria-hidden=\"true\"></span>Print</a>\n    </li>\n
+        \ </ul>\n  <div class=\"form-group\"><!-- start language drop down menu div-->\n
+        \   <label class=\"sr-only\" for=\"languageselection\">Read this page in</label>\n
+        \   \n  </div><!-- end language drop down--> \n\n     \n</div><!-- end share
+        toolbar div --> \n</div>\n\n  </section>\n\n\n\n\n\n\n                      </header>\n
+        \                             \n                                                                           <div
+        class=\"col-md-8 col-md-push-2\" role=\"main\">\n\n                            \n
+        \                           \n                            \n                            \n
+        \                                               <h1 class=\"page-header\"><!--
+        This is a workaround that hides the Page Title Block when previewing a node,
+        becasue we are \nalready printing it out inside template node-xx-entity-view-article-top-\nregion.html.twig.
+        This also using hidetitle.js-->\n<span class=\"remove-duplicate-title\">Page
+        Not Found</span>\n</h1>\n\n  <!-- Main Image display options. If the Boolean
+        is checked or has a value = 1, and the main image field has an image, then
+        the main image will not display. -->\n\n<p>We’re sorry. The page you are looking
+        for is not available for one of the following reasons.</p>\n\n<ul><li>The
+        link to this page may not be correct or is out-of-date.</li>\n\t<li>You have
+        bookmarked a page that has moved.</li>\n</ul><p>Try one of these options:</p>\n\n<p><a
+        class=\"btn btn-primary bottom-margin\" href=\"https://search.usa.gov/search?utf8=%E2%9C%93&amp;affiliate=fda\"
+        role=\"button\">Search FDA.gov</a> <a class=\"btn btn-primary bottom-margin\"
+        href=\"/about-fda/about-website/fdagov-archive\" role=\"button\">Check the
+        FDA Archive</a> <a class=\"btn btn-primary bottom-margin\" href=\"/about-fda/contact-fda\"
+        role=\"button\">Contact FDA</a></p>\n\n<hr /><p>Or try one of these helpful
+        links to FDA topics:</p>\n\n<div class=\"inset-column\"><div class=\"row\">
+        <div class=\"col-sm-6\"> \n<ul style=\"margin-bottom: .5rem;\"><li><a data-entity-substitution=\"canonical\"
+        data-entity-type=\"node\" data-entity-uuid=\"96b51152-5d6e-440f-ab97-fdd7c8d60fa5\"
+        href=\"/home\" title=\"U.S. Food and Drug Administration\">FDA.gov Homepage</a></li>\n\t<li><a
+        data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"27682501-ce57-46f6-bdcc-ed03ab7edfac\"
+        href=\"/food\" title=\"Food\">Food</a></li>\n\t<li><a data-entity-substitution=\"canonical\"
+        data-entity-type=\"node\" data-entity-uuid=\"fa2ee775-8209-43d2-8376-3afcbc455f15\"
+        href=\"/drugs\" title=\"Drugs\">Human Drugs</a></li>\n\t<li><a data-entity-substitution=\"canonical\"
+        data-entity-type=\"node\" data-entity-uuid=\"ee788d26-dc06-4edf-93cc-e9c219f3f170\"
+        href=\"/medical-devices\" title=\"Medical Devices\">Medical Devices</a></li>\n\t<li><a
+        data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"c6685181-def7-416a-b475-6185aa07ad1c\"
+        href=\"/radiation-emitting-products\" title=\"Radiation-Emitting Products\">Radiation-Emitting
+        Products</a></li>\n</ul></div> <div class=\"col-sm-6\"> \n\n<ul><li><a data-entity-substitution=\"canonical\"
+        data-entity-type=\"node\" data-entity-uuid=\"5b7a634d-387f-42ab-b882-955e64ae93d7\"
+        href=\"/vaccines-blood-biologics\" title=\"Vaccines, Blood &amp; Biologics\">Vaccines,
+        Blood, and Biologics</a></li>\n\t<li><a data-entity-substitution=\"canonical\"
+        data-entity-type=\"node\" data-entity-uuid=\"01791ea7-9acc-4811-9a6b-47fc24b35c19\"
+        href=\"/animal-veterinary\" title=\"Animal &amp; Veterinary\">Animal and Veterinary</a></li>\n\t<li><a
+        data-entity-substitution=\"canonical\" data-entity-type=\"node\" data-entity-uuid=\"c725151b-4a47-47f7-ab63-6598893922f5\"
+        href=\"/cosmetics\" title=\"Cosmetics\">Cosmetics</a></li>\n\t<li><a data-entity-substitution=\"canonical\"
+        data-entity-type=\"node\" data-entity-uuid=\"4d36e2ba-1dcb-421b-a1b5-a09969a2aaba\"
+        href=\"/tobacco-products\" title=\"Tobacco Products\">Tobacco Products</a></li>\n</ul></div>
+        </div></div>\n\n<hr /><p>Are you sure this is the right web address? <a href=\"mailto:webmail@oc.fda.gov\">Let
+        us know.</a></p>\n<style type=\"text/css\">\n<!--/*--><![CDATA[/* ><!--*/\n\n<!--/*--><![CDATA[/*
+        ><!--*/\n.lcds-toolbar--social, .lcds-card {\n  display:none}\n  #section-nav,
+        #block-entityviewcontent-15{\n    display:none}\n\n/*--><!]]]]><![CDATA[>*/\n\n/*--><!]]>*/\n</style>\n\n\n\n
+        \             \n                                            \n              \n
+        \           </div>\n\n                                                                                  <aside
+        class=\"col-md-2 col-md-push-2\" role=\"complementary\">\n                  <section
+        id=\"block-entityviewcontent-4\" data-block-plugin-id=\"entity_view:node\"
+        class=\"block block-ctools block-entity-viewnode clearfix\">\n  \n    \n\n
+        \       <div role=\"article\" about=\"/about-fda/page-not-found\" class=\"region
+        region-\">\n  <aside class=\"lcds-card lcds-card--border-top\" role=\"menu\"><!--
+        start of metadata aside -->\n    <ul class=\"lcds-description-list\">\n      \n
+        \             <li class=\"lcds-description-list__item\">\n            <div>\n
+        \             <h2 class=\"lcds-description-list__item-heading\">Content current
+        as of:</h2>\n              <!-- display the change date value below -->\n
+        \             <p class=\"lcds-description-list__item-text\">04/01/2019</p>\n
+        \           </div>\n          </li>\n                <li class=\"lcds-description-list__item\">\n
+        \         <div>\n                                             \n                    \n\n
+        \                             \n            \n        </div>\n        </li>\n
+        \             </ul>\n    </aside><!-- end left navigation 2 list group with
+        heading and text -->\n    </div>\n\n  </section>\n\n\n                </aside>\n
+        \           \n\n                                                                                <aside
+        class=\"col-md-2 col-md-pull-10\" role=\"complementary\">\n                  <section
+        id=\"block-entityviewcontent-3\" data-block-plugin-id=\"entity_view:node\"
+        class=\"block block-ctools block-entity-viewnode clearfix\">\n  \n    \n\n
+        \       <div role=\"article\" about=\"/about-fda/page-not-found\" class=\"region
+        region-\">\n        <nav id=\"section-nav\"class=\"lcds-card lcds-section-nav
+        lcds-section-nav--side hidden-xs hidden-sm\">\n      <ul class=\"lcds-section-nav__list
+        lcds-section-nav--side__list\">\n        <li>\n\n                    <a href=\"/about-fda\"
+        class=\"lcds-section-nav__link lcds-section-nav--side__link lcds-section-nav__parent-link
+        lcds-section-nav--side__parent-link\">\n                                        About
+        FDA\n                      </a>\n\n          \n                        <div
+        class=\"views-element-container form-group\"><div class=\"view view-in-this-section
+        view-id-in_this_section view-display-id-block_4 js-view-dom-id-6a79639e22907b5b1173f85423eda91f096f3d6982d83de4cf3023466c6656da\">\n
+        \ \n    \n      \n  \n          </div>\n</div>\n\n\n                        <div
+        class=\"views-element-container form-group\"><div class=\"view view-in-this-section-sub
+        view-id-in_this_section_sub view-display-id-block_1 js-view-dom-id-cd6336db3414cb2515a0f46d588f1132e6d4841bf29c1adc4f82e6f81a13739a\">\n
+        \ \n    \n      \n      <div class=\"view-content\">\n      <div>\n  \n  <ul
+        class=\"lcds-section-nav__list\">\n\n          <li><a href=\"/about-fda/transparency\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link lcds-section-nav--side__link\">Transparency</a></li>\n
+        \         <li><a href=\"/about-fda/about-website\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link lcds-section-nav--side__link\">About This Website</a></li>\n
+        \         <li><a href=\"/about-fda/contact-fda\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link lcds-section-nav--side__link\">Contact FDA</a></li>\n
+        \         <li><a href=\"/about-fda/doing-business-fda\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link lcds-section-nav--side__link\">Doing Business With
+        FDA</a></li>\n          <li><a href=\"/about-fda/fda-acronyms-abbreviations\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link lcds-section-nav--side__link\">FDA
+        Acronyms &amp; Abbreviations</a></li>\n          <li><a href=\"/about-fda/fda-commissioner\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link lcds-section-nav--side__link\">FDA
+        Commissioner</a></li>\n          <li><a href=\"/about-fda/fda-en-espanol\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link lcds-section-nav--side__link\">FDA
+        en Español</a></li>\n          <li><a href=\"/about-fda/fda-organization\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link lcds-section-nav--side__link\">FDA
+        Organization</a></li>\n          <li><a href=\"/about-fda/innovation-fda\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link lcds-section-nav--side__link\">Innovation
+        at FDA</a></li>\n          <li><a href=\"/about-fda/jobs-and-training-fda\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link lcds-section-nav--side__link\">Jobs
+        and Training at FDA</a></li>\n          <li><a href=\"/about-fda/partnerships-enhancing-science-through-collaborations-fda\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link lcds-section-nav--side__link\">Partnerships:
+        Enhancing Science Through Collaborations With FDA</a></li>\n          <li><a
+        href=\"/about-fda/plain-writing-its-law\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link lcds-section-nav--side__link\">Plain Writing: It&#039;s
+        the Law!</a></li>\n          <li><a href=\"/about-fda/reports-manuals-forms\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link lcds-section-nav--side__link\">Reports,
+        Manuals, &amp; Forms</a></li>\n          <li><a href=\"/about-fda/history-fdas-fight-consumer-protection-and-public-health\"
+        class=\"lcds-section-nav__section-link lcds-section-nav__link lcds-section-nav--side__link\">The
+        History of FDA&#039;s Fight for Consumer Protection and Public Health</a></li>\n
+        \         <li><a href=\"/about-fda/what-we-do\" class=\"lcds-section-nav__section-link
+        lcds-section-nav__link lcds-section-nav--side__link\">What We Do</a></li>\n
+        \   \n  </ul>\n\n</div>\n\n    </div>\n  \n          </div>\n</div>\n\n\n
+        \       </li>\n      </ul>\n    </nav>\n    </div>\n\n  </section>\n\n\n                </aside>\n
+        \           \n                 </article><!-- end main content article -->\n
+        \       \n      </main>\n\n    </div><!-- end row wrapper-->\n  </div><!--
+        end container-fluid wrapper-->\n\n<!-- end main block -->\n\n                <div
+        class=\"region region-subscribe\">\n    <section id=\"block-entityviewcontent-5\"
+        data-block-plugin-id=\"entity_view:node\" class=\"block block-ctools block-entity-viewnode
+        clearfix\">\n  \n    \n\n      \n  </section>\n\n\n  </div>\n\n  \n      <footer
+        class=\"lcds-footer container-fluid\">\n        \n    <div class=\"row lcds-footer__primary\">\n
+        \   <nav id=\"footer-heading\" class=\"text-center\">\n      <div class=\"col-sm-4\">\n
+        \       <ul class=\"nav\">\n          <li><a href=\"/about-fda/about-website/fdagov-archive\"
+        title=\"FDA Archive\">FDA Archive</a></li>\n          <li><a href=\"/about-fda\"
+        title=\"About FDA\">About FDA</a></li>\n          <li><a href=\"/about-fda/about-website/internet-accessibility\"
+        title=\"Accessibility\">Accessibility</a></li>\n        </ul>\n      </div>\n
+        \     <div class=\"col-sm-4\">\n        <ul class=\"nav\">\n          <li><a
+        href=\"/about-fda/white-oak-campus-information/public-meetings-fda-white-oak-campus\"
+        title=\"Visitor Information\">Visitor Information</a> </li>\n          <li><a
+        href=\"/about-fda/about-website/website-policies\" title=\"Website Policies
+        / Privacy\">Website Policies / Privacy</a></li>\n          <li><a href=\"/about-fda/jobs-and-training-fda/no-fear-act\"
+        title=\"No FEAR Act\">No FEAR Act</a></li>\n        </ul>\n      </div>\n
+        \     <div class=\"col-sm-4\">\n        <ul class=\"nav\">\n          <li><a
+        href=\"/regulatory-information/freedom-information\" title=\"Freedom of Information
+        Act\">FOIA</a></li>\n          <li><a href=\"https://www.hhs.gov/\" title=\"Health
+        and Human Services\" target=\"_blank\">HHS.gov</a></li>\n          <li><a
+        href=\"https://www.usa.gov/\" title=\"USA.gov\" target=\"_blank\">USA.gov</a></li>\n
+        \       </ul>\n      </div>\n    </nav>\n  </div>\n  <!-- /row -->\n  <div
+        class=\"row lcds-footer__secondary\">\n    <div class=\" col-sm-12 col-md-4
+        lcds-footer__social-links\">\n      <a href=\"/about-fda/contact-fda\" class=\"btn
+        btn-default btn-md\">Contact FDA</a>\n      <a href=\"https://www.facebook.com/FDA\"
+        title=\"Follow FDA on Facebook\" class=\"no-disclaimer\"> \n        <span
+        class=\"fa fa-facebook fa-2x\" aria-hidden=\"true\">\n          <span class=\"sr-only\">Follow
+        FDA on Facebook</span> \n        </span>\n      </a>\n      <a href=\"https://www.twitter.com/US_FDA\"
+        title=\"Follow FDA on Twitter\" class=\"no-disclaimer\"> \n        <span class=\"fa
+        fa-twitter fa-2x\" aria-hidden=\"true\"></span> \n      </a>\n      <a href=\"https://www.youtube.com/user/USFoodandDrugAdmin\"
+        title=\"View FDA videos on YouTube\" class=\"no-disclaimer\">\n        <span
+        class=\"fa fa-youtube fa-2x\" aria-hidden=\"true\"> \n          <span class=\"sr-only\">View
+        FDA videos on YouTube</span>\n        </span>\n      </a>\n      <a href=\"/about-fda/contact-fda/subscribe-podcasts-and-news-feeds\"
+        title=\"Subscribe to FDA RSS feeds\">\n        <span class=\"fa fa-rss fa-2x\"
+        aria-hidden=\"true\">\n          <span class=\"sr-only\">Subscribe to FDA
+        RSS feeds</span>\n        </span>\n      </a>\n    </div>\n    <a href=\"/\"
+        title=\"FDA Homepage\">\n      <div class=\"hidden-xs hidden-sm col-md-4 text-center
+        lcds-footer__logo\"></div>\n    </a>\n\n    <div class=\"col-sm-12 col-md-4
+        text-center lcds-footer__contact-number\">\n      <span class=\"fa fa-phone\"
+        aria-hidden=\"true\"> </span> 1-888-INFO-FDA (1-888-463-6332)\n    </div>\n
+        \ </div>\n        <!-- /row -->\n\n  <!--BEGIN QUALTRICS WEBSITE FEEDBACK
+        SNIPPET-->\n  <script type='text/javascript'>\n  (function(){var g=function(e,h,f,g){\n
+        \ this.get=function(a){for(var a=a+\"=\",c=document.cookie.split(\";\"),b=0,e=c.length;b<e;b++){for(var
+        d=c[b];\" \"==d.charAt(0);)d=d.substring(1,d.length);if(0==d.indexOf(a))return
+        d.substring(a.length,d.length)}return null};\n  this.set=function(a,c){var
+        b=\"\",b=new Date;b.setTime(b.getTime()+6048E5);b=\"; expires=\"+b.toGMTString();document.cookie=a+\"=\"+c+b+\";
+        path=/; \"};\n  this.check=function(){var a=this.get(f);if(a)a=a.split(\":\");else
+        if(100!=e)\"v\"==h&&(e=Math.random()>=e/100?0:100),a=[h,e,0],this.set(f,a.join(\":\"));else
+        return!0;var c=a[1];if(100==c)return!0;switch(a[0]){case \"v\":return!1;case
+        \"r\":return c=a[2]%Math.floor(100/c),a[2]++,this.set(f,a.join(\":\")),!c}return!0};\n
+        \ this.go=function(){if(this.check()){var a=document.createElement(\"script\");a.type=\"text/javascript\";a.src=g+
+        \"&t=\" + (new Date()).getTime();document.body&&document.body.appendChild(a)}};\n
+        \ this.start=function(){var a=this;window.addEventListener?window.addEventListener(\"load\",function(){a.go()},!1):window.attachEvent&&window.attachEvent(\"onload\",function(){a.go()})}};\n
+        \ try{(new g(100,\"r\",\"QSI_S_ZN_6FpQ8uiCQiPh6SN\",\"https://zn6fpq8uicqiph6sn-fdawebcx.gov1.siteintercept.qualtrics.com/SIE/?Q_ZID=ZN_6FpQ8uiCQiPh6SN\")).start()}catch(i){}})();\n
+        \ </script><div id='ZN_6FpQ8uiCQiPh6SN'><!--DO NOT REMOVE-CONTENTS PLACED
+        HERE--></div>\n  <!--END WEBSITE FEEDBACK SNIPPET-->\n\n\n    </footer>\n
+        \ \n  </div>\n\n    \n    <script type=\"application/json\" data-drupal-selector=\"drupal-settings-json\">{\"path\":{\"baseUrl\":\"\\/\",\"scriptPath\":null,\"pathPrefix\":\"\",\"currentPath\":\"\",\"currentPathIsAdmin\":false,\"isFront\":false,\"currentLanguage\":\"en\"},\"pluralDelimiter\":\"\\u0003\",\"jquery\":{\"ui\":{\"datepicker\":{\"isRTL\":false,\"firstDay\":0}}},\"fda_ckeditor_enhancements\":{\"basePath\":\"modules\\/custom\\/fda_ckeditor_enhancements\"},\"google_analytics\":{\"trackOutbound\":true,\"trackMailto\":true,\"trackDownload\":true,\"trackDownloadExtensions\":\"7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip\"},\"bootstrap\":{\"forms_has_error_value_toggle\":1,\"modal_animation\":1,\"modal_backdrop\":\"true\",\"modal_focus_input\":1,\"modal_keyboard\":1,\"modal_select_text\":1,\"modal_show\":1,\"modal_size\":\"\",\"popover_enabled\":1,\"popover_animation\":1,\"popover_auto_close\":1,\"popover_container\":\"body\",\"popover_content\":\"\",\"popover_delay\":\"0\",\"popover_html\":0,\"popover_placement\":\"right\",\"popover_selector\":\"\",\"popover_title\":\"\",\"popover_trigger\":\"click\",\"popover_trigger_autoclose\":1},\"ajax\":[],\"user\":{\"uid\":0,\"permissionsHash\":\"ffb205e810d8b0b2b50c1a3473dd03feffba3af34655a106124f87d0384157df\"}}</script>\n<script
+        src=\"/files/js/js_iP_-Zs66DLh0KyFD4N4qdtD7ZR3eeA0-naTai2N1Xzw.js\"></script>\n\n
+        \ </body>\n</html>\n"
+    http_version: 
+  recorded_at: Wed, 08 May 2019 20:19:06 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
These cucumber tests were failing due to redirected RSS URLs. Why those weren't recorded on VCR cassettes, I have no idea. I've recorded those cassettes now, so these tests won't hit those external URLs in the future.