### PR TITLE
SRCH-670 - Rails 5 new behavior when uploading files in test

### DIFF
--- a/spec/models/sayt_suggestion_spec.rb
+++ b/spec/models/sayt_suggestion_spec.rb
@@ -175,11 +175,13 @@ describe SaytSuggestion do
 
   describe "#process_sayt_suggestion_txt_upload" do
     fixtures :affiliates
+    let(:content_type) { 'text/plain' }
+
     before do
       @affiliate = affiliates(:basic_affiliate)
       @phrases = %w{ one two three }
       tempfile = File.open('spec/fixtures/txt/sayt_suggestions.txt')
-      @file = ActionDispatch::Http::UploadedFile.new(:tempfile => tempfile, :type => 'text/plain')
+      @file = Rack::Test::UploadedFile.new(tempfile, content_type)
       @dummy_suggestion = SaytSuggestion.create(:phrase => 'dummy suggestions')
     end
 

--- a/spec/models/site_domain_spec.rb
+++ b/spec/models/site_domain_spec.rb
@@ -51,7 +51,7 @@ describe SiteDomain do
       end
       tempfile.close
       tempfile.open
-      ActionDispatch::Http::UploadedFile.new(:tempfile => tempfile, :type => content_type)
+      Rack::Test::UploadedFile.new(tempfile, content_type)
     end
     let(:site_domain) { mock_model(SiteDomain) }
 

--- a/spec/models/superfresh_url_spec.rb
+++ b/spec/models/superfresh_url_spec.rb
@@ -28,7 +28,7 @@ describe SuperfreshUrl do
         end
         tempfile.close
         tempfile.open
-        @file = ActionDispatch::Http::UploadedFile.new(:tempfile => tempfile)
+        @file = Rack::Test::UploadedFile.new(tempfile)
       end
 
       it "should create a new SuperfreshUrl for each of the lines in the file" do
@@ -49,7 +49,7 @@ describe SuperfreshUrl do
         101.times { |x| tempfile.write("https://search.usa.gov/#{x}\n") }
         tempfile.close
         tempfile.open
-        @file = ActionDispatch::Http::UploadedFile.new(:tempfile => tempfile)
+        @file = Rack::Test::UploadedFile.new(tempfile)
       end
 
       it "should raise an error that there are too many URLs in the file" do


### PR DESCRIPTION
SRCH-670 - If you are using ActionDispatch::Http::UploadedFile in your tests to upload files, you will need to change to use the similar Rack::Test::UploadedFile class instead.