### PR TITLE
update query_downloads_controller_spec to return correct format

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -67,6 +67,9 @@ Rails.application.configure do
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
   config.ssl_options[:secure_cookies] = true
+
+  # needs autoloading while running in production mode
+  config.enable_dependency_loading = true
 end
 
 ADDITIONAL_BING_PARAMS = {}

--- a/spec/controllers/sites/query_downloads_controller_spec.rb
+++ b/spec/controllers/sites/query_downloads_controller_spec.rb
@@ -21,7 +21,7 @@ describe Sites::QueryDownloadsController do
 
       it 'should generate a CSV of human and bot traffic for some date range, sorted by human count' do
         get :show, site_id: site.id, start_date: '2014-06-08', end_date: '2014-06-14', format: 'csv'
-        expect(response.content_type).to eq("text/csv; charset=utf-8; header=present")
+        expect(response.content_type).to eq("text/csv")
         expect(response.headers["Content-Disposition"]).to eq("attachment;filename=nps.gov_2014-06-08_2014-06-14.csv")
         expect(response.body).to start_with("Search Term,Real (Humans only) Queries,Real Clicks,Real CTR,Total (Bots + Humans) Queries,Total Clicks,Total CTR\njobs,9,15,166.7%,10,15,150.0%\nchartres,1,20,2000.0%,1,1,100.0%\n")
         expect(response.body).to have_content("filing complaints on us priviate militaires companies,0,0,--,8,12,150.0%")


### PR DESCRIPTION
SRCH-696 - After rails 5 upgrade the rspec tests for query downloads failed due to slight change in the format. 