### PR TITLE
SRCH-689 - update generalized unauthorized message

### DIFF
--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -2,7 +2,7 @@ class UserSession < Authlogic::Session::Base
   allow_http_basic_auth false
   consecutive_failed_logins_limit 10
   failed_login_ban_for 30.minutes
-  generalize_credentials_error_messages ''
+  generalize_credentials_error_messages 'These credentials are not recognized as valid for accessing Search.gov. Please contact search@support.digitalgov.gov if you believe this is in error.'
   logout_on_timeout true
 
   def persisted?

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,11 +1,16 @@
+# frozen_string_literal: true
+
 class UserSession < Authlogic::Session::Base
+
+  INVALID_LOGIN_MESSAGE = <<~MESSAGE.chomp
+    These credentials are not recognized as valid for accessing Search.gov.
+    Please contact search@support.digitalgov.gov if you believe this is in error.
+  MESSAGE
+
   allow_http_basic_auth false
   consecutive_failed_logins_limit 10
   failed_login_ban_for 30.minutes
-  generalize_credentials_error_messages 'These credentials are not recognized as valid' \
-                                        ' for accessing Search.gov. Please contact ' \
-                                        'search@support.digitalgov.gov if you believe ' \
-                                        'this is in error.'
+  generalize_credentials_error_messages INVALID_LOGIN_MESSAGE
   logout_on_timeout true
 
   def persisted?

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -2,8 +2,7 @@ class UserSession < Authlogic::Session::Base
   allow_http_basic_auth false
   consecutive_failed_logins_limit 10
   failed_login_ban_for 30.minutes
-  generalize_credentials_error_messages 'Login failed due to invalid ' \
-                                        'username and/or password.'
+  generalize_credentials_error_messages ''
   logout_on_timeout true
 
   def persisted?

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -2,7 +2,10 @@ class UserSession < Authlogic::Session::Base
   allow_http_basic_auth false
   consecutive_failed_logins_limit 10
   failed_login_ban_for 30.minutes
-  generalize_credentials_error_messages 'These credentials are not recognized as valid for accessing Search.gov. Please contact search@support.digitalgov.gov if you believe this is in error.'
+  generalize_credentials_error_messages 'These credentials are not recognized as valid' \
+                                        ' for accessing Search.gov. Please contact ' \
+                                        'search@support.digitalgov.gov if you believe ' \
+                                        'this is in error.'
   logout_on_timeout true
 
   def persisted?

--- a/app/models/user_session.rb
+++ b/app/models/user_session.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class UserSession < Authlogic::Session::Base
-
   INVALID_LOGIN_MESSAGE = <<~MESSAGE.chomp
     These credentials are not recognized as valid for accessing Search.gov.
     Please contact search@support.digitalgov.gov if you believe this is in error.

--- a/config/locales/authlogic.en.yml
+++ b/config/locales/authlogic.en.yml
@@ -1,4 +1,4 @@
 en:
   authlogic:
     error_messages:
-      not_approved: "You are not authorized to access Search.gov. Please contact search@support.digitalgov.gov with any questions."
+      not_approved: "These credentials are not recognized as valid for accessing Search.gov. Please contact search@support.digitalgov.gov if you believe this is in error."

--- a/config/locales/authlogic.en.yml
+++ b/config/locales/authlogic.en.yml
@@ -1,3 +1,5 @@
+# This file is maintained by usasearch-cookbook anything you place here will be written over. 
+
 en:
   authlogic:
     error_messages:

--- a/config/locales/dynamic_form.yml
+++ b/config/locales/dynamic_form.yml
@@ -1,3 +1,5 @@
+# This file is maintained by usasearch-cookbook anything you place here will be written over.
+
 en:
   dynamic_form:
     errors:

--- a/features/user_sessions.feature
+++ b/features/user_sessions.feature
@@ -10,7 +10,7 @@ Feature: User sessions
 
   Scenario: User has trouble logging in
     When I log in with email "not@valid.gov" and password "fail"
-    Then I should see "Login failed due to invalid username and/or password."
+    Then I should see "These credentials are not recognized as valid for accessing Search.gov. Please contact search@support.digitalgov.gov if you believe this is in error."
 
   Scenario: Affiliate admin should be on the site home page upon successful login
     Given I am on the login page
@@ -51,14 +51,14 @@ Feature: User sessions
   Scenario: User is not approved
     When I log in with email "affiliate_manager_with_not_approved_status@fixtures.org" and password "test1234!"
     Then I should be on the user session page
-    And I should see "You are not authorized to access Search.gov. Please contact search@support.digitalgov.gov with any questions."
+    And I should see "These credentials are not recognized as valid for accessing Search.gov. Please contact search@support.digitalgov.gov if you believe this is in error."
 
   Scenario: User is not approved and user's password is more than 90 days old
     Given the following Users exist:
       | contact_name | email            | password  | password_updated_at | approval_status |
       | Jane         | jane@example.com | test1234! | 2015-01-01          | not_approved    |
     When I log in with email "jane@example.com" and password "test1234!"
-    Then I should see "You are not authorized to access Search.gov. Please contact search@support.digitalgov.gov with any questions."
+    Then I should see "These credentials are not recognized as valid for accessing Search.gov. Please contact search@support.digitalgov.gov if you believe this is in error."
     And "jane@example.com" should receive no emails
 
   Scenario: User's password expires during session

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -1,11 +1,16 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-NOT_AUTHORIZED_MESSAGE = 'These credentials are not recognized as valid '\
-                         'for accessing Search.gov. Please contact ' \
-                         'search@support.digitalgov.gov if you believe '\
-                         'this is in error.'.freeze
-RESET_PASSWORD_MESSAGE = 'Instructions to reset your password have been ' \
-                         'emailed to you. Please check your email.'.freeze
+RESET_PASSWORD_MESSAGE  = <<~MESSAGE.chomp
+    Instructions to reset your password have been
+    emailed to you. Please check your email.
+MESSAGE
+
+NOT_AUTHORIZED_MESSAGE = <<~MESSAGE.chomp
+    These credentials are not recognized as valid for accessing Search.gov.
+    Please contact search@support.digitalgov.gov if you believe this is in error.
+MESSAGE
 
 describe PasswordResetsController do
   context 'when unknown token is passed in' do

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -1,6 +1,9 @@
 require 'spec_helper'
 
-NOT_AUTHORIZED_MESSAGE = 'You are not authorized to access Search.gov.'.freeze
+NOT_AUTHORIZED_MESSAGE = 'These credentials are not recognized as valid '\
+                         'for accessing Search.gov. Please contact ' \
+                         'search@support.digitalgov.gov if you believe '\
+                         'this is in error.'.freeze
 RESET_PASSWORD_MESSAGE = 'Instructions to reset your password have been ' \
                          'emailed to you. Please check your email.'.freeze
 

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -2,12 +2,12 @@
 
 require 'spec_helper'
 
-RESET_PASSWORD_MESSAGE  = <<~MESSAGE.chomp
+RESET_PASSWORD_MESSAGE  = <<~MESSAGE.chomp.squish
     Instructions to reset your password have been
     emailed to you. Please check your email.
 MESSAGE
 
-NOT_AUTHORIZED_MESSAGE = <<~MESSAGE.chomp
+NOT_AUTHORIZED_MESSAGE = <<~MESSAGE.chomp.squish
     These credentials are not recognized as valid for accessing Search.gov.
     Please contact search@support.digitalgov.gov if you believe this is in error.
 MESSAGE


### PR DESCRIPTION
Login error message given have to be ambiguous so we updated the login failed and un-approved accounts to have the same message. 