### PR TITLE
Feature/drilldown_content_types

### DIFF
--- a/spec/controllers/sites/click_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/click_drilldowns_controller_spec.rb
@@ -18,7 +18,7 @@ describe Sites::ClickDrilldownsController do
 
       it 'should generate a CSV of various click fields' do
         get :show, site_id: site.id, url:'http://some.gov.url/super_long_so_truncate_at_50/blah.cfm', start_date: '2015-02-01', end_date: '2015-02-05', format: 'csv'
-        expect(response.content_type).to eq("text/csv; charset=utf-8; header=present")
+        expect(response.content_type).to eq("text/csv")
         expect(response.headers["Content-Disposition"]).to eq("attachment;filename=nps.gov_http://some.gov.url/super_long_so_truncate_at_50/b_2015-02-01_2015-02-05.csv")
         expect(response.body).to start_with(Sites::ClickDrilldownsController::HEADER_FIELDS.to_csv)
         expect(response.body).to have_content("2015-02-01,10:23:58,the constitution and the bill of rights,2,/clicked?a=usagov&l=en&q=the+constitution+and+the+bill+of+rights&s=BWEB&t=1422786234&v=web&u=http%3A%2F%2Fwww.archives.gov%2Fexhibits%2Fcharters%2Fbill_of_rights.html&p=2,https://search.usa.gov/search?affiliate=usagov&query=the+constitution+and+the+bill+of+rights,web,BWEB,Other,Chrome,Windows,US,SC,206.53.115.243,\"Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.93 Safari/537.36\"")

--- a/spec/controllers/sites/click_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/click_drilldowns_controller_spec.rb
@@ -18,7 +18,7 @@ describe Sites::ClickDrilldownsController do
 
       it 'should generate a CSV of various click fields' do
         get :show, site_id: site.id, url:'http://some.gov.url/super_long_so_truncate_at_50/blah.cfm', start_date: '2015-02-01', end_date: '2015-02-05', format: 'csv'
-        expect(response.content_type).to eq("text/csv")
+        expect(response.content_type).to eq('text/csv')
         expect(response.headers["Content-Disposition"]).to eq("attachment;filename=nps.gov_http://some.gov.url/super_long_so_truncate_at_50/b_2015-02-01_2015-02-05.csv")
         expect(response.body).to start_with(Sites::ClickDrilldownsController::HEADER_FIELDS.to_csv)
         expect(response.body).to have_content("2015-02-01,10:23:58,the constitution and the bill of rights,2,/clicked?a=usagov&l=en&q=the+constitution+and+the+bill+of+rights&s=BWEB&t=1422786234&v=web&u=http%3A%2F%2Fwww.archives.gov%2Fexhibits%2Fcharters%2Fbill_of_rights.html&p=2,https://search.usa.gov/search?affiliate=usagov&query=the+constitution+and+the+bill+of+rights,web,BWEB,Other,Chrome,Windows,US,SC,206.53.115.243,\"Mozilla/5.0 (Windows NT 6.3; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/40.0.2214.93 Safari/537.36\"")

--- a/spec/controllers/sites/query_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/query_drilldowns_controller_spec.rb
@@ -18,7 +18,7 @@ describe Sites::QueryDrilldownsController do
 
       it 'should generate a CSV of various query fields' do
         get :show, query:'foo bar', start_date: '2015-02-01', end_date: '2015-02-05', format: 'csv', site_id: site.id
-        expect(response.content_type).to eq("text/csv; charset=utf-8; header=present")
+        expect(response.content_type).to eq("text/csv")
         expect(response.headers["Content-Disposition"]).to eq("attachment;filename=nps.gov_foo_bar_2015-02-01_2015-02-05.csv")
         expect(response.body).to start_with(Sites::QueryDrilldownsController::HEADER_FIELDS.to_csv)
         expect(response.body).to have_content("2015-02-01,04:52:14,https://search.usa.gov/search?utf8=%E2%9C%93&affiliate=usagov&query=fashion+psychology,https://search.usa.gov/search?affiliate=usagov&query=fashion,web,BWEB BOOS,Other,IE,Windows 7,US,MO,204.184.232.180,Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko")

--- a/spec/controllers/sites/query_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/query_drilldowns_controller_spec.rb
@@ -18,7 +18,7 @@ describe Sites::QueryDrilldownsController do
 
       it 'should generate a CSV of various query fields' do
         get :show, query:'foo bar', start_date: '2015-02-01', end_date: '2015-02-05', format: 'csv', site_id: site.id
-        expect(response.content_type).to eq("text/csv")
+        expect(response.content_type).to eq('text/csv')
         expect(response.headers["Content-Disposition"]).to eq("attachment;filename=nps.gov_foo_bar_2015-02-01_2015-02-05.csv")
         expect(response.body).to start_with(Sites::QueryDrilldownsController::HEADER_FIELDS.to_csv)
         expect(response.body).to have_content("2015-02-01,04:52:14,https://search.usa.gov/search?utf8=%E2%9C%93&affiliate=usagov&query=fashion+psychology,https://search.usa.gov/search?affiliate=usagov&query=fashion,web,BWEB BOOS,Other,IE,Windows 7,US,MO,204.184.232.180,Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko")


### PR DESCRIPTION
- Update query_drilldown_controller and click_drilldown_controller rspecs to check content type to be just text/csv.  