### PR TITLE
SRCH-714 - Rails 5 upgrade - rspec errors for missing template errors

### DIFF
--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -30,17 +30,15 @@ describe ExampleController do
     Rails.application.reload_routes!
   end
 
-  context "when a request raises an ActionView::MissingTemplate error" do
-    context "when the format for the request is not a valid format" do
-      it "should render a 204" do
-        get :missing_template, :format => "orig"
-        expect(response.code).to eq("204")
-      end
+  context 'when the format for the request is not a valid format' do
+    it 'responds with a 204' do
+      get :missing_template, :format => "orig"
+      expect(response.code).to eq('204')
     end
   end
 
-  describe "#handle_unverified_request" do
-    it "raises an error" do
+  describe '#handle_unverified_request' do
+    it 'raises an error' do
       expect { ExampleController.new.handle_unverified_request }.to raise_error(ActionController::InvalidAuthenticityToken)
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -32,7 +32,7 @@ describe ExampleController do
 
   context 'when the format for the request is not a valid format' do
     it 'responds with a 204' do
-      get :missing_template, :format => "orig"
+      get :missing_template, format: 'orig'
       expect(response.code).to eq('204')
     end
   end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -31,16 +31,10 @@ describe ExampleController do
   end
 
   context "when a request raises an ActionView::MissingTemplate error" do
-    context "when the format for the request is a valid format" do
-      it "should raise an error" do
-        expect { get :missing_template, :format => 'json' }.to raise_error(ActionView::MissingTemplate)
-      end
-    end
-
     context "when the format for the request is not a valid format" do
-      it "should render a 406" do
+      it "should render a 204" do
         get :missing_template, :format => "orig"
-        expect(response.code).to eq("406")
+        expect(response.code).to eq("204")
       end
     end
   end


### PR DESCRIPTION
Before Rails 5, when we forget to add template for an action, we get ActionView::MissingTemplate exception. with a 406 response. Now it returns 204 response and does not return MissingTemplate exception.


