### PR TITLE
SRCH-659 display videos on I14y SERP (#292)

### DIFF
--- a/app/views/searches/i14y.mobile.haml
+++ b/app/views/searches/i14y.mobile.haml
@@ -10,6 +10,7 @@
   = render partial: 'med_topic', locals: { search: @search } if @search.med_topic.present?
   = render partial: 'jobs', locals: { search: @search } if @search.jobs.present?
   = render partial: 'tweets', locals: { search:  @search } if @search.has_tweets?
+  = render partial: 'govbox_video_news_items', locals: { search:  @search, search_params: @search_params } if @search.has_video_news_items?
   = render partial: 'govbox_news_items', locals: { search:  @search } if @search.has_fresh_news_items?
 
   - if @search.results.present?

--- a/features/searchgov_search.feature
+++ b/features/searchgov_search.feature
@@ -5,8 +5,8 @@ Feature: SearchGov search
 
   Background:
     Given the following SearchGov Affiliates exist:
-      | display_name | name | contact_email | contact_name | header         | domains                     |
-      | EPA          | epa  | aff@epa.gov   | Jane Bar     | EPA.gov Header | www.epa.gov,archive.epa.gov |
+      | display_name | name | contact_email | contact_name | header         | domains                     | youtube_handles |
+      | EPA          | epa  | aff@epa.gov   | Jane Bar     | EPA.gov Header | www.epa.gov,archive.epa.gov | usgovernment    |
 
   Scenario: Everything search
     When I am on epa's search page
@@ -59,3 +59,14 @@ Feature: SearchGov search
     When I am on epa's search page with site limited to "www.epa.gov/news"
     When I search for "carbon emissions"
     Then I should see "We're including results for carbon emissions from www.epa.gov/news only."
+
+  Scenario: Video news search
+    Given affiliate "epa" has the following RSS feeds:
+      | name   | url                        | is_navigable | is_managed |
+      | Videos | http://www.epa.gov/videos/ | true         | true       |
+    And there are 20 video news items for "usgovernment_channel_id"
+
+    When I am on epa's search page
+    And I search for "video"
+    Then I should see exactly "1" video govbox search result
+    And I should see "More videos about video"

--- a/features/vcr_cassettes/SearchGov_search/Video_news_search.yml
+++ b/features/vcr_cassettes/SearchGov_search/Video_news_search.yml
@@ -1,0 +1,42 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:8081/api/v1/collections/search?handles=searchgov&language=en&offset=0&query=video%20site:www.epa.gov%20site:archive.epa.gov&size=20
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - USASearch
+      Authorization:
+      - Basic dGVzdDp0ZXN0cHdk
+      Expect:
+      - ''
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Content-Type:
+      - application/json
+      Content-Length:
+      - '49'
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 28af568f-ec46-4b14-9a1a-b145832be1a0
+      X-Runtime:
+      - '2.443739'
+      Vary:
+      - Origin
+      Connection:
+      - keep-alive
+      Server:
+      - thin
+    body:
+      encoding: UTF-8
+      string: '{"developer_message":"Unauthorized","status":400}'
+    http_version: 
+  recorded_at: Wed, 19 Jun 2019 01:09:40 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
These changes were originally approved per https://github.com/GSA/search-gov/pull/292. We pulled them out per https://github.com/GSA/search-gov/pull/307, so this puts 'em back in.