### PR TITLE
SRCH-700 update sitemaps gem to 0.2.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'tweetstream', '~> 2.6.1' # no longer maintained?
 gem 'twitter', '~> 5.5'
 gem 'flickraw', '~> 0.9.9'
 gem 'active_scaffold', '~> 3.5.0'
-gem 'active_scaffold_export', github: 'naaano/active_scaffold_export'
+gem 'active_scaffold_export', git: 'https://github.com/naaano/active_scaffold_export'
 gem 'us_states_select', '~> 1.2.0', :git => 'https://github.com/jeremydurham/us-state-select-plugin.git', :require => 'us_states_select'
 gem 'mobile-fu', '~> 1.4.0'
 gem "recaptcha", '~> 4.6.3', :require => "recaptcha/rails"
@@ -85,9 +85,7 @@ gem 'medusa', git: 'https://github.com/MothOnMars/medusa', branch: 'clean_urls'
 # Robotex is required by Medusa. Specifying fork until https://github.com/chriskite/robotex/issues/4
 # is resolved
 gem 'robotex', git: 'https://github.com/MothOnMars/robotex'
-# Using custom branch until https://github.com/lygaret/sitemaps/pull/4 is merged,
-# and https://github.com/lygaret/sitemaps/issues/5 and https://github.com/lygaret/sitemaps/issues/6 are resolved
-gem 'sitemaps_parser', require: 'sitemaps', git: 'https://github.com/MothOnMars/sitemaps', branch: 'discovery_fixes'
+gem 'sitemaps_parser', '~> 0.2', require: 'sitemaps'
 gem 'counter_culture', '~> 2.0.0'
 gem 'aasm', '~> 4.12'
 gem 'active_scheduler', '~> 0.5.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,11 +1,4 @@
 GIT
-  remote: git://github.com/naaano/active_scaffold_export.git
-  revision: 879ceb549b871ebb597ae5339a2e67498beb70d1
-  specs:
-    active_scaffold_export (3.3.2)
-      active_scaffold (>= 3.3.0.rc)
-
-GIT
   remote: https://github.com/GSA/jquery-rails
   revision: c0c56208f57746a4bc63431d5e771cea4486efca
   ref: c0c56208f57746a4bc63431d5e771cea4486efca
@@ -61,14 +54,6 @@ GIT
       open_uri_redirections (~> 0.2.1)
 
 GIT
-  remote: https://github.com/MothOnMars/sitemaps
-  revision: f9fe5a1f80683eb1969e2849a2a3f81789a3a00a
-  branch: discovery_fixes
-  specs:
-    sitemaps_parser (0.2.2)
-      activesupport (~> 4)
-
-GIT
   remote: https://github.com/gsa/font-awesome-grunticon-rails
   revision: 8ad9734a65f7e2d2de934bebe4ee7b460734f96e
   ref: 8ad9734a65f7e2d2de934bebe4ee7b460734f96e
@@ -82,6 +67,13 @@ GIT
   specs:
     us_states_select (1.2.0)
       rails (>= 1.2)
+
+GIT
+  remote: https://github.com/naaano/active_scaffold_export
+  revision: 879ceb549b871ebb597ae5339a2e67498beb70d1
+  specs:
+    active_scaffold_export (3.3.2)
+      active_scaffold (>= 3.3.0.rc)
 
 GEM
   remote: https://rubygems.org/
@@ -646,6 +638,8 @@ GEM
       rack (~> 1.5)
       rack-protection (~> 1.4)
       tilt (>= 1.3, < 3)
+    sitemaps_parser (0.2.3)
+      activesupport (>= 4, < 7)
     spring (2.0.2)
       activesupport (>= 4.2)
     sprockets (3.7.2)
@@ -851,7 +845,7 @@ DEPENDENCIES
   shoulda-matchers (~> 3.1.2)
   simplecov (~> 0.15.1)
   sitelink_generator!
-  sitemaps_parser!
+  sitemaps_parser (~> 0.2)
   spring (~> 2.0)
   test-unit (~> 3.2.7)
   test_after_commit (~> 1.1.0)


### PR DESCRIPTION
This PR:
- upgrades the sitemaps gem to the latest version, which is compatible with Rails 5
- fixes the insecure source of the `active_scaffold_export` gem

The changes in this PR were previously approved per https://github.com/GSA/search-gov/pull/298.