### PR TITLE
SRCH-723 - rails 5 upgrade search_helper_spec returns errors

### DIFF
--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -13,3 +13,13 @@
 # ActiveSupport::Inflector.inflections(:en) do |inflect|
 #   inflect.acronym 'RESTful'
 # end
+
+ActiveSupport::Inflector.inflections(:es) do |inflect|
+  inflect.plural /([^djlnrs])([A-Z]|_|$)/, '\1s\2'
+  inflect.plural /([djlnrs])([A-Z]|_|$)/, '\1es\2'
+  inflect.plural /(.*)z([A-Z]|_|$)$/i, '\1ces\2'
+
+  inflect.singular /([^djlnrs])s([A-Z]|_|$)/, '\1\2'
+  inflect.singular /([djlnrs])es([A-Z]|_|$)/, '\1\2'
+  inflect.singular /(.*)ces([A-Z]|_|$)$/i, '\1z\2'
+end

--- a/spec/config/initializers/inflections_spec.rb
+++ b/spec/config/initializers/inflections_spec.rb
@@ -1,7 +1,7 @@
 # coding: utf-8
 require 'spec_helper'
 
-describe "Inflections" do
+describe 'Inflections' do
   context 'when locale = :es' do
     context 'if the spanish word is being pluralized' do
       it 'adds "es" if a noun ends in a consonant' do

--- a/spec/config/initializers/inflections_spec.rb
+++ b/spec/config/initializers/inflections_spec.rb
@@ -1,0 +1,34 @@
+# coding: utf-8
+require 'spec_helper'
+
+describe "Inflections" do
+  context 'when locale = :es' do
+    context 'if the spanish word is being pluralized' do
+      it 'adds "es" if a noun ends in a consonant' do
+        expect("flor".pluralize(2, :es)).to eq("flores")
+      end
+
+      it 'adds "s" if a noun ends in a vowel' do
+        expect("libro".pluralize(2, :es)).to eq("libros")
+      end
+
+      it 'changes the "z" to "c" before adding "es" if a noun ends in a "z"' do
+        expect("tapiz".pluralize(2, :es)).to eq("tapices")
+      end
+    end
+
+    context 'if the spanish word is being singulularized' do
+      it 'removes "es" spanish words if a noun ends in a consonant' do
+        expect("flores".singularize( :es)).to eq("flor")
+      end
+
+      it 'removes "s" if a noun ends in a vowel' do
+        expect("libros".singularize(:es)).to eq("libro")
+      end
+
+      it 'changes the "c" to "z" before removing "es" if a noun ends in a "z"' do
+        expect("tapices".singularize(:es)).to eq("tapiz")
+      end
+    end
+  end
+end

--- a/spec/config/initializers/inflections_spec.rb
+++ b/spec/config/initializers/inflections_spec.rb
@@ -5,29 +5,29 @@ describe 'Inflections' do
   context 'when locale = :es' do
     context 'if the spanish word is being pluralized' do
       it 'adds "es" if a noun ends in a consonant' do
-        expect("flor".pluralize(2, :es)).to eq("flores")
+        expect('flor'.pluralize(2, :es)).to eq('flores')
       end
 
       it 'adds "s" if a noun ends in a vowel' do
-        expect("libro".pluralize(2, :es)).to eq("libros")
+        expect('libro'.pluralize(2, :es)).to eq('libros')
       end
 
       it 'changes the "z" to "c" before adding "es" if a noun ends in a "z"' do
-        expect("tapiz".pluralize(2, :es)).to eq("tapices")
+        expect('tapiz'.pluralize(2, :es)).to eq('tapices')
       end
     end
 
     context 'if the spanish word is being singulularized' do
-      it 'removes "es" spanish words if a noun ends in a consonant' do
-        expect("flores".singularize( :es)).to eq("flor")
+      it 'removes es" spanish words if a noun ends in a consonant' do
+        expect('flores'.singularize( :es)).to eq('flor')
       end
 
       it 'removes "s" if a noun ends in a vowel' do
-        expect("libros".singularize(:es)).to eq("libro")
+        expect('libros'.singularize(:es)).to eq('libro')
       end
 
       it 'changes the "c" to "z" before removing "es" if a noun ends in a "z"' do
-        expect("tapices".singularize(:es)).to eq("tapiz")
+        expect('tapices'.singularize(:es)).to eq('tapiz')
       end
     end
   end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -266,11 +266,7 @@ Veterans of the Vietnam War, families, friends, distinguished guests. I know it 
         search = double(Search, :total => 2000, :page => 5, :first_page? => false)
         expect(make_summary_p(search)).to eq('<p>Página 5 de aproximadamente 2,000 resultados</p>')
       end
-
-      it "should pluralize spanish words for spanish language" do
-        expect("flor".pluralize(2, :es)).to eq("flores")
-      end
-
+      
       after(:all) { I18n.locale = I18n.default_locale }
     end
   end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -267,6 +267,10 @@ Veterans of the Vietnam War, families, friends, distinguished guests. I know it 
         expect(make_summary_p(search)).to eq('<p>Página 5 de aproximadamente 2,000 resultados</p>')
       end
 
+      it "should pluralize spanish words for spanish language" do
+        expect("flor".pluralize(2, :es)).to eq("flores")
+      end
+
       after(:all) { I18n.locale = I18n.default_locale }
     end
   end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -266,7 +266,6 @@ Veterans of the Vietnam War, families, friends, distinguished guests. I know it 
         search = double(Search, :total => 2000, :page => 5, :first_page? => false)
         expect(make_summary_p(search)).to eq('<p>Página 5 de aproximadamente 2,000 resultados</p>')
       end
-      
       after(:all) { I18n.locale = I18n.default_locale }
     end
   end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -257,12 +257,12 @@ Veterans of the Vietnam War, families, friends, distinguished guests. I know it 
         expect(make_summary_p(search)).to eq('<p>1 resultado</p>')
       end
 
-      xit "should return 'Página %{page} de %{total} resultados' when total is 2..99 and page > 1" do
+      it "should return 'Página %{page} de %{total} resultados' when total is 2..99 and page > 1" do
         search = double(Search, :total => 80, :page => 5, :first_page? => false)
         expect(make_summary_p(search)).to eq('<p>Página 5 de 80 resultados</p>')
       end
 
-      xit "should return 'Página %{page} de aproximadamente %{total} resultados' when total >= 100 and page > 1" do
+      it "should return 'Página %{page} de aproximadamente %{total} resultados' when total >= 100 and page > 1" do
         search = double(Search, :total => 2000, :page => 5, :first_page? => false)
         expect(make_summary_p(search)).to eq('<p>Página 5 de aproximadamente 2,000 resultados</p>')
       end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -266,6 +266,7 @@ Veterans of the Vietnam War, families, friends, distinguished guests. I know it 
         search = double(Search, :total => 2000, :page => 5, :first_page? => false)
         expect(make_summary_p(search)).to eq('<p>Página 5 de aproximadamente 2,000 resultados</p>')
       end
+
       after(:all) { I18n.locale = I18n.default_locale }
     end
   end


### PR DESCRIPTION
SRCH-723 - pluralize was not working for the Spanish words. 