### PR TITLE
SRCH-724 - news_search_spec errors

### DIFF
--- a/spec/models/news_search_spec.rb
+++ b/spec/models/news_search_spec.rb
@@ -18,9 +18,7 @@ describe NewsSearch do
       { affiliate: affiliate, channel: feed.id }
     end
 
-    pending('does not work for rails 5') do
-      it_behaves_like 'an initialized filterable search'
-    end
+    it_behaves_like 'an initialized filterable search'
 
     context 'when options does not include sort_by' do
       subject(:search) { described_class.new filterable_search_options }

--- a/spec/support/filterable_search_behavior.rb
+++ b/spec/support/filterable_search_behavior.rb
@@ -6,7 +6,7 @@ shared_examples 'an initialized filterable search' do
                                   until_date: '11/30/2014')
     end
     let(:expected_since) { DateTime.parse('2012-08-20T00:00:00Z') }
-    let(:expected_until) { DateTime.parse('2014-11-30T23:59:59Z') }
+    let(:expected_until) { DateTime.parse('2014-11-30T23:59:59.999999999Z') }
 
     its(:since) { should eq(expected_since) }
     its(:until) { should eq(expected_until) }
@@ -19,7 +19,7 @@ shared_examples 'an initialized filterable search' do
                                   until_date: '11/30/2014')
     end
     let(:expected_since) { DateTime.parse('2013-11-30T00:00:00Z') }
-    let(:expected_until) { DateTime.parse('2014-11-30T23:59:59Z') }
+    let(:expected_until) { DateTime.parse('2014-11-30T23:59:59.999999999.Z') }
 
     its(:since) { should eq(expected_since) }
     its(:until) { should eq(expected_until) }
@@ -56,8 +56,9 @@ shared_examples 'an initialized filterable search' do
                             merge(since_date: '12/25/2014',
                                   until_date: '10/18/2012')
     end
+
     let(:expected_since) { DateTime.parse('2012-10-18T00:00:00Z') }
-    let(:expected_until) { DateTime.parse('2014-12-25T23:59:59Z') }
+    let(:expected_until) { DateTime.parse('2014-12-25T23:59:59.999999999Z') }
 
     its(:since) { should eq(expected_since) }
     its(:until) { should eq(expected_until) }
@@ -74,7 +75,7 @@ shared_examples 'an initialized filterable search' do
       end
 
       let(:expected_since) { DateTime.parse('2012-10-18T00:00:00Z') }
-      let(:expected_until) { DateTime.parse('2014-12-25T23:59:59Z') }
+      let(:expected_until) { DateTime.parse('2014-12-25T23:59:59.999999999Z') }
 
       its(:since) { should eq(expected_since) }
       its(:until) { should eq(expected_until) }
@@ -137,7 +138,7 @@ shared_examples 'a runnable filterable search' do
     it 'searches for results between since_date and start_date' do
       expect(ElasticBlended).to receive(:search_for).
         with(hash_including(since: DateTime.parse('2012-08-20T00:00:00Z'),
-                            until: DateTime.parse('2014-11-30T23:59:59Z'))).
+                            until: DateTime.parse('2014-11-30T23:59:59.999999999Z'))).
         and_return(double(ElasticBlendedResults,
                         results: [],
                         suggestion: nil,


### PR DESCRIPTION
Rails 5 handles DateTime with better precision. 
You can see more info about it here https://blog.bigbinary.com/2016/02/23/rails-5-handles-datetime-with-better-precision.html.

The expected result should be 2014-11-30T23:59:59.999999999Z  instead of it being rounded off to 0