### PR TITLE
SRCH-725-fix i14y_search_spec errors

### DIFF
--- a/spec/models/i14y_search_spec.rb
+++ b/spec/models/i14y_search_spec.rb
@@ -69,11 +69,11 @@ describe I14ySearch do
                                        per_page: 20,
                                        query: 'marketplase') }
 
-    xit 'searches I14y with the appropriate params' do
+    it 'searches I14y with the appropriate params' do
       expect(I14yCollections).to receive(:search).
         with(hash_including(sort_by_date: 1, 
                             min_timestamp: DateTime.parse('07/28/2015').beginning_of_day,
-                            max_timestamp: DateTime.parse('09/28/2015').end_of_day))
+                            max_timestamp: DateTime.parse('09/28/2015T23:59:59.999999999Z')))
       i14y_search.run
     end
   end


### PR DESCRIPTION
Same issue as SRCH-724.  The .end_of_day does not return the milliseconds that the results now return so this test fails. 