### PR TITLE
SRCH-726 - blended_search_spec errors

### DIFF
--- a/spec/models/blended_search_spec.rb
+++ b/spec/models/blended_search_spec.rb
@@ -14,9 +14,7 @@ describe BlendedSearch do
   end
 
   describe '#initialize' do
-    pending('Does not work with Rails 5') do
-      it_behaves_like 'an initialized filterable search'
-    end
+    it_behaves_like 'an initialized filterable search'
 
     context 'when options does not include sort_by' do
       subject(:search) { described_class.new filterable_search_options }
@@ -26,9 +24,7 @@ describe BlendedSearch do
   end
 
   describe '#run' do
-    pending('Does not work with Rails 5') do
-      it_behaves_like 'a runnable filterable search'
-    end
+    it_behaves_like 'a runnable filterable search'
 
     context 'when search engine response contains spelling suggestion' do
       subject(:search) do


### PR DESCRIPTION
No changes were needed except removing the pending code to comment out the tests. The problem has been resolved in:

SRCH-724 - news_search_spec.
Rails 5 handles DateTime with better precision.
You can see more info about it here https://blog.bigbinary.com/2016/02/23/rails-5-handles-datetime-with-better-precision.html.

