### PR TITLE
SRCH-728 - rspec error - user_spec.rb

### DIFF
--- a/app/models/language.rb
+++ b/app/models/language.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class Language < ActiveRecord::Base
+  validates :code, :name, presence: true
+
   validates_uniqueness_of :code, case_sensitive: false
 
   has_many :affiliates, foreign_key: :locale, primary_key: :code, inverse_of: :language

--- a/spec/lib/tasks/user_spec.rb
+++ b/spec/lib/tasks/user_spec.rb
@@ -36,7 +36,7 @@ describe 'User rake tasks' do
       @rake[task_name].invoke
     end
 
-    xit 'logs the change' do
+    it 'logs the change' do
       expected_message = <<~MESSAGE.squish
         User #{user.id}, affiliate_manager_with_no_affiliates@fixtures.org,
         is no longer associated with any sites,


### PR DESCRIPTION
Rspec tests are now passing. This test was refactored during 
SRCH-688 - set users unapproved for inactive accounts
SRCH-726 - Bug/account approval

Just removing the pending code in the test. 