### PR TITLE
SRCH-634 - Add default log_level to info

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -35,7 +35,8 @@ Rails.application.configure do
 
   # See everything in the log (default is :info)
   # config.log_level = :debug
-
+  config.log_level = :info
+  
   # Use a different logger for distributed setups
   # config.logger = ActiveSupport::TaggedLogging.new(SyslogLogger.new)
 


### PR DESCRIPTION
SRCH-634 - Currently, the default value for `log_level` is `:info` for the production environment and `:debug` in all other environments. In Rails 5 the default value will be unified to `:debug` across all environments. To preserve the current setting, add the following line to your `production.rb`:

config.log_level = :info

