### PR TITLE
SRCH-721 update superfresh_urls_bulk_upload_controller_spec.rb

### DIFF
--- a/app/controllers/admin/superfresh_urls_bulk_upload_controller.rb
+++ b/app/controllers/admin/superfresh_urls_bulk_upload_controller.rb
@@ -15,8 +15,8 @@ class Admin::SuperfreshUrlsBulkUploadController < Admin::AdminController
         else
           flash[:error] = "No urls uploaded; please check your file and try again."
         end
-      rescue Exception => e
-        flash[:error] = e.message
+      rescue StandardError => error
+        flash[:error] = error.message
       end
     else
       flash[:error] = "Invalid file format; please upload a plain text file (.txt)."

--- a/spec/fixtures/txt/superfresh_urls.txt
+++ b/spec/fixtures/txt/superfresh_urls.txt
@@ -1,0 +1,5 @@
+http://aff.gov/1.html
+http://aff.gov/2.html
+http://aff.gov/3.html
+http://aff.gov/4.html
+http://aff.gov/5.html


### PR DESCRIPTION
This PR updates the `superfresh_urls_bulk_upload_controller_spec` to work with Rails 5. It also tweaks the controller code slightly to resolve a couple of Rubocop errors, including rescuing `Exception`.