### PR TITLE
SRCH-643 - Fix deprecation warning for models using activescaffold

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -166,54 +166,52 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :affiliates do as_routes end
-    resources :affiliate_notes do as_routes end
-    resources :affiliate_templates do as_routes end
-    resources :users do as_routes end
-    resources :sayt_filters do as_routes end
-    resources :sayt_suggestions do as_routes end
-    resources :misspellings do as_routes end
-    resources :affiliate_boosted_contents do as_routes end
-    resources :document_collections do as_routes end
-    resources :url_prefixes do as_routes end
-    resources :catalog_prefixes do as_routes end
-    resources :site_feed_urls do as_routes end
-    resources :superfresh_urls do as_routes end
+    resources :affiliate_notes, concerns: :active_scaffold
+    resources :affiliate_templates, concerns: :active_scaffold
+    resources :users, concerns: :active_scaffold
+    resources :sayt_filters, concerns: :active_scaffold
+    resources :sayt_suggestions, concerns: :active_scaffold
+    resources :misspellings, concerns: :active_scaffold
+    resources :affiliate_boosted_contents, concerns: :active_scaffold
+    resources :document_collections, concerns: :active_scaffold
+    resources :url_prefixes, concerns: :active_scaffold
+    resources :catalog_prefixes, concerns: :active_scaffold
+    resources :site_feed_urls, concerns: :active_scaffold
+    resources :superfresh_urls, concerns: :active_scaffold
     resources :superfresh_urls_bulk_upload, :only => :index do
       collection do
         post :upload
       end
     end
-    resources :agencies do as_routes end
-    resources :agency_queries do as_routes end
-    resources :agency_organization_codes do as_routes end
-    resources :federal_register_agencies do
+    resources :agencies, concerns: :active_scaffold
+    resources :agency_queries, concerns: :active_scaffold
+    resources :agency_organization_codes, concerns: :active_scaffold
+    resources :federal_register_agencies, concerns: :active_scaffold do
       collection { get 'reimport' }
-      as_routes
     end
-    resources :federal_register_documents do as_routes end
-    resources :outbound_rate_limits do as_routes end
-    resources :search_modules do as_routes end
-    resources :excluded_domains do as_routes end
-    resources :affiliate_scopes do as_routes end
-    resources :site_domains do as_routes end
+    resources :federal_register_documents, concerns: :active_scaffold
+    resources :outbound_rate_limits, concerns: :active_scaffold
+    resources :search_modules, concerns: :active_scaffold
+    resources :excluded_domains, concerns: :active_scaffold
+    resources :affiliate_scopes, concerns: :active_scaffold
+    resources :site_domains, concerns: :active_scaffold
     resources :features do as_routes end
-    resources :affiliate_feature_additions do as_routes end
-    resources :help_links do as_routes end
+    resources :affiliate_feature_additions, concerns: :active_scaffold
+    resources :help_links, concerns: :active_scaffold
     resources :compare_search_results, :only => :index
-    resources :bing_urls do as_routes end
-    resources :statuses do as_routes end
-    resources :system_alerts do as_routes end
-    resources :tags do as_routes end
+    resources :bing_urls, concerns: :active_scaffold
+    resources :statuses, concerns: :active_scaffold
+    resources :system_alerts, concerns: :active_scaffold
+    resources :tags, concerns: :active_scaffold
     resources :trending_urls, :only => :index
-    resources :news_items do as_routes end
-    resources :suggestion_blocks do as_routes end
-    resources :rss_feeds do as_routes end
-    resources :rss_feed_urls do
+    resources :news_items, concerns: :active_scaffold
+    resources :suggestion_blocks, concerns: :active_scaffold
+    resources :rss_feeds, concerns: :active_scaffold
+    resources :rss_feed_urls, concerns: :active_scaffold do
       member do
         get 'destroy_news_items'
         get 'news_items'
       end
-      as_routes
     end
     resource :search_module_ctrs, only: [:show]
     resource :site_ctrs, only: [:show]
@@ -223,25 +221,22 @@ Rails.application.routes.draw do
       collection { get 'reload_hints' }
       as_routes
     end
-    resources :i14y_drawers do as_routes end
-    resources :languages do as_routes end
-    resources :routed_queries do as_routes end
-    resources :routed_query_keywords do as_routes end
-    resources :watchers do as_routes end
-    resources :searchgov_domains do
-      resources :searchgov_urls do
+    resources :i14y_drawers, concerns: :active_scaffold
+    resources :languages, concerns: :active_scaffold
+    resources :routed_queries, concerns: :active_scaffold
+    resources :routed_query_keywords, concerns: :active_scaffold
+    resources :watchers, concerns: :active_scaffold
+    resources :searchgov_domains, concerns: :active_scaffold do
+      resources :searchgov_urls, concerns: :active_scaffold do
         member do
           post 'fetch'
         end
-        as_routes
       end
-      resources :sitemaps do
+      resources :sitemaps, concerns: :active_scaffold do
         member do
           post 'fetch'
         end
-        as_routes
       end
-      as_routes
     end
   end
 

--- a/spec/controllers/image_searches_controller_spec.rb
+++ b/spec/controllers/image_searches_controller_spec.rb
@@ -5,7 +5,7 @@ describe ImageSearchesController do
   let(:affiliate) { affiliates(:usagov_affiliate) }
 
   describe "#index" do
-    context "when searching on legacy affiliate and the query is present" do
+    context 'when searching on legacy affiliate and the query is present' do
       let(:affiliate) { affiliates(:basic_affiliate) }
       let(:query) { '<script>thunder & lightning</script>' }
       let(:image_search) { double(LegacyImageSearch, :query => 'thunder & lightning', :modules => [], :diagnostics => {}) }


### PR DESCRIPTION
SRCH-643 - In routs.rb, use concerns: :active_scaffold in resources instead of as_routes, or concerns :active_scaffold in resources block if want to disable association routes or restrict routes with only or except options