### PR TITLE
Feature/test http request methods

### DIFF
--- a/spec/controllers/admin/affiliates_controller_spec.rb
+++ b/spec/controllers/admin/affiliates_controller_spec.rb
@@ -213,7 +213,7 @@ describe Admin::AffiliatesController do
       end
 
       describe 'exports file' do
-        before { post :export, format: :csv }
+        before { post :export, params: { format: :csv } }
 
         it { is_expected.to respond_with :success }
       end

--- a/spec/controllers/admin/affiliates_controller_spec.rb
+++ b/spec/controllers/admin/affiliates_controller_spec.rb
@@ -32,7 +32,7 @@ describe Admin::AffiliatesController do
       end
 
       it "should redirect to the affiliate analytics page for the affiliate id passed" do
-        get :analytics, :id => @affiliate.id
+        get :analytics, params: { id: @affiliate.id }
         expect(response).to redirect_to new_site_queries_path(@affiliate)
       end
     end
@@ -45,8 +45,8 @@ describe Admin::AffiliatesController do
 
       before do
         activate_authlogic
-        UserSession.create(users("affiliate_admin"))
-        get :edit, :id => affiliate.id
+        UserSession.create(users('affiliate_admin'))
+        get :edit, params: { id: affiliate.id }
       end
 
       it { is_expected.to respond_with :success }

--- a/spec/controllers/admin/query_ctrs_controller_spec.rb
+++ b/spec/controllers/admin/query_ctrs_controller_spec.rb
@@ -15,16 +15,16 @@ describe Admin::QueryCtrsController do
 
     context "when not logged in" do
       it "should redirect to the home page" do
-        get :show, module_tag: 'BOOS', site_name: 'usagov'
+        get :show, params: { module_tag: 'BOOS', site_name: 'usagov' }
         expect(response).to redirect_to login_path
       end
     end
 
-    context "when logged in as an admin" do
+    context 'when logged in as an admin' do
       before do
-        @user = users("affiliate_admin")
+        @user = users('affiliate_admin')
         UserSession.create(@user)
-        get :show, module_tag: 'BOOS', site_name: 'usagov'
+        get :show, params: { module_tag: 'BOOS', site_name: 'usagov' }
       end
 
       it "should allow the admin to see query CTRs for some search module on a given site" do

--- a/spec/controllers/admin/rss_feed_urls_controller_spec.rb
+++ b/spec/controllers/admin/rss_feed_urls_controller_spec.rb
@@ -9,7 +9,7 @@ describe Admin::RssFeedUrlsController do
         activate_authlogic
         UserSession.create(users('affiliate_admin'))
         @rss_feed_url = rss_feed_urls(:white_house_blog_url)
-        get :news_items, id: @rss_feed_url.id
+        get :news_items, params: { id: @rss_feed_url.id }
       end
 
       it { is_expected.to redirect_to admin_news_items_path(rss_feed_url_id: @rss_feed_url.id) }
@@ -29,7 +29,7 @@ describe Admin::RssFeedUrlsController do
         expect(RssFeedUrl).to receive(:find).with('100').and_return(rss_feed_url)
         expect(rss_feed_url).to receive(:enqueue_destroy_news_items).with(:high)
 
-        get :destroy_news_items, id: '100', all: 'true'
+        get :destroy_news_items, params: { id: '100', all: 'true' }
         expect(response.body).to match(/to delete #{rss_feed_url.url} news items./)
       end
     end
@@ -39,7 +39,7 @@ describe Admin::RssFeedUrlsController do
         expect(RssFeedUrl).to receive(:find).with('100').and_return(rss_feed_url)
         expect(rss_feed_url).to receive(:enqueue_destroy_news_items_with_404).with(:high)
 
-        get :destroy_news_items, id: '100'
+        get :destroy_news_items, params: { id: '100' }
         expect(response.body).to match(/to delete #{rss_feed_url.url} news items with status code 404./)
       end
     end

--- a/spec/controllers/admin/searchgov_urls_controller_spec.rb
+++ b/spec/controllers/admin/searchgov_urls_controller_spec.rb
@@ -10,7 +10,7 @@ describe Admin::SearchgovUrlsController do
   include_context 'super admin logged in' do
     describe '#fetch' do
       it 'enqueues a searchgov_url_fetcher_job to the searchgov queue' do
-        expect{ post :fetch, params }.
+        expect{ post :fetch, params: params }.
           to have_enqueued_job(SearchgovUrlFetcherJob).on_queue("searchgov").
           with(searchgov_url: searchgov_url)
       end

--- a/spec/controllers/admin/site_ctrs_controller_spec.rb
+++ b/spec/controllers/admin/site_ctrs_controller_spec.rb
@@ -14,7 +14,7 @@ describe Admin::SiteCtrsController do
 
     context "when not logged in" do
       it "should redirect to the home page" do
-        get :show, module_tag: 'BOOS'
+        get :show, params: { module_tag: 'BOOS' }
         expect(response).to redirect_to login_path
       end
     end
@@ -23,7 +23,7 @@ describe Admin::SiteCtrsController do
       before do
         @user = users("affiliate_admin")
         UserSession.create(@user)
-        get :show, module_tag: 'BOOS'
+        get :show, params: { module_tag: 'BOOS' }
       end
 
       it "should allow the admin to see site CTRs for some search module" do

--- a/spec/controllers/api/v1/agencies_controller_spec.rb
+++ b/spec/controllers/api/v1/agencies_controller_spec.rb
@@ -4,28 +4,36 @@ describe Api::V1::AgenciesController do
 
   describe "#search" do
 
-    context "when results are available" do
+    context 'when results are available' do
       before do
-        @agency = Agency.create!(name: "National Park Service", abbreviation: "NPS")
-        AgencyOrganizationCode.create!(organization_code: "NP00", agency: @agency)
-        AgencyOrganizationCode.create!(organization_code: "NP01", agency: @agency)
+        @agency = Agency.
+          create!(name: 'National Park Service', abbreviation: 'NPS')
+        AgencyOrganizationCode.create!(organization_code: 'NP00', agency: @agency)
+        AgencyOrganizationCode.create!(organization_code: 'NP01', agency: @agency)
       end
 
-      it "should return valid JSON with just the first organization code" do
-        get :search, :query => 'the nps', :format => 'json'
+      it 'should return valid JSON with just the first organization code' do
+        get :search,
+            params: {
+              query: 'the nps'
+            },
+            format: 'json'
         expect(response).to be_success
         expect(response.body).to eq({name: @agency.name, abbreviation: @agency.abbreviation,
                                  organization_code: @agency.agency_organization_codes.first.organization_code }.to_json)
       end
     end
 
-    context "when search returns nil or raises an exception" do
-      it "should return error string" do
-        get :search, :query => 'error', :format => 'json'
+    context 'when search returns nil or raises an exception' do
+      it 'should return error string' do
+        get :search,
+            params: {
+              query: 'error',
+              format: 'json'
+            }
         expect(response).not_to be_success
         expect(response.body).to match(/No matching agency could be found./)
       end
     end
   end
-
 end

--- a/spec/controllers/api/v2/agencies_controller_spec.rb
+++ b/spec/controllers/api/v2/agencies_controller_spec.rb
@@ -20,7 +20,7 @@ describe Api::V2::AgenciesController do
 
     context "when search returns nil or raises an exception" do
       it "should return error string" do
-        get :search, params: { query: 'error', format: 'json' }
+        get :search, params: { query: 'error' }, format: 'json'
         expect(response).not_to be_success
         expect(response.body).to match(/No matching agency could be found./)
       end

--- a/spec/controllers/api/v2/agencies_controller_spec.rb
+++ b/spec/controllers/api/v2/agencies_controller_spec.rb
@@ -11,7 +11,7 @@ describe Api::V2::AgenciesController do
       end
 
       it "should return valid JSON with the organization codes array in alpha order" do
-        get :search, params { query: 'the nps', format: 'json' }
+        get :search, params: { query: 'the nps' }, format: 'json'
         expect(response).to be_success
         expect(response.body).to eq({name: @agency.name, abbreviation: @agency.abbreviation,
                                  organization_codes: @agency.agency_organization_codes.collect(&:organization_code).sort }.to_json)

--- a/spec/controllers/api/v2/agencies_controller_spec.rb
+++ b/spec/controllers/api/v2/agencies_controller_spec.rb
@@ -11,7 +11,7 @@ describe Api::V2::AgenciesController do
       end
 
       it "should return valid JSON with the organization codes array in alpha order" do
-        get :search, :query => 'the nps', :format => 'json'
+        get :search, params { query: 'the nps', format: 'json' }
         expect(response).to be_success
         expect(response.body).to eq({name: @agency.name, abbreviation: @agency.abbreviation,
                                  organization_codes: @agency.agency_organization_codes.collect(&:organization_code).sort }.to_json)
@@ -20,7 +20,7 @@ describe Api::V2::AgenciesController do
 
     context "when search returns nil or raises an exception" do
       it "should return error string" do
-        get :search, :query => 'error', :format => 'json'
+        get :search, params: { query: 'error', format: 'json' }
         expect(response).not_to be_success
         expect(response.body).to match(/No matching agency could be found./)
       end

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -38,7 +38,7 @@ describe Api::V2::SearchesController do
                                                  hash_including('query'),
                                                  be_a_kind_of(ActionDispatch::Request))
 
-      get :blended, search_params
+      get :blended, params: search_params
     end
 
     it { is_expected.to respond_with :success }
@@ -50,7 +50,7 @@ describe Api::V2::SearchesController do
 
   describe '#azure' do
     context 'when the search options are not valid' do
-      before { get :azure, search_params.except(:api_key) }
+      before { get :azure, params: search_params.except(:api_key) }
 
       it { is_expected.to respond_with :bad_request }
 
@@ -73,7 +73,9 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :azure, search_params.merge({ access_key: 'usagov_key' })
+        get :azure,
+            params: search_params.
+              merge(access_key: 'usagov_key')
       end
 
       it { is_expected.to respond_with :success }
@@ -91,7 +93,8 @@ describe Api::V2::SearchesController do
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :azure, search_params.merge({ query: 'foo bar', routed: 'true' })
+        get :azure,
+            params: search_params.merge(query: 'foo bar', routed: 'true')
       end
 
       it { is_expected.to respond_with :success }
@@ -104,7 +107,7 @@ describe Api::V2::SearchesController do
 
   describe '#azure_web' do
     context 'when the search options are not valid' do
-      before { get :azure, search_params.except(:api_key) }
+      before { get :azure, params: search_params.except(:api_key) }
 
       it { is_expected.to respond_with :bad_request }
 
@@ -128,7 +131,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :azure_web, search_params.merge({ access_key: 'usagov_key' })
+        get :azure_web, params: search_params.merge(access_key: 'usagov_key')
       end
 
       it { is_expected.to respond_with :success }
@@ -146,7 +149,7 @@ describe Api::V2::SearchesController do
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :azure_web, search_params.merge({ query: 'foo bar', routed: 'true' })
+        get :azure_web, params: search_params.merge(query: 'foo bar', routed: 'true')
       end
 
       it { is_expected.to respond_with :success }
@@ -159,7 +162,7 @@ describe Api::V2::SearchesController do
 
   describe '#azure_image' do
     context 'when the search options are not valid' do
-      before { get :azure, search_params.except(:api_key) }
+      before { get :azure, params: search_params.except(:api_key) }
 
       it { is_expected.to respond_with :bad_request }
 
@@ -183,7 +186,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :azure_image, search_params
+        get :azure_image, params: search_params
       end
 
       it { is_expected.to respond_with :success }
@@ -201,7 +204,7 @@ describe Api::V2::SearchesController do
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :azure_image, search_params.merge({ query: 'foo bar', routed: 'true'})
+        get :azure_image, params: search_params.merge(query: 'foo bar', routed: 'true')
       end
 
       it { is_expected.to respond_with :success }
@@ -213,10 +216,10 @@ describe Api::V2::SearchesController do
   end
 
   describe '#bing' do
-    let(:bing_params) { search_params.merge({ sc_access_key: 'secureKey' }) }
+    let(:bing_params) { search_params.merge(sc_access_key: 'secureKey') }
 
     context 'when the search options are not valid' do
-      before { get :bing, bing_params.except(:sc_access_key) }
+      before { get :bing, params: bing_params.except(:sc_access_key) }
 
       it { is_expected.to respond_with :bad_request }
 
@@ -240,7 +243,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :bing, bing_params
+        get :bing, params: bing_params
       end
 
       it { is_expected.to respond_with :success }
@@ -258,7 +261,7 @@ describe Api::V2::SearchesController do
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :bing, bing_params.merge({ query: 'foo bar', routed: 'true'})
+        get :bing, params: bing_params.merge(query: 'foo bar', routed: 'true')
       end
 
       it { is_expected.to respond_with :success }
@@ -274,7 +277,7 @@ describe Api::V2::SearchesController do
 
     context 'when the search options are not valid' do
       before do
-        get :gss, gss_params.except(:cx, :api_key)
+        get :gss, params: gss_params.except(:cx, :api_key)
       end
 
       it { is_expected.to respond_with :bad_request }
@@ -300,7 +303,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :gss, gss_params
+        get :gss, params: gss_params
       end
 
       it { is_expected.to respond_with :success }
@@ -318,7 +321,7 @@ describe Api::V2::SearchesController do
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :gss, gss_params.merge({ query: 'foo bar', routed: 'true'})
+        get :gss, params: gss_params.merge(query: 'foo bar', routed: 'true')
       end
 
       it { is_expected.to respond_with :success }
@@ -333,9 +336,11 @@ describe Api::V2::SearchesController do
     context 'when the search options are not valid' do
       before do
         get :i14y,
-            affiliate: 'usagov',
-            format: 'json',
-            query: 'api'
+            params: {
+              affiliate: 'usagov',
+              format: 'json',
+              query: 'api'
+            }
       end
 
       it { is_expected.to respond_with :bad_request }
@@ -359,7 +364,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :i14y, search_params
+        get :i14y, params: search_params
       end
 
       it { is_expected.to respond_with :success }
@@ -391,7 +396,7 @@ describe Api::V2::SearchesController do
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :i14y, search_params.merge({ query: 'foo bar', routed: 'true'})
+        get :i14y, params: search_params.merge(query: 'foo bar', routed: 'true')
       end
 
       it { is_expected.to respond_with :success }
@@ -406,9 +411,11 @@ describe Api::V2::SearchesController do
     context 'when the search options are not valid' do
       before do
         get :video,
-            affiliate: 'usagov',
-            format: 'json',
-            query: 'api'
+            params: {
+              affiliate: 'usagov',
+              format: 'json',
+              query: 'api'
+            }
       end
 
       it { is_expected.to respond_with :bad_request }
@@ -433,7 +440,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :video, search_params
+        get :video, params: search_params
       end
 
       it { is_expected.to respond_with :success }
@@ -451,7 +458,7 @@ describe Api::V2::SearchesController do
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :video, search_params.merge({ query: 'foo bar', routed: 'true'})
+        get :video, params: search_params.merge(query: 'foo bar', routed: 'true')
       end
 
       it { is_expected.to respond_with :success }
@@ -466,7 +473,7 @@ describe Api::V2::SearchesController do
     let(:docs_params) { search_params.merge({ dc: 1 }) }
 
     context 'when the search options are not valid' do
-      before { get :docs, docs_params.except(:dc) }
+      before { get :docs, params: docs_params.except(:dc) }
       it { is_expected.to respond_with :bad_request }
 
       it 'returns errors in JSON' do
@@ -488,7 +495,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :docs, docs_params
+        get :docs, params: docs_params
       end
 
       it { is_expected.to respond_with :success }
@@ -515,7 +522,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :docs, docs_params
+        get :docs, params: docs_params
       end
 
       it { is_expected.to respond_with :success }
@@ -539,7 +546,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :docs, docs_params
+        get :docs, params: docs_params
       end
 
       it { is_expected.to respond_with :success }
@@ -557,7 +564,7 @@ describe Api::V2::SearchesController do
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :docs, docs_params.merge({ query: 'foo bar', routed: 'true'})
+        get :docs, params: docs_params.merge(query: 'foo bar', routed: 'true')
       end
 
       it { is_expected.to respond_with :success }

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -11,7 +11,7 @@ describe ApiController do
 
       before do
         allow(affiliate).to receive_message_chain(:active, :find_by_name).with('missingaffiliate').and_return(nil)
-        get :search, affiliate: 'missingaffiliate'
+        get :search, params: { affiliate: 'missingaffiliate' }
       end
 
       it { is_expected.to respond_with :not_found }
@@ -20,14 +20,14 @@ describe ApiController do
     context "when the affiliate is not on the v1 whitelist" do
       before do
         WhitelistedV1ApiHandle.delete_all
-        get :search, affiliate: 'usagov'
+        get :search, params: { affiliate: 'usagov' }
       end
 
       it { is_expected.to respond_with :not_found }
     end
 
     context 'when the params[:affiliate] is not a string' do
-      before { get :search, affiliate: { 'foo' => 'bar' } }
+      before { get :search, params: { affiliate: { 'foo' => 'bar' } } }
 
       it { is_expected.to respond_with :not_found }
     end
@@ -39,7 +39,11 @@ describe ApiController do
         json = { result_field: 'result' }.to_json
         expect(ApiSearch).to receive(:new).with(hash_including(affiliate: affiliate, query: 'solar')).and_return(api_search)
         allow(api_search).to receive(:run).and_return(json)
-        get :search, :affiliate => affiliate.name, :format => 'json', :query => 'solar'
+        get :search, 
+            params: { affiliate: affiliate.name,
+                      format: 'json',
+                      query: 'solar'
+            }
       end
 
       it { is_expected.to respond_with :success }
@@ -50,14 +54,19 @@ describe ApiController do
       end
     end
 
-    context "with format=xml" do
+    context 'with format=xml' do
       let(:api_search) { double(ApiSearch, :query => 'pdf', :modules => [], :diagnostics => {}) }
 
       before do
         xml = { result_field: 'result' }.to_xml
         expect(ApiSearch).to receive(:new).with(hash_including(affiliate: affiliate, query: 'solar')).and_return(api_search)
         allow(api_search).to receive(:run).and_return(xml)
-        get :search, :affiliate => affiliate.name, :format => 'xml', :query => 'solar'
+        get :search, 
+            params: { 
+              affiliate: affiliate.name, 
+              format:'xml', 
+              query: 'solar' 
+            }
       end
 
       it { is_expected.to respond_with :success }
@@ -71,7 +80,11 @@ describe ApiController do
 
     context "with format=html" do
       before do
-        get :search, :affiliate => affiliate.name, :format => :html
+        get :search, 
+        params: { 
+          affiliate: affiliate.name, 
+          format: :html 
+        }
       end
 
       it { is_expected.to respond_with :not_acceptable }
@@ -83,17 +96,17 @@ describe ApiController do
       end
 
       it "should set the affiliate" do
-        get :search, @auth_params
+        get :search, params: @auth_params
         expect(assigns[:search_options][:affiliate]).to eq(affiliates(:basic_affiliate))
       end
 
       it "should set the query" do
-        get :search, @auth_params.merge(:query => "fish")
+        get :search, params: @auth_params.merge(:query => "fish")
         expect(assigns[:search_options][:query]).to eq("fish")
       end
 
       it "should set the lat_lon" do
-        get :search, @auth_params.merge(:query => "fish", :lat_lon => '37.7676,-122.5164')
+        get :search, params: @auth_params.merge(:query => "fish", :lat_lon => '37.7676,-122.5164')
         expect(assigns[:search_options][:lat_lon]).to eq("37.7676,-122.5164")
       end
     end
@@ -109,7 +122,7 @@ describe ApiController do
         it "should log the impression with the :web vertical" do
           params = {'affiliate' => affiliate.name, 'query' => "foo", 'index' => 'web'}
           expect(SearchImpression).to receive(:log).with(api_search, :web, hash_including(params), instance_of(ActionController::TestRequest))
-          get :search, params
+          get :search, params: params
         end
       end
 
@@ -117,7 +130,7 @@ describe ApiController do
         it "should log the impression with the :image vertical" do
           params = {'affiliate' => affiliate.name, 'query' => "foo", 'index' => 'images'}
           expect(SearchImpression).to receive(:log).with(api_search, :image, hash_including(params), instance_of(ActionController::TestRequest))
-          get :search, params
+          get :search, params: params
         end
       end
 
@@ -125,7 +138,7 @@ describe ApiController do
         it "should log the impression with the :news vertical" do
           params = {'affiliate' => affiliate.name, 'query' => "foo", 'index' => 'news'}
           expect(SearchImpression).to receive(:log).with(api_search, :news, hash_including(params), instance_of(ActionController::TestRequest))
-          get :search, params
+          get :search, params: params
         end
       end
 
@@ -133,7 +146,7 @@ describe ApiController do
         it "should log the impression with the :news vertical" do
           params = {'affiliate' => affiliate.name, 'query' => "foo", 'index' => 'videonews'}
           expect(SearchImpression).to receive(:log).with(api_search, :news, hash_including(params), instance_of(ActionController::TestRequest))
-          get :search, params
+          get :search, params: params
         end
       end
 
@@ -141,7 +154,7 @@ describe ApiController do
         it "should log the impression with the :docs vertical" do
           params = {'affiliate' => affiliate.name, 'query' => "foo", 'index' => 'docs'}
           expect(SearchImpression).to receive(:log).with(api_search, :docs, hash_including(params), instance_of(ActionController::TestRequest))
-          get :search, params
+          get :search, params: params
         end
       end
 
@@ -149,7 +162,7 @@ describe ApiController do
         it "should log the impression with the :web vertical" do
           params = {'affiliate' => affiliate.name, 'query' => "foo"}
           expect(SearchImpression).to receive(:log).with(api_search, :web, hash_including(params), instance_of(ActionController::TestRequest))
-          get :search, params
+          get :search, params: params
         end
       end
     end

--- a/spec/controllers/api_controller_spec.rb
+++ b/spec/controllers/api_controller_spec.rb
@@ -39,10 +39,11 @@ describe ApiController do
         json = { result_field: 'result' }.to_json
         expect(ApiSearch).to receive(:new).with(hash_including(affiliate: affiliate, query: 'solar')).and_return(api_search)
         allow(api_search).to receive(:run).and_return(json)
-        get :search, 
-            params: { affiliate: affiliate.name,
-                      format: 'json',
-                      query: 'solar'
+        get :search,
+            params: {
+              affiliate: affiliate.name,
+              format: 'json',
+              query: 'solar'
             }
       end
 

--- a/spec/controllers/complete_registration_controller_spec.rb
+++ b/spec/controllers/complete_registration_controller_spec.rb
@@ -7,19 +7,19 @@ describe CompleteRegistrationController do
     'Sorry! Your request to complete registration is invalid. Are you sure you copied the right link from your email?'
   end
 
-  describe "do GET on #edit" do
-    context "when unknown token is passed in" do
-      before { get :edit, :id=>"unknown" }
+  describe 'do GET on #edit' do
+    context 'when unknown token is passed in' do
+      before { get :edit, params: { id: 'unknown' } }
       specify { expect(response).to redirect_to(login_path) }
 
       it { is_expected.to set_flash[:notice].to(failure_message) }
     end
 
-    context "when a known token is passed in" do
+    context 'when a known token is passed in' do
       let(:user) { users(:affiliate_added_by_another_affiliate_with_pending_email_verification_status) }
       before do
         expect(User).to receive(:find_by_email_verification_token).and_return(user)
-        get :edit, :id => "known"
+        get :edit, params: { id: 'known' }
       end
 
       it "@user should be assigned" do
@@ -30,7 +30,7 @@ describe CompleteRegistrationController do
 
   describe "do POST on #update" do
     context "when unknown token is passed in" do
-      before { post :update, :id=>"unknown" }
+      before { post :update, params: { id: 'unknown' } }
       specify { expect(response).to redirect_to(login_path) }
 
       it { is_expected.to set_flash[:notice].to(failure_message) }
@@ -43,14 +43,22 @@ describe CompleteRegistrationController do
       end
 
       it '@user should be assigned' do
-        post :update, { id: 'known', 'user': { 'contact_name': 'Homer Simpson' } }
+        post :update, 
+             params: {
+               id: 'known', 
+               'user': { 'contact_name': 'Homer Simpson' } 
+             }
+   
         expect(assigns[:user]).to eq(user)
       end
 
       context "when the form parameters are valid" do
         before do
           expect(user).to receive(:complete_registration).and_return(true)
-          post :update, :id => "known"
+          post :update, 
+          params: { 
+            id: 'known'
+          }
         end
 
         it { is_expected.to set_flash[:success].to(success_message) }
@@ -61,7 +69,7 @@ describe CompleteRegistrationController do
       context "when the form parameters are invalid" do
         before do
           expect(user).to receive(:complete_registration).and_return(false)
-          post :update, :id => "known"
+          post :update, params: { id: 'known' }
         end
 
         it "flash[:success] should be blank" do

--- a/spec/controllers/complete_registration_controller_spec.rb
+++ b/spec/controllers/complete_registration_controller_spec.rb
@@ -48,17 +48,14 @@ describe CompleteRegistrationController do
                id: 'known', 
                'user': { 'contact_name': 'Homer Simpson' } 
              }
-   
+
         expect(assigns[:user]).to eq(user)
       end
 
       context "when the form parameters are valid" do
         before do
           expect(user).to receive(:complete_registration).and_return(true)
-          post :update, 
-          params: { 
-            id: 'known'
-          }
+          post :update, params: { id: 'known' }
         end
 
         it { is_expected.to set_flash[:success].to(success_message) }

--- a/spec/controllers/email_verification_controller_spec.rb
+++ b/spec/controllers/email_verification_controller_spec.rb
@@ -7,7 +7,7 @@ describe EmailVerificationController do
   end
 
   describe "#show" do
-    subject(:attempt_email_verification) { get :show, id: token }
+    subject(:attempt_email_verification) { get :show, params: { id: token } }
     let(:email) { 'verifyme@example.com' }
     let(:verifying_user) { mock_model(User, email: email) }
     let(:token) { 'verifyme' }

--- a/spec/controllers/help_docs_controller_spec.rb
+++ b/spec/controllers/help_docs_controller_spec.rb
@@ -12,7 +12,7 @@ describe HelpDocsController do
 
       before do
         expect(HelpDoc).to receive(:extract_article).with(url).and_return 'Site Information'
-        get :show, url: url, format: :json
+        get :show, params: { url: url }, format: :json
       end
 
       it { respond_with :success }
@@ -24,7 +24,7 @@ describe HelpDocsController do
 
       before do
         expect(HelpDoc).not_to receive(:extract_article)
-        get :show, url: url, format: :json
+        get :show, params: { url: url }, format: :json
       end
 
       it { is_expected.to redirect_to('https://www.usa.gov/search-error') }
@@ -33,7 +33,7 @@ describe HelpDocsController do
     context 'when user is not logged in' do
       let(:url) { 'https://search.gov/manual/site-information.html' }
 
-      before { get :show, url: url, format: :json }
+      before { get :show, params: { url: url }, format: :json }
 
       it { respond_with :bad_request }
     end

--- a/spec/controllers/human_sessions_controller_spec.rb
+++ b/spec/controllers/human_sessions_controller_spec.rb
@@ -8,7 +8,7 @@ describe HumanSessionsController do
 
     context 'when the referenced affiliate does not exist' do
       it 'redirects to the usa.gov search-error page' do
-        get :new, r: '/search?affiliate=imaginaryaffiliate&query=building'
+        get :new, params: { r: '/search?affiliate=imaginaryaffiliate&query=building' }
         expect(response).to redirect_to('https://www.usa.gov/search-error')
       end
     end
@@ -16,22 +16,22 @@ describe HumanSessionsController do
     context 'when the referenced affiliate does exist' do
       it 'records the "challenge" captcha activity' do
         expect(subject).to receive(:record_captcha_activity).with('challenge')
-        get :new, r: '/search?affiliate=usagov&query=building'
+        get :new, params: { r: '/search?affiliate=usagov&query=building' }
       end
 
       it 'includes the "r" parameter in a "redirect_to" form input' do
-        get :new, r: '/search?affiliate=usagov&query=building'
+        get :new, params: { r: '/search?affiliate=usagov&query=building' }
         expect(response.body).to have_selector(:css, 'input[name=redirect_to][value="%2Fsearch%3Faffiliate%3Dusagov%26query%3Dbuilding"]', visible: false)
       end
 
       it 'includes a noscript tag with a span for holding the "please enable javascript" message' do
-        get :new, r: '/search?affiliate=usagov&query=building'
+        get :new, params: { r: '/search?affiliate=usagov&query=building' }
         expect(response.body).to have_selector('//noscript/span')
       end
 
       context 'when using an english-language affiliate' do
         it 'says "Search" in the captcha form submit button' do
-          get :new, r: '/search?affiliate=usagov&query=building'
+          get :new, params: { r: '/search?affiliate=usagov&query=building' }
           expect(response.body).to have_selector('input[type=submit][value=Search]')
         end
       end
@@ -39,7 +39,7 @@ describe HumanSessionsController do
       context 'when using a spanish-lanugage affiliate' do
         after { I18n.locale = I18n.default_locale }
         it 'says "Buscar" in the captcha form submit button' do
-          get :new, r: '/search?affiliate=gobiernousa&query=building'
+          get :new, params: { r: '/search?affiliate=gobiernousa&query=building' }
           expect(response.body).to have_selector('input[type=submit][value=Buscar]')
         end
       end
@@ -58,29 +58,29 @@ describe HumanSessionsController do
 
       it 'records the "success" captcha activity' do
         expect(subject).to receive(:record_captcha_activity).with('success')
-        post :create, redirect_to: '%2Flol%2Fwut'
+        post :create, params: { redirect_to: '%2Flol%2Fwut' }
       end
 
       it 'does not record a "failure" captcha activity' do
         expect(subject).not_to receive(:record_captcha_activity).with('failure')
-        post :create, redirect_to: '%2Flol%2Fwut'
+        post :create, params: { redirect_to: '%2Flol%2Fwut' }
       end
 
       it 'sets the "bon" cookie to a combination of client_ip, timestamp, and digest' do
-        post :create, redirect_to: '%2Flol%2Fwut'
+        post :create, params: { redirect_to: '%2Flol%2Fwut' } 
         expect(response.cookies['bon']).to eq('0.0.0.0:870671640:sha-na-na')
       end
 
       context 'when the redirect_to parameter starts with a URL-encoded slash' do
         it 'should redirect to the redirect_to parameter' do
-          post :create, redirect_to: '%2Flol%2Fwut'
+          post :create, params: { redirect_to: '%2Flol%2Fwut' }
           expect(response).to redirect_to('/lol/wut')
         end
       end
 
       context 'when the redirect_to parameter does not start with a URL-encoded slash' do
         it 'should redirect to the usa.gov search-error URL' do
-          post :create, redirect_to: 'http:%2F%2Flol%2Fwut'
+          post :create, params: { redirect_to: 'http:%2F%2Flol%2Fwut' }
           expect(response).to redirect_to(ApplicationController::PAGE_NOT_FOUND)
         end
       end
@@ -91,29 +91,29 @@ describe HumanSessionsController do
 
       it 'recods the "failure" captcha activity' do
         expect(subject).to receive(:record_captcha_activity).with('failure')
-        post :create, redirect_to: '%2Flol%2Fwut'
+        post :create, params: { redirect_to: '%2Flol%2Fwut' }
       end
 
       it 'does not record a "success" captcha activity' do
         expect(subject).not_to receive(:record_captcha_activity).with('success')
-        post :create, redirect_to: '%2Flol%2Fwut'
+        post :create, params: { redirect_to: '%2Flol%2Fwut' }
       end
 
       it 'does not set a "bon" cookie' do
-        post :create, redirect_to: '%2Flol%2Fwut'
+        post :create, params: { redirect_to: '%2Flol%2Fwut' }
         expect(response.cookies[:bon]).to be_nil
       end
 
       context 'when the redirect_to parameter starts with a URL-encoded slash' do
         it 'should redirect to the redirect_to parameter' do
-          post :create, redirect_to: '%2Flol%2Fwut'
+          post :create, params: { redirect_to: '%2Flol%2Fwut' }
           expect(response).to redirect_to('/lol/wut')
         end
       end
 
       context 'when the redirect_to parameter does not start with a URL-encoded slash' do
         it 'should redirect to the usa.gov search-error URL' do
-          post :create, redirect_to: 'http:%2F%2Flol%2Fwut'
+          post :create, params: { redirect_to: 'http:%2F%2Flol%2Fwut' }
           expect(response).to redirect_to(ApplicationController::PAGE_NOT_FOUND)
         end
       end

--- a/spec/controllers/image_searches_controller_spec.rb
+++ b/spec/controllers/image_searches_controller_spec.rb
@@ -4,148 +4,174 @@ describe ImageSearchesController do
   fixtures :affiliates, :instagram_profiles, :languages
   let(:affiliate) { affiliates(:usagov_affiliate) }
 
-  describe "#index" do
-    context "when searching on legacy affiliate and the query is present" do
+  describe '#index' do
+    context 'when searching on legacy affiliate and the query is present' do
       let(:affiliate) { affiliates(:basic_affiliate) }
       let(:query) { '<script>thunder & lightning</script>' }
-      let(:image_search) { double(LegacyImageSearch, :query => 'thunder & lightning', :modules => [], :diagnostics => {}) }
+      let(:image_search) do
+        double(LegacyImageSearch,
+               query: 'thunder & lightning',
+               modules: [],
+               diagnostics: {})
+      end
 
       before do
         allow(affiliate).to receive(:force_mobile_format?).and_return(false)
         expect(Affiliate).to receive(:find_by_name).with('nps.gov').and_return(affiliate)
-        expect(LegacyImageSearch).to receive(:new).with(hash_including(affiliate: affiliate, query: 'thunder & lightning')).and_return(image_search)
+        expect(LegacyImageSearch).to receive(:new).
+          with(hash_including(affiliate: affiliate, query: 'thunder & lightning')).
+          and_return(image_search)
         expect(image_search).to receive(:run)
       end
 
-      context "for a live search" do
+      context 'for a live search' do
         before do
-          get :index, :affiliate => 'nps.gov', :query => '<script>thunder & lightning</script>'
+          get :index, params: { affiliate: 'nps.gov',
+                                query: '<script>thunder & lightning</script>' }
         end
 
         it { is_expected.to assign_to(:search).with(image_search) }
         it { is_expected.to assign_to :affiliate }
-        it { is_expected.to assign_to(:page_title).with("thunder & lightning - NPS Site Search Results") }
-        it { is_expected.to assign_to(:search_params).with(
-                        hash_including(affiliate: affiliate.name, query: 'thunder & lightning')) }
+        it do
+          is_expected.to assign_to(:page_title).
+            with('thunder & lightning - NPS Site Search Results')
+        end
+        it do
+          is_expected.to assign_to(:search_params).
+            with(hash_including(affiliate: affiliate.name, query: 'thunder & lightning'))
+        end
         it { is_expected.to render_template 'image_searches/index' }
 
-        it "should render the template" do
+        it 'should render the template' do
           expect(response).to render_template 'image_searches/index'
           expect(response).to render_template 'layouts/searches'
         end
       end
 
-      context "for a staged search" do
+      context 'for a staged search' do
         before do
-          get :index, :affiliate => 'nps.gov', :query => '<script>thunder & lightning</script>', :staged => "true"
+          get :index, params: { affiliate: 'nps.gov',
+                                query: '<script>thunder & lightning</script>',
+                                staged: 'true' }
         end
 
-        it { is_expected.to assign_to(:page_title).with("thunder & lightning - NPS Site Search Results") }
+        it do
+          is_expected.to assign_to(:page_title).
+            with('thunder & lightning - NPS Site Search Results')
+        end
       end
 
-      context "via the JSON API" do
+      context 'via the JSON API' do
         let(:search_results_json) { 'search results json' }
         before do
           expect(image_search).to receive(:to_json).and_return(search_results_json)
-          get :index, :affiliate => 'nps.gov', :query => '<script>thunder & lightning</script>', :format => :json
+          get :index,
+              params: { affiliate: 'nps.gov',
+                        query: '<script>thunder & lightning</script>' },
+              format: :json
         end
 
         it { is_expected.to respond_with :success }
 
-        it "should render the results in json" do
-          expect(response.content_type). to eq "application/json"
+        it 'should render the results in json' do
+          expect(response.content_type). to eq 'application/json'
           expect(response.body).to eq(search_results_json)
         end
       end
     end
 
-    context "when searching on legacy affiliate and the query is blank" do
+    context 'when searching on legacy affiliate and the query is blank' do
       let(:affiliate) { mock_model(Affiliate, :locale => 'en', force_mobile_format?: false) }
       let(:image_search) { double(LegacyImageSearch, :query => nil, :modules => [], :diagnostics => {}) }
 
       before do
         expect(Affiliate).to receive(:find_by_name).with('agency100').and_return(affiliate)
-        expect(LegacyImageSearch).to receive(:new).with(hash_including(:affiliate => affiliate, :query => '')).and_return(image_search)
+        expect(LegacyImageSearch).to receive(:new).
+          with(hash_including(affiliate: affiliate,
+                              query: '')).and_return(image_search)
         expect(image_search).to receive(:run)
-        get :index, :affiliate => "agency100"
+        get :index, params: { affiliate: 'agency100' }
       end
 
       it { is_expected.to respond_with :success }
     end
 
     context 'when params[:affiliate] is not a string' do
-      before { get :index, affiliate: { 'foo' => 'bar' }, query: 'gov' }
+      before { get :index, params: { affiliate: { 'foo': 'bar' }, query: 'gov' } }
 
       it { is_expected.to redirect_to 'https://www.usa.gov/search-error' }
     end
 
-    context "when searching on legacy affiliate via the API" do
+    context 'when searching on legacy affiliate via the API' do
       fixtures :image_search_labels
       render_views
 
       before do
-        affiliates(:usagov_affiliate).update_attributes!(force_mobile_format: false)
+        affiliates(:usagov_affiliate).update!(force_mobile_format: false)
       end
 
-      context "when searching normally" do
+      context 'when searching normally' do
         before do
-          get :index, :query => '<script>weather</script>', :format => "json", affiliate: 'usagov'
+          get :index,
+              params: { query: '<script>weather</script>',
+                        affiliate: 'usagov' },
+              format: 'json'
           @search = assigns[:search]
         end
 
-        it "should set the format to json" do
-          expect(response.content_type).to eq("application/json")
+        it 'should set the format to json' do
+          expect(response.content_type).to eq('application/json')
         end
 
-        it "should sanitize the query term" do
-          expect(@search.query).to eq("weather")
+        it 'should sanitize the query term' do
+          expect(@search.query).to eq('weather')
         end
 
-        it "should serialize the results into JSON" do
+        it 'should serialize the results into JSON' do
           expect(response.body).to match(/total/)
           expect(response.body).to match(/startrecord/)
           expect(response.body).to match(/endrecord/)
         end
       end
 
-      context "when some error is returned" do
+      context 'when some error is returned' do
         before do
-          get :index, :query => 'a' * 1001, :format => "json", affiliate: 'usagov'
+          get :index, params: { query: 'a' * 1001, format: 'json', affiliate: 'usagov' }
           @search = assigns[:search]
         end
 
-        it "should serialize an error into JSON" do
+        it 'should serialize an error into JSON' do
           expect(response.body).to match(/error/)
           expect(response.body).to match(/#{I18n.translate :too_long}/)
         end
       end
     end
 
-    context "when searching in mobile mode" do
+    context 'when searching in mobile mode' do
       before do
         affiliate.instagram_profiles << instagram_profiles(:whitehouse)
-        get :index, :query => 'obama', :m => "true", :affiliate => 'usagov'
+        get :index, params: { query: 'obama', m: 'true', affiliate: 'usagov' }
       end
 
-      it "should show the mobile version of the page" do
+      it 'should show the mobile version of the page' do
         expect(response).to be_success
       end
     end
 
-    context "when searching in desktop mode" do
+    context 'when searching in desktop mode' do
       before do
         affiliate.instagram_profiles << instagram_profiles(:whitehouse)
-        get :index, :query => 'obama', :affiliate => 'usagov'
+        get :index, params: { query: 'obama', affiliate: 'usagov' }
       end
 
-      it "assigns @page_title" do
+      it 'assigns @page_title' do
         expect(assigns[:page_title]).not_to be_blank
       end
     end
 
     context 'when query param is nil/missing' do
       before do
-        get :index, :affiliate => 'usagov'
+        get :index, params: { affiliate: 'usagov' }
       end
 
       it 'should treat it as an empty string' do

--- a/spec/controllers/password_resets_controller_spec.rb
+++ b/spec/controllers/password_resets_controller_spec.rb
@@ -15,14 +15,14 @@ MESSAGE
 describe PasswordResetsController do
   context 'when unknown token is passed in' do
     it 'should redirect to the password reset page' do
-      get :edit, id: 'fail'
+      get :edit, params: { id: 'fail' }
       expect(response).to redirect_to(new_password_reset_path)
     end
   end
 
   describe '#create' do
     context 'when params[:email] is not a string' do
-      before { post :create, email: { 'foo': 'bar' } }
+      before { post :create, params: { email: { 'foo': 'bar' } } }
       it { is_expected.to set_flash.now.to(/#{RESET_PASSWORD_MESSAGE}/) }
     end
 
@@ -31,7 +31,7 @@ describe PasswordResetsController do
         user = mock_model User
         expect(User).to receive(:find_by_email).with('not_approved@email.gov').and_return user
         expect(user).to receive(:is_not_approved?).and_return true
-        post :create, email: 'not_approved@email.gov'
+        post :create, params: { email: 'not_approved@email.gov' }
       end
 
       it { is_expected.to set_flash[:notice].to(/#{NOT_AUTHORIZED_MESSAGE}/) }
@@ -45,7 +45,7 @@ describe PasswordResetsController do
         user = mock_model User
         expect(User).to receive(:find_using_perishable_token).and_return user
         expect(user).to receive(:is_not_approved?).and_return true
-        get :edit, id: 'my token'
+        get :edit, params: { id: 'my token' }
       end
 
       it { is_expected.to set_flash[:notice].to(/#{NOT_AUTHORIZED_MESSAGE}/) }
@@ -59,7 +59,7 @@ describe PasswordResetsController do
         user = mock_model User
         expect(User).to receive(:find_using_perishable_token).and_return user
         expect(user).to receive(:is_not_approved?).and_return true
-        put :update, id: 'my token'
+        put :update, params: { id: 'my token' }
       end
 
       it { is_expected.to set_flash[:notice].to(/#{NOT_AUTHORIZED_MESSAGE}/) }

--- a/spec/controllers/sayt_controller_spec.rb
+++ b/spec/controllers/sayt_controller_spec.rb
@@ -10,7 +10,7 @@ describe SaytController, type: :request do
   describe '#index' do
     context 'when sanitized query is empty' do
       it 'returns empty string' do
-        get '/sayt', q: ' \\ '
+        get '/sayt', params: { q: ' \\ ' }
         expect(response.body).to eq('')
       end
     end
@@ -25,7 +25,7 @@ describe SaytController, type: :request do
                                 number_of_results: 5)).
             and_return(search)
 
-        get '/sayt', q: 'lorem \\ ipsum', name: affiliate.name
+        get '/sayt', params: { q: 'lorem \\ ipsum', name: affiliate.name }
         expect(response.body).to eq('some json string')
       end
     end
@@ -41,7 +41,7 @@ describe SaytController, type: :request do
                                 number_of_results: 5)).
             and_return(search)
 
-        get '/sayt', q: 'lorem \\ ipsum', name: affiliate.name, extras: true
+        get '/sayt', params: { q: 'lorem \\ ipsum', name: affiliate.name, extras: true }
         expect(response.body).to eq('some json string')
       end
     end
@@ -50,7 +50,7 @@ describe SaytController, type: :request do
       it 'should return blank' do
         expect(SaytSearch).not_to receive(:new)
 
-        get '/sayt', q: 'lorem \\ ipsum', name: 'invalid'
+        get '/sayt', params: { q: 'lorem \\ ipsum', name: 'invalid' }
         expect(response.body).to eq('')
       end
     end
@@ -65,7 +65,7 @@ describe SaytController, type: :request do
                                 number_of_results: 5)).
             and_return(search)
 
-        get '/sayt', :q => 'lorem \\ ipsum', :aid => affiliate.id
+        get '/sayt', params: { q: 'lorem \\ ipsum', aid: affiliate.id }
         expect(response.body).to eq('some json string')
       end
     end
@@ -80,7 +80,7 @@ describe SaytController, type: :request do
                                 number_of_results: 5)).
             and_return(search)
 
-        get '/sayt', :q => 'lorem \\ ipsum', :aid => affiliate.id, :extras => 'true'
+        get '/sayt', params: { q: 'lorem \\ ipsum', aid: affiliate.id, extras: 'true' }
         expect(response.body).to eq('some json string')
       end
     end
@@ -90,7 +90,7 @@ describe SaytController, type: :request do
         expect(Affiliate).to receive(:find_by_id_and_is_sayt_enabled).with('0', true).and_return(nil)
         expect(SaytSearch).not_to receive(:new)
 
-        get '/sayt', :q => 'lorem // ipsum', :aid => 0
+        get '/sayt', params: { q: 'lorem // ipsum', aid: 0 }
         expect(response.body).to eq('')
       end
     end

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -6,9 +6,9 @@ describe SearchesController do
 
   let(:affiliate) { affiliates(:usagov_affiliate) }
 
-  context "when showing a new search" do
+  context 'when showing a new search' do
     render_views
-    context "when searching in English" do
+    context 'when searching in English' do
       before do
         get :index, params: { query: 'social security', page: 4, affiliate: 'usagov' }
         @search = assigns[:search]
@@ -19,32 +19,32 @@ describe SearchesController do
         expect(@controller.view_assigns['search_options'].keys.map(&:class).uniq).to eq([Symbol])
       end
 
-      it "should assign the USA.gov affiliate as the default affiliate" do
+      it 'should assign the USA.gov affiliate as the default affiliate' do
         expect(assigns[:affiliate]).to eq(affiliates(:usagov_affiliate))
       end
 
-      it "should render the template" do
+      it 'should render the template' do
         expect(response).to render_template 'index'
         expect(response).to render_template 'layouts/searches'
       end
 
-      it "should assign the query as the page title" do
-        expect(@page_title).to eq("social security - USA.gov Search Results")
+      it 'should assign the query as the page title' do
+        expect(@page_title).to eq('social security - USA.gov Search Results')
       end
 
-      it "should show a custom title for the results page" do
+      it 'should show a custom title for the results page' do
         expect(response.body).to match(/social security - USA.gov Search Results/)
       end
 
-      it "should set the query in the Search model" do
-        expect(@search.query).to eq("social security")
+      it 'should set the query in the Search model' do
+        expect(@search.query).to eq('social security')
       end
 
-      it "should set the page" do
+      it 'should set the page' do
         expect(@search.page).to eq(4)
       end
 
-      it "should load results for a keyword query" do
+      it 'should load results for a keyword query' do
         expect(@search).not_to be_nil
         expect(@search.results).not_to be_nil
       end
@@ -56,7 +56,12 @@ describe SearchesController do
     context 'when searching on a Spanish site' do
       it 'assigns locale to :es' do
         expect(I18n).to receive(:locale=).with(:es)
-        get :index, query: 'social security', page: 4, affiliate: 'gobiernousa'
+        get :index,
+            params: {
+              query: 'social security',
+              page: 4,
+              affiliate: 'gobiernousa'
+            }
       end
     end
   end
@@ -68,14 +73,20 @@ describe SearchesController do
 
   context 'when the affiliate is not active' do
     let(:affiliate) { affiliates(:inactive_affiliate) }
-    before { get :index, query: 'gov', affiliate: affiliate.name }
+    before do
+      get :index,
+          params: {
+            query: 'gov',
+            affiliate: affiliate.name
+          }
+    end
 
     it { is_expected.to redirect_to 'https://www.usa.gov/search-error' }
   end
 
   context 'when searching with non scalar query' do
     it "should not blow up if query is not a string" do
-      get :index, query: { 'foo' => 'bar' }, affiliate: 'usagov'
+      get :index, params: { query: { 'foo' => 'bar' }, affiliate: 'usagov' }
       expect(assigns[:search].query).to be_blank
     end
   end
@@ -105,7 +116,11 @@ describe SearchesController do
 
       it 'logs the impression' do
         expect(SearchImpression).to receive(:log)
-        get :index, query: "foo bar", affiliate: affiliate.name
+        get :index,
+            params: {
+              query: 'foo bar',
+              affiliate: affiliate.name
+            }
       end
     end
 
@@ -119,7 +134,11 @@ describe SearchesController do
           routed_query.routed_query_keywords.build(keyword: 'foo bar')
           routed_query.save!
           request.env['HTTP_REFERER'] = ref_url
-          get :index, query: "foo bar", affiliate: affiliate.name
+          get :index,
+              params: {
+                query: 'foo bar',
+                affiliate: affiliate.name
+              }
         end
 
         it { is_expected.to render_template(:index) }
@@ -195,7 +214,11 @@ describe SearchesController do
     let(:affiliate) { affiliates(:legacy_affiliate) }
 
     before do
-      get :index, :affiliate => affiliate.name, :query => "<script>thunder & lightning</script>"
+      get :index,
+          params: {
+            affiliate: affiliate.name,
+            query: '<script>thunder & lightning</script>'
+          }
       @search = assigns[:search]
       @page_title = assigns[:page_title]
     end
@@ -232,7 +255,12 @@ describe SearchesController do
   context "when the affiliate locale is set to Spanish" do
     before do
       affiliate = affiliates(:gobiernousa_affiliate)
-      get :index, :affiliate => affiliate.name, :query => 'weather', :locale => 'en'
+      get :index,
+          params: {
+            affiliate: affiliate.name,
+            query: 'weather',
+            locale: 'en'
+          }
     end
     after { I18n.locale = I18n.default_locale }
 
@@ -262,7 +290,11 @@ describe SearchesController do
     before do
       iphone_user_agent = "Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3"
       request.env["HTTP_USER_AGENT"] = iphone_user_agent
-      get :index, :affiliate => affiliate.name, :query => "weather"
+      get :index,
+          params: {
+            affiliate: affiliate.name,
+            query: 'weather'
+          }
     end
 
     it { is_expected.to respond_with(:success) }
@@ -302,7 +334,11 @@ describe SearchesController do
   context "when handling any affiliate search request (mobile or otherwise)" do
     render_views
     before do
-      get :index, :affiliate=> affiliates(:power_affiliate).name, :query => "weather"
+      get :index,
+          params: {
+            affiliate: affiliates(:power_affiliate).name,
+            query: 'weather'
+          }
     end
 
     it "should render the template" do
@@ -313,7 +349,11 @@ describe SearchesController do
 
   context "when handling an invalid affiliate search request" do
     before do
-      get :index, :affiliate=>"doesnotexist.gov", :query => "weather"
+      get :index,
+          params: {
+            affiliate: 'doesnotexist.gov',
+            query: 'weather'
+          }
     end
 
     it { is_expected.to redirect_to 'https://www.usa.gov/search-error' }
@@ -322,7 +362,12 @@ describe SearchesController do
   context "when handling any affiliate search request with a JSON format" do
     render_views
     before do
-      get :index, :affiliate => affiliates(:power_affiliate).name, :query => "weather", :format => "json"
+      get :index,
+          params: {
+            affiliate: affiliates(:power_affiliate).name,
+            query: 'weather'
+          },
+          format: 'json'
     end
 
     it "should serialize the results into JSON" do
@@ -334,7 +379,7 @@ describe SearchesController do
 
   context "when a user is attempting to visit an old-style advanced search page" do
     before do
-      get :index, :form => "advanced-firstgov"
+      get :index, params: { form: 'advanced-firstgov' }
     end
 
     it "should redirect to the advanced search page" do
@@ -344,7 +389,11 @@ describe SearchesController do
 
   context "when a user is attempting to visit an old-style advanced search page for an affiliate" do
     before do
-      get :index, :form => 'advanced-firstgov', :affiliate => 'aff.gov'
+      get :index,
+          params: {
+            form: 'advanced-firstgov',
+            affiliate: 'aff.gov'
+          }
     end
 
     it "should redirect to the affiliate advanced search page" do
@@ -356,7 +405,12 @@ describe SearchesController do
   context "highlighting" do
     context "when a client requests results without highlighting" do
       before do
-        get :index, :query => "obama", :hl => "false", affiliate: 'usagov'
+        get :index,
+            params: {
+              query: 'obama',
+              hl: 'false',
+              affiliate: 'usagov'
+            }
       end
 
       it "should set the highlighting option to false" do
@@ -367,21 +421,30 @@ describe SearchesController do
 
     context "when a client requests result with highlighting" do
       before do
-        get :index, :query => "obama", :hl => "true", affiliate: 'usagov'
+        get :index,
+            params: {
+              query: 'obama',
+              hl: 'true',
+              affiliate: 'usagov'
+            }
       end
 
-      it "should set the highlighting option to true" do
+      it 'should set the highlighting option to true' do
         @search_options = assigns[:search_options]
         expect(@search_options[:enable_highlighting]).to be true
       end
     end
 
-    context "when a client does not specify highlighting" do
+    context 'when a client does not specify highlighting' do
       before do
-        get :index, :query => "obama", affiliate: 'usagov'
+        get :index,
+            params: {
+              query: 'obama',
+              affiliate: 'usagov'
+            }
       end
 
-      it "should set the highlighting option to true" do
+      it 'should set the highlighting option to true' do
         @search_options = assigns[:search_options]
         expect(@search_options[:enable_highlighting]).to be true
       end
@@ -394,7 +457,7 @@ describe SearchesController do
     before do
       expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
       expect(affiliate).to receive(:force_mobile_format?).and_return(true)
-      get :index, query: 'gov', affiliate: affiliate.name
+      get :index, params: { query: 'gov', affiliate: affiliate.name }
     end
 
     it 'requests the mobile format' do
@@ -427,7 +490,7 @@ describe SearchesController do
         allow(affiliate).to receive_message_chain(:document_collections, :find_by_id).and_return(dc)
         expect(SiteSearch).to receive(:new).with(hash_including(dc: '100', per_page: 20)).and_return(site_search)
         expect(site_search).to receive(:run)
-        get :docs, docs_params
+        get :docs, params: docs_params
       end
 
       it { is_expected.to assign_to(:affiliate).with(affiliate) }
@@ -453,7 +516,12 @@ describe SearchesController do
         it 'triggers an I14y search' do
           expect(I14ySearch).to receive(:new).and_return(i14y_search)
           expect(i14y_search).to receive(:run)
-          get :docs, :query => 'gov', :affiliate => affiliate.name, :dc => 100
+          get :docs,
+              params: {
+                query: 'gov',
+                affiliate: affiliate.name,
+                dc: 100
+              }
         end
       end
 
@@ -484,7 +552,13 @@ describe SearchesController do
         allow(affiliate).to receive_message_chain(:document_collections, :find_by_id).and_return(dc)
         expect(SiteSearch).to receive(:new).with(hash_including(:dc => '100')).and_return(site_search)
         expect(site_search).to receive(:run)
-        get :docs, :query => 'pdf', :affiliate => affiliate.name, :dc => 100, :page => 3
+        get :docs,
+            params: {
+              query: 'pdf',
+              affiliate: affiliate.name,
+              dc: 100,
+              page: 3
+            }
       end
 
       specify { expect(assigns[:search_options][:page]).to eq('3') }
@@ -499,7 +573,12 @@ describe SearchesController do
         expect(WebSearch).to receive(:new).with(hash_including(dc: '100', per_page: 20)).and_return(web_search)
         expect(web_search).to receive(:run)
         expect(SiteSearch).not_to receive(:new)
-        get :docs, :query => 'pdf', :affiliate => affiliate.name, :dc => 100
+        get :docs,
+            params: {
+              query: 'pdf',
+              affiliate: affiliate.name,
+              dc: 100
+            }
       end
 
       it { is_expected.to assign_to(:affiliate).with(affiliate) }
@@ -514,7 +593,12 @@ describe SearchesController do
         expect(WebSearch).to receive(:new).with(hash_including(query: 'pdf')).and_return(web_search)
         expect(web_search).to receive(:run)
         expect(SiteSearch).not_to receive(:new)
-        get :docs, query: 'pdf', affiliate: affiliate.name, dc: { 'foo' => 'bar' }
+        get :docs,
+            params: {
+              query: 'pdf',
+              affiliate: affiliate.name,
+              dc: { 'foo': 'bar' }
+            }
       end
 
       it { is_expected.to assign_to(:affiliate).with(affiliate) }
@@ -527,7 +611,7 @@ describe SearchesController do
       end
 
       it 'should redirect to the search-consumer display page' do
-        get :docs, docs_search_params
+        get :docs, params: docs_search_params
         expect(response).to redirect_to search_consumer_docs_search_url(docs_search_params)
       end
     end
@@ -541,7 +625,12 @@ describe SearchesController do
         affiliate.search_engine = 'SearchGov'
         expect(I14ySearch).to receive(:new).and_return(i14y_search)
         expect(i14y_search).to receive(:run)
-        get :docs, :query => 'gov', :affiliate => affiliate.name, :dc => 100
+        get :docs,
+            params: {
+              query: 'gov',
+              affiliate: affiliate.name,
+              dc: 100
+            }
       end
 
       it { is_expected.to render_template(:i14y) }
@@ -562,16 +651,31 @@ describe SearchesController do
       ElasticNewsItem.commit
     end
 
-    it "should assign page title, vertical, form_path, and search members" do
-      get :news, :query => "element", :affiliate => affiliate.name, :channel => rss_feeds(:white_house_blog).id, :tbs => "w", :page => "1", :per_page => "5"
+    it 'should assign page title, vertical, form_path, and search members' do
+      get :news,
+          params: {
+            query: 'element',
+            affiliate: affiliate.name,
+            channel: rss_feeds(:white_house_blog).id,
+            tbs: 'w',
+            page: '1',
+            per_page: '5'
+          }
       expect(assigns[:page_title]).to eq("element - #{affiliate.display_name} Search Results")
       expect(assigns[:search_vertical]).to eq(:news)
       expect(assigns[:form_path]).to eq(news_search_path)
       expect(assigns[:search]).to be_an_instance_of(NewsSearch)
     end
 
-    it "should find news items that match the query for the affiliate" do
-      get :news, :query => "element", :affiliate => affiliate.name, :channel => rss_feeds(:white_house_blog).id, :tbs => "w"
+    it 'should find news items that match the query for the affiliate' do
+      get :news,
+          params: {
+            query: 'element',
+            affiliate: affiliate.name,
+            channel: rss_feeds(:white_house_blog).id,
+            tbs: 'w'
+          }
+
       expect(assigns[:search].total).to eq(1)
       expect(assigns[:search].results.first).to eq(news_items(:item1))
       expect(assigns[:search].results.first.title).to eq("News \uE000element\uE001 1")
@@ -580,22 +684,43 @@ describe SearchesController do
       expect(assigns[:search].results.first.description).to eq("News \uE000element\uE001 1 has a description")
     end
 
-    context "when the affiliate does not exist" do
+    context 'when the affiliate does not exist' do
       before do
-        get :news, :query => "element", :affiliate => "donotexist", :channel => rss_feeds(:white_house_blog).id, :tbs => "w"
+        get :news,
+            params: {
+              query: 'element',
+              affiliate: 'donotexist',
+              channel: rss_feeds(:white_house_blog).id,
+              tbs: 'w'
+            }
       end
 
       it { is_expected.to redirect_to 'https://www.usa.gov/search-error' }
     end
 
-    context "when the query is blank and total is > 0" do
-      before { get :news, :query => "", :affiliate => affiliate.name, :channel => rss_feeds(:white_house_blog).id, :tbs => "w" }
+    context 'when the query is blank and total is > 0' do
+      before do
+        get :news,
+            params: {
+              query: '',
+              affiliate: affiliate.name,
+              channel: rss_feeds(:white_house_blog).id,
+              tbs: 'w'
+            }
+      end
+
       it { is_expected.to assign_to(:page_title).with('White House Blog - NPS Site Search Results') }
     end
 
     context "when handling an array parameter" do
       before do
-        get :news, {"affiliate"=>affiliate.name, "channel"=>rss_feeds(:white_house_blog).id, "m"=>"false", "query"=>["loren"]}
+        get :news,
+            params: {
+              'affiliate': affiliate.name,
+              'channel': rss_feeds(:white_house_blog).id,
+              'm': 'false',
+              'query': ['loren']
+            }
       end
 
       it "should render the template" do
@@ -619,14 +744,16 @@ describe SearchesController do
         expect(news_search).to receive(:run)
 
         get :news,
-            query: 'element',
-            affiliate: affiliate.name,
-            channel: rss_feeds(:white_house_blog).id,
-            tbs: 'w',
-            sort_by: 'r',
-            contributor: 'The President',
-            publisher: 'The White House',
-            subject: 'Economy'
+            params: {
+              query: 'element',
+              affiliate: affiliate.name,
+              channel: rss_feeds(:white_house_blog).id,
+              tbs: 'w',
+              sort_by: 'r',
+              contributor: 'The President',
+              publisher: 'The White House',
+              subject: 'Economy'
+            }
       end
 
       it { is_expected.to assign_to(:search_params).with(
@@ -660,7 +787,17 @@ describe SearchesController do
             and_return(news_search)
         expect(news_search).to receive(:run)
 
-        get :news, query: 'element', affiliate: affiliate.name, channel: channel_id, tbs: 'w', since_date: '10/1/2012', until_date: '10/15/2012'
+        get :news,
+            params: {
+              query: 'element',
+              affiliate: affiliate.name,
+              channel: channel_id,
+              tbs: 'w',
+              since_date:
+                '10/1/2012',
+              until_date:
+                '10/15/2012'
+            }
       end
 
       it { is_expected.to assign_to(:affiliate).with(affiliate) }
@@ -673,11 +810,17 @@ describe SearchesController do
                                      until_date: '10/15/2012')) }
     end
 
-    describe "rendering the view" do
+    describe 'rendering the view' do
       render_views
 
-      it "should render the template" do
-        get :news, :query => "element", :affiliate => affiliate.name, :channel => rss_feeds(:white_house_blog).id, :tbs => "w"
+      it 'should render the template' do
+        get :news,
+            params: {
+              query: 'element',
+              affiliate: affiliate.name,
+              channel: rss_feeds(:white_house_blog).id,
+              tbs: 'w'
+            }
         expect(response).to render_template 'news'
         expect(response).to render_template 'layouts/searches'
       end
@@ -690,7 +833,7 @@ describe SearchesController do
       end
 
       it 'should redirect to the search-consumer display page' do
-        get :news, news_search_params
+        get :news, params: news_search_params
         expect(response).to redirect_to search_consumer_news_search_url(news_search_params)
       end
     end
@@ -705,7 +848,12 @@ describe SearchesController do
       before do
         expect(VideoNewsSearch).to receive(:new).with(hash_including(per_page: 20)).and_return(video_news_search)
         expect(video_news_search).to receive(:run)
-        get :video_news, :query => "element", :affiliate => affiliate.name, :tbs => "w"
+        get :video_news,
+            params: {
+              query: 'element',
+              affiliate: affiliate.name,
+              tbs: 'w'
+            }
       end
 
       it { is_expected.to assign_to(:search).with(video_news_search) }
@@ -725,7 +873,13 @@ describe SearchesController do
         rss_feed = double('rss feed', :name => 'Videos')
         expect(video_news_search).to receive(:rss_feed).at_least(:once).and_return(rss_feed)
         expect(video_news_search).to receive(:total).and_return(1)
-        get :video_news, :query => "", :affiliate => affiliate.name, :channel => '100', :tbs => "w"
+        get :video_news,
+            params: {
+              query: '',
+              affiliate: affiliate.name,
+              channel: '100',
+              tbs: 'w'
+            }
       end
 
       it { is_expected.to assign_to(:page_title).with('Videos - NPS Site Search Results') }

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -10,7 +10,7 @@ describe SearchesController do
     render_views
     context "when searching in English" do
       before do
-        get :index, query: 'social security', page: 4, affiliate: 'usagov'
+        get :index, params: { query: 'social security', page: 4, affiliate: 'usagov' }
         @search = assigns[:search]
         @page_title = assigns[:page_title]
       end
@@ -62,7 +62,7 @@ describe SearchesController do
   end
 
   context 'when affiliate is not valid' do
-    before { get :index, query: 'gov', affiliate: { 'foo' => 'bar' } }
+    before { get :index, params: { query: 'gov', affiliate: { 'foo' => 'bar' } } }
     it { is_expected.to redirect_to 'https://www.usa.gov/search-error' }
   end
 
@@ -84,7 +84,7 @@ describe SearchesController do
     let(:affiliate) { affiliates(:search_consumer_affiliate) }
 
     it 'should redirect to the search-consumer display page' do
-      get :index, query: 'matzo balls', affiliate: affiliate.name
+      get :index, params: { query: 'matzo balls', affiliate: affiliate.name }
       expect(response).to redirect_to search_consumer_search_url({query: 'matzo balls', affiliate: affiliate.name})
     end
   end
@@ -99,7 +99,7 @@ describe SearchesController do
       end
 
       it 'redirects to the proper url' do
-        get :index, query: "foo bar", affiliate: affiliate.name
+        get :index, params: { query: "foo bar", affiliate: affiliate.name }
         expect(response).to redirect_to 'http://www.gov.gov/foo.html'
       end
 
@@ -148,7 +148,7 @@ describe SearchesController do
       affiliate.gets_i14y_results = true
       expect(I14ySearch).to receive(:new).and_return(i14y_search)
       expect(i14y_search).to receive(:run)
-      get :index, :query => 'gov', :affiliate => affiliate.name
+      get :index, params: { query: 'gov', affiliate: affiliate.name }
     end
 
     it { is_expected.to assign_to(:affiliate).with(affiliate) }
@@ -174,7 +174,7 @@ describe SearchesController do
       affiliate.search_engine = 'SearchGov'
       expect(I14ySearch).to receive(:new).and_return(i14y_search)
       expect(i14y_search).to receive(:run)
-      get :index, :query => 'gov', :affiliate => affiliate.name
+      get :index, params: { query: 'gov', affiliate: affiliate.name }
     end
 
     it { is_expected.to assign_to(:affiliate).with(affiliate) }
@@ -246,12 +246,12 @@ describe SearchesController do
     let(:affiliate) { affiliates(:power_affiliate) }
 
     it "should maintain the staged parameter for future searches" do
-      get :index, :affiliate => affiliate.name, :query => "weather", :staged => 1
+      get :index, params: { affiliate: affiliate.name, query: 'weather', staged: 1 }
       expect(response.body).to have_selector("input[type='hidden'][value='1'][name='staged']", visible: false)
     end
 
     it "should set an affiliate page title" do
-      get :index, :affiliate => affiliate.name, :query => "weather", :staged => 1
+      get :index, params: { affiliate: affiliate.name, query: 'weather', staged: 1 }
       expect(assigns[:page_title]).to eq("weather - Noaa Site Search Results")
     end
   end
@@ -275,7 +275,7 @@ describe SearchesController do
 
     context "when searching normally" do
       before do
-        get :index, :query => 'weather', :format => "json", affiliate: 'usagov'
+        get :index, params: { query: 'weather', affiliate: 'usagov' }, format: 'json'
         @search = assigns[:search]
       end
 
@@ -288,7 +288,7 @@ describe SearchesController do
 
     context "when some error is returned" do
       before do
-        get :index, :query => 'a' * 1001, :format => "json", affiliate: 'usagov'
+        get :index, params: { query: 'a' * 1001,  affiliate: 'usagov' }, format: 'json'
         @search = assigns[:search]
       end
 
@@ -406,7 +406,7 @@ describe SearchesController do
   end
 
   describe "#advanced" do
-    before { get :advanced, affiliate: 'usagov' }
+    before { get :advanced, params: { affiliate: 'usagov' } }
 
     it { is_expected.to assign_to(:page_title).with_kind_of(String) }
   end

--- a/spec/controllers/sites/alerts_controller_spec.rb
+++ b/spec/controllers/sites/alerts_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::AlertsController do
 
       before do
         expect(site).to receive(:alert).and_return(alert)
-        get :edit, site_id: site.id
+        get :edit, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -40,11 +40,14 @@ describe Sites::AlertsController do
               and_return(true)
 
           put :update,
-               site_id: site.id,
-               alert: { title: 'Updated Title for Alert',
-                        text: 'Some text for the alert.',
-                        status: 'Active',
-                        not_allowed_key: 'not allowed value' }
+              params: {
+                site_id: site.id,
+                alert: { title: 'Updated Title for Alert',
+                         text: 'Some text for the alert.',
+                         status: 'Active',
+                         not_allowed_key: 'not allowed value' }
+              }
+
         end
 
         it { is_expected.to assign_to(:alert).with(alert) }
@@ -64,10 +67,12 @@ describe Sites::AlertsController do
               and_return(false)
 
           put :update,
-              site_id: site.id,
-              alert: { title: 'Title',
-                        text: '',
-                        status: 'Active' }
+              params: {
+                site_id: site.id,
+                alert: { title: 'Title',
+                         text: '',
+                         status: 'Active' }
+              }
         end
 
         it { is_expected.to assign_to(:alert).with(alert) }

--- a/spec/controllers/sites/autodiscoveries_controller_spec.rb
+++ b/spec/controllers/sites/autodiscoveries_controller_spec.rb
@@ -23,14 +23,14 @@ describe Sites::AutodiscoveriesController do
         end
 
         it { is_expected.to redirect_to(site_content_path(site)) }
-        it "should set the flash to reflect success and preserve the autodiscovery_url" do
+        it 'should set the flash to reflect success and preserve the autodiscovery_url' do
           expect(flash[:success]).to match("Discovery complete for #{autodiscovery_url}")
           expect(flash[:autodiscovery_url]).to eq(autodiscovery_url)
         end
       end
 
-      context "when an invalid autodiscovery_url is invalid" do
-        let(:autodiscovery_url) { "http://_" }
+      context 'when an invalid autodiscovery_url is invalid' do
+        let(:autodiscovery_url) { 'http://_' }
         before do
           expect(SiteAutodiscoverer).to receive(:new).with(site, autodiscovery_url).and_raise URI::InvalidURIError
           post :create, params: { site_id: site.id, autodiscovery_url: autodiscovery_url }

--- a/spec/controllers/sites/autodiscoveries_controller_spec.rb
+++ b/spec/controllers/sites/autodiscoveries_controller_spec.rb
@@ -19,7 +19,7 @@ describe Sites::AutodiscoveriesController do
           expect(SiteAutodiscoverer).to receive(:new).with(site, autodiscovery_url).and_return site_autodiscoverer
           expect(site_autodiscoverer).to receive(:run)
           allow(site_autodiscoverer).to receive(:discovered_resources)
-          post :create, site_id: site.id, autodiscovery_url: autodiscovery_url
+          post :create, params: { site_id: site.id, autodiscovery_url: autodiscovery_url }
         end
 
         it { is_expected.to redirect_to(site_content_path(site)) }
@@ -33,7 +33,7 @@ describe Sites::AutodiscoveriesController do
         let(:autodiscovery_url) { "http://_" }
         before do
           expect(SiteAutodiscoverer).to receive(:new).with(site, autodiscovery_url).and_raise URI::InvalidURIError
-          post :create, site_id: site.id, autodiscovery_url: autodiscovery_url
+          post :create, params: { site_id: site.id, autodiscovery_url: autodiscovery_url }
         end
 
         it { is_expected.to redirect_to(site_content_path(site)) }
@@ -45,7 +45,7 @@ describe Sites::AutodiscoveriesController do
 
       context "when no autodiscovery_url is provided" do
         it "raises a 400 error" do
-          post :create, site_id: site.id
+          post :create, params: { site_id: site.id }
           expect(response.status).to eq(400)
         end
       end

--- a/spec/controllers/sites/boosted_contents_bulk_uploads_controller_spec.rb
+++ b/spec/controllers/sites/boosted_contents_bulk_uploads_controller_spec.rb
@@ -21,7 +21,7 @@ describe Sites::BoostedContentsBulkUploadsController do
           allow(BoostedContentBulkUploader).to receive(:new).and_return uploader
           expect(uploader).to receive(:upload).and_return({ created: 3, updated: 2, failed: 1 , success: true })
 
-          post :create, best_bets_text_data_file: data_file, site_id: site.id
+          post :create, params: { best_bets_text_data_file: data_file, site_id: site.id }
         end
 
         it { is_expected.to redirect_to(site_best_bets_texts_path(site)) }
@@ -35,7 +35,7 @@ describe Sites::BoostedContentsBulkUploadsController do
           allow(BoostedContentBulkUploader).to receive(:new).and_return uploader
           expect(uploader).to receive(:upload).and_return({ error_message: 'some error message' })
 
-          post :create, best_bets_text_data_file: data_file, site_id: site.id
+          post :create, params: { best_bets_text_data_file: data_file, site_id: site.id }
         end
 
         it { is_expected.to set_flash.now.to('some error message') }

--- a/spec/controllers/sites/boosted_contents_controller_spec.rb
+++ b/spec/controllers/sites/boosted_contents_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::BoostedContentsController do
 
       before do
         allow(site).to receive_message_chain(:boosted_contents, :substring_match, :paginate, :order).and_return(boosted_contents)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -41,8 +41,11 @@ describe Sites::BoostedContentsController do
           expect(boosted_content).to receive(:save).and_return(true)
 
           post :create,
-               site_id: site.id,
-               boosted_content: { title: 'page title', not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 boosted_content: { title: 'page title',
+                                    not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:boosted_content).with(boosted_content) }
@@ -64,8 +67,10 @@ describe Sites::BoostedContentsController do
           allow(boosted_content).to receive_message_chain(:boosted_content_keywords, :build)
 
           post :create,
-               site_id: site.id,
-               boosted_content: { title: '', not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 boosted_content: { title: '', not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:boosted_content).with(boosted_content) }
@@ -121,7 +126,7 @@ describe Sites::BoostedContentsController do
             and_return(boosted_content)
         expect(boosted_content).to receive(:destroy)
 
-        delete :destroy, site_id: site.id, id: 100
+        delete :destroy, params: { site_id: site.id, id: 100 }
       end
 
       it { is_expected.to redirect_to(site_best_bets_texts_path(site)) }

--- a/spec/controllers/sites/boosted_contents_controller_spec.rb
+++ b/spec/controllers/sites/boosted_contents_controller_spec.rb
@@ -99,9 +99,14 @@ describe Sites::BoostedContentsController do
           allow(boosted_content).to receive_message_chain(:boosted_content_keywords, :build)
 
           put :update,
-              site_id: site.id,
-              id: 100,
-              boosted_content: { title: 'updated title', not_allowed_key: 'not allowed value' }
+              params: {
+                site_id: site.id,
+                id: 100,
+                boosted_content: { 
+                  title: 'updated title',
+                  not_allowed_key: 'not allowed value'
+                }
+              }
         end
 
         it { is_expected.to assign_to(:boosted_content).with(boosted_content) }

--- a/spec/controllers/sites/click_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/click_drilldowns_controller_spec.rb
@@ -17,7 +17,14 @@ describe Sites::ClickDrilldownsController do
       end
 
       it 'should generate a CSV of various click fields' do
-        get :show, site_id: site.id, url:'http://some.gov.url/super_long_so_truncate_at_50/blah.cfm', start_date: '2015-02-01', end_date: '2015-02-05', format: 'csv'
+        get :show,
+            params: {
+              site_id: site.id,
+              url: 'http://some.gov.url/super_long_so_truncate_at_50/blah.cfm',
+              start_date: '2015-02-01', end_date: '2015-02-05'
+            },
+            format: 'csv'
+
         expect(response.content_type).to eq('text/csv')
         expect(response.headers["Content-Disposition"]).to eq("attachment;filename=nps.gov_http://some.gov.url/super_long_so_truncate_at_50/b_2015-02-01_2015-02-05.csv")
         expect(response.body).to start_with(Sites::ClickDrilldownsController::HEADER_FIELDS.to_csv)

--- a/spec/controllers/sites/click_queries_controller_spec.rb
+++ b/spec/controllers/sites/click_queries_controller_spec.rb
@@ -14,7 +14,13 @@ describe Sites::ClickQueriesController do
 
       before do
         allow(RtuTopClicks).to receive(:new).and_return rtu_top_clicks
-        get :show, site_id: site.id, start_date: Date.current, end_date: Date.current, url: 'http://www.url.gov'
+        get :show,
+            params: {
+              site_id: site.id,
+              start_date: Date.current,
+              end_date: Date.current,
+              url: 'http://www.url.gov'
+            }
       end
 
       it { is_expected.to assign_to(:top_queries).with(top_n) }

--- a/spec/controllers/sites/clicks_controller_spec.rb
+++ b/spec/controllers/sites/clicks_controller_spec.rb
@@ -17,7 +17,7 @@ describe Sites::ClicksController do
           start_date: Date.current.beginning_of_month, end_date: Date.current
         ).and_return rtu_clicks_request
         expect(rtu_clicks_request).to receive(:save)
-        get :new, site_id: site.id
+        get :new, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:clicks_request).with(rtu_clicks_request) }
@@ -37,7 +37,11 @@ describe Sites::ClicksController do
         expect(rtu_clicks_request).to receive(:save)
         expect(rtu_clicks_request).to receive(:start_date).and_return "05/01/2014".to_date
         expect(rtu_clicks_request).to receive(:end_date).and_return "05/26/2014".to_date
-        post :create, site_id: site.id, rtu_clicks_request: { start_date: "05/01/2014", end_date: "05/26/2014" }
+        post :create,
+             params: {
+               site_id: site.id,
+               rtu_clicks_request: { start_date: '05/01/2014', end_date: '05/26/2014' }
+             }
       end
 
       it { is_expected.to assign_to(:clicks_request).with(rtu_clicks_request) }

--- a/spec/controllers/sites/displays_controller_spec.rb
+++ b/spec/controllers/sites/displays_controller_spec.rb
@@ -16,9 +16,11 @@ describe Sites::DisplaysController do
           allow(site).to receive_message_chain(:connections, :build)
 
           put :update,
-               site_id: site.id,
-               id: 100,
-               site: { default_search_label: 'Search' }
+              params: {
+                site_id: site.id,
+                id: 100,
+                site: { default_search_label: 'Search' }
+              }
         end
 
         it { is_expected.to redirect_to(edit_site_display_path(site)) }
@@ -34,9 +36,11 @@ describe Sites::DisplaysController do
           allow(site).to receive_message_chain(:connections, :build)
 
           put :update,
-               site_id: site.id,
-               id: 100,
-               site: { default_search_label: 'Search' }
+              params: {
+                site_id: site.id,
+                id: 100,
+                site: { default_search_label: 'Search' }
+              }
         end
 
         it { is_expected.to render_template(:edit) }

--- a/spec/controllers/sites/document_collections_controller_spec.rb
+++ b/spec/controllers/sites/document_collections_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::DocumentCollectionsController do
 
       before do
         expect(site).to receive(:document_collections).and_return(document_collections)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -49,11 +49,15 @@ describe Sites::DocumentCollectionsController do
           expect(email).to receive(:deliver_now)
 
           post :create,
-               site_id: site.id,
-               document_collection: { name: 'News',
-                                      url_prefixes_attributes: { '0' => { prefix: 'some.agency.gov/news',
-                                                                          invalid_key: 'invalid value'} },
-                                      not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 document_collection: { name: 'News',
+                                        url_prefixes_attributes: {
+                                          '0': { prefix: 'some.agency.gov/news',
+                                                 invalid_key: 'invalid value' }
+                                        },
+                                        not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:document_collection).with(document_collection) }
@@ -75,11 +79,15 @@ describe Sites::DocumentCollectionsController do
           allow(document_collection).to receive_message_chain(:url_prefixes, :build)
 
           post :create,
-               site_id: site.id,
-               document_collection: { name: 'News',
-                                      url_prefixes_attributes: { '0' => { prefix: '',
-                                                                          invalid_key: 'invalid value'} },
-                                      not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 document_collection: { name: 'News',
+                                        url_prefixes_attributes: {
+                                          '0': { prefix: '',
+                                                 invalid_key: 'invalid value' }
+                                        },
+                                        not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:document_collection).with(document_collection) }
@@ -109,12 +117,16 @@ describe Sites::DocumentCollectionsController do
           allow(document_collection).to receive_message_chain(:url_prefixes, :build)
 
           put :update,
-               site_id: site.id,
-               id: 100,
-               document_collection: { name: 'News',
-                                      url_prefixes_attributes: { '0' => { prefix: '',
-                                                                          invalid_key: 'invalid value'} },
-                                      not_allowed_key: 'not allowed value' }
+              params: {
+                site_id: site.id,
+                id: 100,
+                document_collection: { name: 'News',
+                                       url_prefixes_attributes: {
+                                         '0': { prefix: '',
+                                                invalid_key: 'invalid value' }
+                                       },
+                                       not_allowed_key: 'not allowed value' }
+              }
         end
 
         it { is_expected.to assign_to(:document_collection).with(document_collection) }

--- a/spec/controllers/sites/excluded_urls_controller_spec.rb
+++ b/spec/controllers/sites/excluded_urls_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::ExcludedUrlsController do
 
       before do
         allow(site).to receive_message_chain(:excluded_urls, :paginate, :order).and_return(excluded_urls)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -41,9 +41,11 @@ describe Sites::ExcludedUrlsController do
           expect(excluded_url).to receive(:save).and_return(true)
 
           post :create,
-               site_id: site.id,
-               excluded_url: { url: 'http://agency.gov/exclude-me.html',
-                               not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 excluded_url: { url: 'http://agency.gov/exclude-me.html',
+                                 not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:excluded_url).with(excluded_url) }
@@ -63,9 +65,11 @@ describe Sites::ExcludedUrlsController do
           expect(excluded_url).to receive(:save).and_return(false)
 
           post :create,
-               site_id: site.id,
-               excluded_url: { url: '',
-                               not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 excluded_url: { url: '',
+                                 not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:excluded_url).with(excluded_url) }
@@ -89,7 +93,7 @@ describe Sites::ExcludedUrlsController do
             and_return(excluded_url)
         expect(excluded_url).to receive(:destroy)
 
-        delete :destroy, site_id: site.id, id: 100
+        delete :destroy, params: { site_id: site.id, id: 100 }
       end
 
       it { is_expected.to redirect_to(site_filter_urls_path(site)) }

--- a/spec/controllers/sites/featured_collections_controller_spec.rb
+++ b/spec/controllers/sites/featured_collections_controller_spec.rb
@@ -130,7 +130,7 @@ describe Sites::FeaturedCollectionsController do
             and_return(featured_collection)
         expect(featured_collection).to receive(:destroy)
 
-        delete :destroy, site_id: site.id, id: 100
+        delete :destroy, params: { site_id: site.id, id: 100 }
       end
 
       it { is_expected.to redirect_to(site_best_bets_graphics_path(site)) }

--- a/spec/controllers/sites/featured_collections_controller_spec.rb
+++ b/spec/controllers/sites/featured_collections_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::FeaturedCollectionsController do
 
       before do
         allow(site).to receive_message_chain(:featured_collections, :substring_match, :paginate, :order).and_return(featured_collections)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -41,8 +41,11 @@ describe Sites::FeaturedCollectionsController do
           expect(featured_collection).to receive(:save).and_return(true)
 
           post :create,
-               site_id: site.id,
-               featured_collection: { title: 'page title', not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 featured_collection: { title: 'page title',
+                                        not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:featured_collection).with(featured_collection) }
@@ -65,8 +68,10 @@ describe Sites::FeaturedCollectionsController do
           allow(featured_collection).to receive_message_chain(:featured_collection_links, :build)
 
           post :create,
-               site_id: site.id,
-               featured_collection: { title: '', not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 featured_collection: { title: '', not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:featured_collection).with(featured_collection) }
@@ -96,9 +101,12 @@ describe Sites::FeaturedCollectionsController do
           allow(featured_collection).to receive_message_chain(:featured_collection_links, :build)
 
           put :update,
-              site_id: site.id,
-              id: 100,
-              featured_collection: { title: 'updated title', not_allowed_key: 'not allowed value' }
+              params: {
+                site_id: site.id,
+                id: 100,
+                featured_collection: { title: 'updated title',
+                                       not_allowed_key: 'not allowed value' }
+              }
         end
 
         it { is_expected.to assign_to(:featured_collection).with(featured_collection) }

--- a/spec/controllers/sites/flickr_profiles_controller_spec.rb
+++ b/spec/controllers/sites/flickr_profiles_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::FlickrProfilesController do
 
       before do
         expect(site).to receive(:flickr_profiles).and_return(flickr_profiles)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -41,8 +41,12 @@ describe Sites::FlickrProfilesController do
           expect(flickr_profile).to receive(:save).and_return(true)
 
           post :create,
-               site_id: site.id,
-               flickr_profile: { url: 'http://www.flickr.com/groups/usagov/', not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 flickr_profile: { url: 'http://www.flickr.com/groups/usagov/',
+                                   not_allowed_key: 'not allowed value'
+                 }
+               }
         end
 
         it { is_expected.to assign_to(:flickr_profile).with(flickr_profile) }
@@ -63,8 +67,12 @@ describe Sites::FlickrProfilesController do
           expect(flickr_profile).to receive(:save).and_return(false)
 
           post :create,
-               site_id: site.id,
-               flickr_profile: { url: 'usagov', not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 flickr_profile: { url: 'usagov',
+                                   not_allowed_key: 'not allowed value'
+                 }
+               }
         end
 
         it { is_expected.to assign_to(:flickr_profile).with(flickr_profile) }
@@ -88,7 +96,7 @@ describe Sites::FlickrProfilesController do
             and_return(flickr_profile)
         expect(flickr_profile).to receive(:destroy)
 
-        delete :destroy, site_id: site.id, id: 100
+        delete :destroy, params: { site_id: site.id, id: 100 }
       end
 
       it { is_expected.to redirect_to(site_flickr_urls_path(site)) }

--- a/spec/controllers/sites/font_and_colors_controller_spec.rb
+++ b/spec/controllers/sites/font_and_colors_controller_spec.rb
@@ -19,8 +19,10 @@ describe Sites::FontAndColorsController do
               and_return(false)
 
           put :update,
-              site_id: site.id,
-              site: { css_property_hash: { font_family: 'Arial, san-serif' } }
+              params: {
+                site_id: site.id,
+                site: { css_property_hash: { font_family: 'Arial, san-serif' } }
+              }
         end
 
         it { is_expected.to render_template(:edit) }

--- a/spec/controllers/sites/i14y_drawers_controller_spec.rb
+++ b/spec/controllers/sites/i14y_drawers_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::I14yDrawersController do
 
       before do
         allow(site).to receive_message_chain(:i14y_drawers).and_return(i14y_drawers)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -44,7 +44,13 @@ describe Sites::I14yDrawersController do
       before do
         allow(site).to receive_message_chain(:i14y_drawers, :find_by_id).and_return i14y_drawer
         expect(I14yCollections).to receive(:search).with(search_params).and_return search_response
-        get :show, site_id: site.id, id: 5, query: 'my query', page: 1
+        get :show,
+            params: {
+              site_id: site.id,
+              id: 5,
+              query: 'my query',
+              page: 1
+            }
       end
 
       it { is_expected.to assign_to(:site).with(site) }

--- a/spec/controllers/sites/image_assets_controller_spec.rb
+++ b/spec/controllers/sites/image_assets_controller_spec.rb
@@ -19,9 +19,15 @@ describe Sites::ImageAssetsController do
               and_return(false)
 
           put :update,
-              site_id: site.id,
-              id: 100,
-              image_asset: { css_property_hash: { page_background_image_repeat: 'repeat-x' } }
+              params: {
+                site_id: site.id,
+                id: 100,
+                image_asset: {
+                  css_property_hash: {
+                    page_background_image_repeat: 'repeat-x'
+                  }
+                }
+              }
         end
 
         it { is_expected.to render_template(:edit) }

--- a/spec/controllers/sites/indexed_documents_controller_spec.rb
+++ b/spec/controllers/sites/indexed_documents_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::IndexedDocumentsController do
 
       before do
         allow(site).to receive_message_chain(:indexed_documents, :by_matching_url, :paginate, :order).and_return(indexed_documents)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -47,11 +47,15 @@ describe Sites::IndexedDocumentsController do
               with(:high, IndexedDocumentFetcher, indexed_document.id)
 
           post :create,
-               site_id: site.id,
-               indexed_document: { url: 'http://search.gov/developer/jobs.html',
-                                   title: 'Jobs API',
-                                   description: 'Helping job seekers land a job with the government.',
-                                   not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 indexed_document: {
+                   url: 'http://search.gov/developer/jobs.html',
+                   title: 'Jobs API',
+                   description: 'Helping job seekers land a job with the government.',
+                   not_allowed_key: 'not allowed value'
+                 }
+               }
         end
 
         it { is_expected.to assign_to(:indexed_document).with(indexed_document) }
@@ -76,11 +80,15 @@ describe Sites::IndexedDocumentsController do
           expect(indexed_document).to receive(:save).and_return(false)
 
           post :create,
-               site_id: site.id,
-               indexed_document: { url: 'http://search.gov/developer/jobs.html',
-                                   title: '',
-                                   description: '',
-                                   not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 indexed_document: {
+                   url: 'http://search.gov/developer/jobs.html',
+                   title: '',
+                   description: '',
+                   not_allowed_key: 'not allowed value'
+                 }
+               }
         end
 
         it { is_expected.to assign_to(:indexed_document).with(indexed_document) }
@@ -106,7 +114,7 @@ describe Sites::IndexedDocumentsController do
             and_return(indexed_document)
         expect(indexed_document).to receive(:destroy)
 
-        delete :destroy, site_id: site.id, id: 100
+        delete :destroy, params: { site_id: site.id, id: 100 }
       end
 
       it { is_expected.to redirect_to(site_supplemental_urls_path(site)) }

--- a/spec/controllers/sites/monthly_reports_controller_spec.rb
+++ b/spec/controllers/sites/monthly_reports_controller_spec.rb
@@ -15,7 +15,7 @@ describe Sites::MonthlyReportsController do
       context 'when valid target month passed in' do
         before do
           expect(RtuMonthlyReport).to receive(:new).with(site, '2014', '06', current_user.sees_filtered_totals).and_return rtu_monthly_report
-          get :show, parms: { mmyyyy: '06/2014', site_id: site.id }
+          get :show, params: { mmyyyy: '06/2014', site_id: site.id }
         end
 
         it { is_expected.to assign_to(:monthly_report).with(rtu_monthly_report) }

--- a/spec/controllers/sites/monthly_reports_controller_spec.rb
+++ b/spec/controllers/sites/monthly_reports_controller_spec.rb
@@ -15,7 +15,7 @@ describe Sites::MonthlyReportsController do
       context 'when valid target month passed in' do
         before do
           expect(RtuMonthlyReport).to receive(:new).with(site, '2014', '06', current_user.sees_filtered_totals).and_return rtu_monthly_report
-          get :show, mmyyyy: '06/2014', site_id: site.id
+          get :show, parms: { mmyyyy: '06/2014', site_id: site.id }
         end
 
         it { is_expected.to assign_to(:monthly_report).with(rtu_monthly_report) }
@@ -26,13 +26,13 @@ describe Sites::MonthlyReportsController do
           expect(RtuMonthlyReport).to receive(:new).
             with(site, Date.current.strftime('%Y'), Date.current.strftime('%m'), current_user.sees_filtered_totals).
             and_return rtu_monthly_report
-          get :show, site_id: site.id
+          get :show, params: { site_id: site.id }
         end
       end
 
       context 'when invalid target month passed in' do
         before do
-          get :show, mmyyyy: 'blah', site_id: site.id
+          get :show, params: { mmyyyy: 'blah', site_id: site.id }
         end
 
         it { is_expected.to assign_to(:monthly_report).with_kind_of(RtuMonthlyReport) }

--- a/spec/controllers/sites/no_results_pages_controller_spec.rb
+++ b/spec/controllers/sites/no_results_pages_controller_spec.rb
@@ -25,9 +25,19 @@ describe Sites::NoResultsPagesController do
               and_return(false)
 
           put :update,
-              site_id: site.id,
-              id: 100,
-              no_results_pages: {"additional_guidance_text"=>"Testadfaf", "managed_no_results_pages_alt_links_attributes"=>{"0"=>{"title"=>"test", "position"=>"0", "url"=>"http://google.com"}}}
+              params: {
+                site_id: site.id,
+                id: 100,
+                no_results_pages: {'additional_guidance_text': 'Testadfaf',
+                                   'managed_no_results_pages_alt_links_attributes': {
+                                     '0': {
+                                       'title': 'test',
+                                       'position': '0',
+                                       'url': 'http://google.com'
+                                     }
+                                   }
+                }
+              }
         end
 
         it { is_expected.to render_template(:edit) }

--- a/spec/controllers/sites/queries_controller_spec.rb
+++ b/spec/controllers/sites/queries_controller_spec.rb
@@ -17,7 +17,7 @@ describe Sites::QueriesController do
           start_date: Date.current.beginning_of_month, end_date: Date.current
         ).and_return rtu_queries_request
         expect(rtu_queries_request).to receive(:save)
-        get :new, site_id: site.id
+        get :new, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:queries_request).with(rtu_queries_request) }
@@ -40,7 +40,14 @@ describe Sites::QueriesController do
         expect(rtu_queries_request).to receive(:save)
         expect(rtu_queries_request).to receive(:start_date).and_return '05/01/2014'.to_date
         expect(rtu_queries_request).to receive(:end_date).and_return '05/26/2014'.to_date
-        post :create, site_id: site.id, rtu_queries_request: { start_date: "05/01/2014", end_date: "05/26/2014", query: "foo" }
+        post :create,
+             params: {
+               site_id: site.id,
+               rtu_queries_request: { start_date: '05/01/2014',
+                                      end_date: '05/26/2014',
+                                      query: 'foo'
+               }
+             }
       end
 
       it_should_behave_like 'an analytics controller'

--- a/spec/controllers/sites/query_clicks_controller_spec.rb
+++ b/spec/controllers/sites/query_clicks_controller_spec.rb
@@ -14,7 +14,13 @@ describe Sites::QueryClicksController do
 
       before do
         allow(RtuTopClicks).to receive(:new).and_return rtu_top_clicks
-        get :show, site_id: site.id, start_date: Date.current, end_date: Date.current, query: 'foo'
+        get :show,
+            params: {
+              site_id: site.id,
+              start_date: Date.current,
+              end_date: Date.current,
+              query: 'foo'
+            }
       end
 
       it { is_expected.to assign_to(:top_urls).with(top_n) }

--- a/spec/controllers/sites/query_downloads_controller_spec.rb
+++ b/spec/controllers/sites/query_downloads_controller_spec.rb
@@ -20,7 +20,13 @@ describe Sites::QueryDownloadsController do
       end
 
       it 'should generate a CSV of human and bot traffic for some date range, sorted by human count' do
-        get :show, site_id: site.id, start_date: '2014-06-08', end_date: '2014-06-14', format: 'csv'
+        get :show,
+            params: {
+              site_id: site.id,
+              start_date: '2014-06-08',
+              end_date: '2014-06-14',
+              format: 'csv'
+            }
         expect(response.content_type).to eq("text/csv")
         expect(response.headers["Content-Disposition"]).to eq("attachment;filename=nps.gov_2014-06-08_2014-06-14.csv")
         expect(response.body).to start_with("Search Term,Real (Humans only) Queries,Real Clicks,Real CTR,Total (Bots + Humans) Queries,Total Clicks,Total CTR\njobs,9,15,166.7%,10,15,150.0%\nchartres,1,20,2000.0%,1,1,100.0%\n")

--- a/spec/controllers/sites/query_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/query_drilldowns_controller_spec.rb
@@ -17,7 +17,15 @@ describe Sites::QueryDrilldownsController do
       end
 
       it 'should generate a CSV of various query fields' do
-        get :show, query:'foo bar', start_date: '2015-02-01', end_date: '2015-02-05', format: 'csv', site_id: site.id
+        get :show,
+            params: {
+              query: 'foo bar',
+              start_date: '2015-02-01',
+              end_date: '2015-02-05',
+              site_id: site.id
+            },
+            format: 'csv'
+
         expect(response.content_type).to eq('text/csv')
         expect(response.headers["Content-Disposition"]).to eq("attachment;filename=nps.gov_foo_bar_2015-02-01_2015-02-05.csv")
         expect(response.body).to start_with(Sites::QueryDrilldownsController::HEADER_FIELDS.to_csv)

--- a/spec/controllers/sites/query_referrers_controller_spec.rb
+++ b/spec/controllers/sites/query_referrers_controller_spec.rb
@@ -14,7 +14,13 @@ describe Sites::QueryReferrersController do
 
       before do
         allow(RtuTopQueries).to receive(:new).and_return rtu_top_queries
-        get :show, site_id: site.id, start_date: Date.current, end_date: Date.current, query: 'foo'
+        get :show,
+            params: {
+              site_id: site.id,
+              start_date: Date.current,
+              end_date: Date.current,
+              query: 'foo'
+            }
       end
 
       it { is_expected.to assign_to(:top_urls).with(top_n) }

--- a/spec/controllers/sites/referrer_queries_controller_spec.rb
+++ b/spec/controllers/sites/referrer_queries_controller_spec.rb
@@ -14,7 +14,13 @@ describe Sites::ReferrerQueriesController do
 
       before do
         allow(RtuTopQueries).to receive(:new).and_return rtu_top_queries
-        get :show, site_id: site.id, start_date: Date.current, end_date: Date.current, url: 'http://www.url.gov'
+        get :show,
+            parms: {
+              site_id: site.id,
+              start_date: Date.current,
+              end_date: Date.current,
+              url: 'http://www.url.gov'
+            }
       end
 
       it { is_expected.to assign_to(:top_queries).with(top_n) }

--- a/spec/controllers/sites/referrer_queries_controller_spec.rb
+++ b/spec/controllers/sites/referrer_queries_controller_spec.rb
@@ -15,7 +15,7 @@ describe Sites::ReferrerQueriesController do
       before do
         allow(RtuTopQueries).to receive(:new).and_return rtu_top_queries
         get :show,
-            parms: {
+            params: {
               site_id: site.id,
               start_date: Date.current,
               end_date: Date.current,

--- a/spec/controllers/sites/referrers_controller_spec.rb
+++ b/spec/controllers/sites/referrers_controller_spec.rb
@@ -17,7 +17,7 @@ describe Sites::ReferrersController do
           start_date: Date.current.beginning_of_month, end_date: Date.current
         ).and_return rtu_referrers_request
         expect(rtu_referrers_request).to receive(:save)
-        get :new, site_id: site.id
+        get :new, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:referrers_request).with(rtu_referrers_request) }
@@ -37,7 +37,14 @@ describe Sites::ReferrersController do
         expect(rtu_referrers_request).to receive(:save)
         expect(rtu_referrers_request).to receive(:start_date).and_return "05/01/2014".to_date
         expect(rtu_referrers_request).to receive(:end_date).and_return "05/26/2014".to_date
-        post :create, site_id: site.id, rtu_referrers_request: { start_date: "05/01/2014", end_date: "05/26/2014" }
+        post :create,
+             params: {
+               site_id: site.id,
+               rtu_referrers_request: {
+                 start_date: '05/01/2014',
+                 end_date: '05/26/2014'
+               }
+             }
       end
 
       it { is_expected.to assign_to(:referrers_request).with(rtu_referrers_request) }

--- a/spec/controllers/sites/routed_queries_controller_spec.rb
+++ b/spec/controllers/sites/routed_queries_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::RoutedQueriesController do
 
       before do
         expect(site).to receive(:routed_queries).and_return(routed_queries)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -36,7 +36,7 @@ describe Sites::RoutedQueriesController do
         allow(routed_query).to receive_message_chain(:routed_query_keywords, :build).and_return(mock_model(RoutedQueryKeyword))
         expect(routed_queries).to receive(:build).and_return(routed_query)
 
-        get :new, site_id: site.id
+        get :new, params: { site_id: site.id }
       end
 
       it { is_expected.to render_template(:new) }
@@ -72,8 +72,10 @@ describe Sites::RoutedQueriesController do
         expect(routed_query).to receive(:save).and_return(!keyword.blank?)
 
         post :create,
-             site_id: site.id,
-             routed_query: attrs.merge('not_allowed_key' => 'not allowed value')
+             params: {
+               site_id: site.id,
+               routed_query: attrs.merge('not_allowed_key': 'not allowed value')
+             }
       end
 
       context 'when routed query params are valid' do
@@ -111,8 +113,10 @@ describe Sites::RoutedQueriesController do
         allow(routed_query).to receive_message_chain(:routed_query_keywords, :empty?).and_return(keyword.blank?)
 
         get :edit,
-            site_id: site.id,
-            id: 100
+            params: {
+              site_id: site.id,
+              id: 100
+            }
       end
 
       context 'when routed query params are valid' do
@@ -151,9 +155,11 @@ describe Sites::RoutedQueriesController do
         allow(routed_query).to receive_message_chain(:routed_query_keywords, :build).and_return(mock_model(RoutedQueryKeyword))
 
         put :update,
-            site_id: site.id,
-            id: 100,
-            routed_query: attrs
+            params: {
+              site_id: site.id,
+              id: 100,
+              routed_query: attrs
+            }
       end
 
       context 'when routed query params are valid' do
@@ -187,7 +193,11 @@ describe Sites::RoutedQueriesController do
         expect(routed_queries).to receive(:find_by_id).with('100').and_return(routed_query)
         expect(routed_query).to receive(:destroy)
 
-        delete :destroy, site_id: site.id, id: 100
+        delete :destroy,
+               params: {
+                 site_id: site.id,
+                 id: 100
+               }
       end
 
       it { is_expected.to assign_to(:routed_query).with(routed_query) }
@@ -203,7 +213,11 @@ describe Sites::RoutedQueriesController do
       include_context 'approved user logged in to a site'
 
       before do
-        xhr :get, :new_routed_query_keyword, site_id: site.id, index: 0, format: :js
+        xhr :get,
+            :new_routed_query_keyword,
+            params: { site_id: site.id,
+                      index: 0 },
+            format: :js
       end
 
       it { is_expected.to render_template(:new_routed_query_keyword) }

--- a/spec/controllers/sites/rss_feeds_controller_spec.rb
+++ b/spec/controllers/sites/rss_feeds_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::RssFeedsController do
 
       before do
         expect(site).to receive(:rss_feeds).and_return(rss_feeds)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -46,11 +46,17 @@ describe Sites::RssFeedsController do
           expect(rss_feed).to receive(:save).and_return(true)
 
           post :create,
-               site_id: site.id,
-               rss_feed: { name: 'Recalls',
-                           show_only_media_content: 'false',
-                           rss_feed_urls_attributes: { '0' => { url: 'some.agency.gov/news.atom' } },
-                           not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 rss_feed: { name: 'Recalls',
+                             show_only_media_content: 'false',
+                             rss_feed_urls_attributes: {
+                               '0': {
+                                 url: 'some.agency.gov/news.atom'
+                               }
+                             },
+                             not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:rss_feed).with(rss_feed) }
@@ -77,11 +83,17 @@ describe Sites::RssFeedsController do
           allow(rss_feed).to receive_message_chain(:rss_feed_urls, :build)
 
           post :create,
-               site_id: site.id,
-               rss_feed: { name: 'Recalls',
-                           show_only_media_content: 'false',
-                           rss_feed_urls_attributes: { '0' => { url: 'some.agency.gov/news.atom' } },
-                           not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 rss_feed: { name: 'Recalls',
+                             show_only_media_content: 'false',
+                             rss_feed_urls_attributes: {
+                               '0': {
+                                 url: 'some.agency.gov/news.atom'
+                               }
+                             },
+                             not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:rss_feed).with(rss_feed) }
@@ -116,12 +128,14 @@ describe Sites::RssFeedsController do
           allow(rss_feed).to receive_message_chain(:rss_feed_urls, :build)
 
           put :update,
-              site_id: site.id,
-              id: 100,
-              rss_feed: { name: 'Recalls',
-                          show_only_media_content: 'false',
-                          rss_feed_urls_attributes: { '0' => { url: 'some.agency.gov/news.atom' } },
-                          not_allowed_key: 'not allowed value' }
+              params: {
+                site_id: site.id,
+                id: 100,
+                rss_feed: { name: 'Recalls',
+                            show_only_media_content: 'false',
+                            rss_feed_urls_attributes: { '0' => { url: 'some.agency.gov/news.atom' } },
+                            not_allowed_key: 'not allowed value' }
+              }
         end
 
         it { is_expected.to assign_to(:rss_feed).with(rss_feed) }
@@ -144,7 +158,7 @@ describe Sites::RssFeedsController do
         allow(rss_feeds).to receive_message_chain(:non_managed, :find_by_id).with('100').and_return(rss_feed)
         expect(rss_feed).to receive(:destroy)
 
-        delete :destroy, site_id: site.id, id: 100
+        delete :destroy, params: { site_id: site.id, id: 100 }
       end
 
       it { is_expected.to redirect_to(site_rss_feeds_path(site)) }

--- a/spec/controllers/sites/settings_controller_spec.rb
+++ b/spec/controllers/sites/settings_controller_spec.rb
@@ -32,10 +32,12 @@ describe Sites::SettingsController do
             and_return true
 
         put :update,
-            site_id: site.id,
-            site: { display_name: 'new name',
-                    website: 'search.gov',
-                    not_allowed_key: 'not allowed value' }
+            params: {
+              site_id: site.id,
+              site: { display_name: 'new name',
+                      website: 'search.gov',
+                      not_allowed_key: 'not allowed value' }
+            }
       end
 
       it { is_expected.to redirect_to edit_site_setting_path(site) }
@@ -51,8 +53,10 @@ describe Sites::SettingsController do
             and_return false
 
         put :update,
-            site_id: site.id,
-            site: { display_name: 'new name', not_allowed_key: 'not allowed value' }
+            params: {
+              site_id: site.id,
+              site: { display_name: 'new name', not_allowed_key: 'not allowed value' }
+            }
       end
 
       it { is_expected.to render_template :edit }

--- a/spec/controllers/sites/site_domains_controller_spec.rb
+++ b/spec/controllers/sites/site_domains_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::SiteDomainsController do
 
       before do
         expect(site).to receive(:site_domains).and_return(site_domains)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -43,9 +43,11 @@ describe Sites::SiteDomainsController do
           expect(site).to receive(:assign_sitelink_generator_names!)
 
           post :create,
-               site_id: site.id,
-               site_domain: { domain: 'usa.gov',
-                              not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 site_domain: { domain: 'usa.gov',
+                                not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:site_domain).with(site_domain) }
@@ -66,9 +68,11 @@ describe Sites::SiteDomainsController do
           expect(site_domain).to receive(:save).and_return(false)
 
           post :create,
-               site_id: site.id,
-               site_domain: { domain: 'gov',
-                              not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 site_domain: { domain: 'gov',
+                                not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:site_domain).with(site_domain) }
@@ -97,10 +101,12 @@ describe Sites::SiteDomainsController do
               and_return(false)
 
           put :update,
-               site_id: site.id,
-               id: 100,
-               site_domain: { domain: 'gov',
-                              not_allowed_key: 'not allowed value' }
+              params: {
+                site_id: site.id,
+                id: 100,
+                site_domain: { domain: 'gov',
+                               not_allowed_key: 'not allowed value' }
+              }
         end
 
         it { is_expected.to assign_to(:site_domain).with(site_domain) }

--- a/spec/controllers/sites/site_feed_urls_controller_spec.rb
+++ b/spec/controllers/sites/site_feed_urls_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::SiteFeedUrlsController do
 
       before do
         expect(site).to receive(:site_feed_url).and_return(site_feed_url)
-        get :edit, site_id: site.id
+        get :edit, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -43,9 +43,11 @@ describe Sites::SiteFeedUrlsController do
               with(:high, SiteFeedUrlFetcher, site_feed_url.id)
 
           put :update,
-               site_id: site.id,
-               site_feed_url: { rss_url: 'http://search.gov/all.atom',
-                                not_allowed_key: 'not allowed value' }
+              params: {
+                site_id: site.id,
+                site_feed_url: { rss_url: 'http://search.gov/all.atom',
+                                 not_allowed_key: 'not allowed value' }
+              }
         end
 
         it { is_expected.to assign_to(:site_feed_url).with(site_feed_url) }
@@ -65,9 +67,11 @@ describe Sites::SiteFeedUrlsController do
               and_return(false)
 
           put :update,
-              site_id: site.id,
-              site_feed_url: { rss_url: '',
-                               not_allowed_key: 'not allowed value' }
+              params: {
+                site_id: site.id,
+                site_feed_url: { rss_url: '',
+                                 not_allowed_key: 'not allowed value' }
+              }
         end
 
         it { is_expected.to assign_to(:site_feed_url).with(site_feed_url) }
@@ -87,7 +91,7 @@ describe Sites::SiteFeedUrlsController do
         expect(site).to receive(:site_feed_url).and_return(site_feed_url)
         expect(site_feed_url).to receive(:destroy)
 
-        delete :destroy, site_id: site.id, id: 100
+        delete :destroy, params: { site_id: site.id, id: 100 }
       end
 
       it { is_expected.to redirect_to(edit_site_supplemental_feed_path(site)) }

--- a/spec/controllers/sites/sites_controller_spec.rb
+++ b/spec/controllers/sites/sites_controller_spec.rb
@@ -171,18 +171,18 @@ describe Sites::SitesController do
 
       it 'should enqueue destruction of affiliate' do
         expect(Resque).to receive(:enqueue_with_priority).with(:low, SiteDestroyer, site.id)
-        delete :destroy, id: site.id
+        delete :destroy, params: { id: site.id }
       end
 
       it 'deactivates the site' do
         expect(site).to receive(:update_attributes!).with(active: false)
         expect(site).to receive(:user_ids=).with([])
-        delete :destroy, id: site.id
+        delete :destroy, params: { id: site.id }
       end
 
       context 'when successful' do
         before do
-          delete :destroy, id: site.id
+          delete :destroy, params: { id: site.id }
         end
 
         it { is_expected.to redirect_to(new_site_path) }

--- a/spec/controllers/sites/sites_controller_spec.rb
+++ b/spec/controllers/sites/sites_controller_spec.rb
@@ -57,7 +57,7 @@ describe Sites::SitesController do
     context 'when logged in as affiliate' do
       include_context 'approved user logged in to a site'
 
-      before { get :show, id: site.id }
+      before { get :show, params: { id: site.id } }
 
       it { is_expected.to assign_to(:site).with(site) }
     end
@@ -65,7 +65,7 @@ describe Sites::SitesController do
     context 'when logged in as affiliate and when the site is no longer accessible' do
       include_context 'approved user logged in'
 
-      before { get :show, id: -1 }
+      before { get :show, params: { id: -1 } }
 
       it { is_expected.to redirect_to(sites_path) }
     end
@@ -73,7 +73,7 @@ describe Sites::SitesController do
     context 'when logged in as super admin' do
       include_context 'super admin logged in to a site'
 
-      before { get :show, id: site.id }
+      before { get :show, params: { id: site.id } }
 
       it { is_expected.to assign_to(:site).with(site) }
     end
@@ -81,7 +81,7 @@ describe Sites::SitesController do
     context 'when logged in as super admin and when the site is no longer accessible' do
       include_context 'super admin logged in'
 
-      before { get :show, id: -1 }
+      before { get :show, params: { id: -1 } }
 
       it { is_expected.to redirect_to(sites_path) }
     end
@@ -93,7 +93,7 @@ describe Sites::SitesController do
 
       before do
         expect(RtuDashboard).to receive(:new).with(site, Date.current, current_user.sees_filtered_totals).and_return dashboard
-        get :show, id: site.id
+        get :show, params: { id: site.id }
       end
 
       it { is_expected.to assign_to(:dashboard).with(dashboard) }
@@ -126,10 +126,14 @@ describe Sites::SitesController do
 
           expect(Emailer).to receive(:new_affiliate_site).and_return(emailer)
           post :create,
-               site: { display_name: 'New Aff',
-                       locale: 'es',
-                       name: 'newaff',
-                       site_domains_attributes: { '0' => { domain: 'http://www.brandnew.gov' } },}
+               params: {
+                 site: { display_name: 'New Aff',
+                         locale: 'es',
+                         name: 'newaff',
+                         site_domains_attributes: {
+                           '0': { domain: 'http://www.brandnew.gov' }
+                         } }
+               }
         end
 
         it { is_expected.to redirect_to(site_path(site)) }
@@ -150,7 +154,7 @@ describe Sites::SitesController do
       before do
         request.env['HTTP_REFERER'] = site_path(site)
         expect(current_user).to receive(:update_attributes!).with(default_affiliate: site)
-        put :pin, id: site.id
+        put :pin, params: { id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }

--- a/spec/controllers/sites/templated_font_and_colors_controller_spec.rb
+++ b/spec/controllers/sites/templated_font_and_colors_controller_spec.rb
@@ -20,20 +20,24 @@ describe Sites::TemplatedFontAndColorsController do
         expect(User).to receive(:find_by_id).and_return(current_user)
       end
 
-      it "resets the template if the checkbox is selected" do
+      it 'resets the template if the checkbox is selected' do
         put :update,
-            site_id: affiliate.id,
-            reset_theme: true,
-            schema: { css_property_hash: { font_family: 'Arial, san-serif' } }
+            params: {
+              site_id: affiliate.id,
+              reset_theme: true,
+              schema: { css_property_hash: { font_family: 'Arial, san-serif' } }
+            }
 
             expect(response).to redirect_to  :edit_site_templated_font_and_colors
       end
 
-      it "should reset the template if the checkbox is selected" do
+      it 'should reset the template if the checkbox is selected' do
         put :update,
-            site_id: affiliate.id,
-            reset_theme: true,
-            schema: { css_property_hash: { font_family: 'Arial, san-serif' } }
+            params: {
+              site_id: affiliate.id,
+              reset_theme: true,
+              schema: { css_property_hash: { font_family: 'Arial, san-serif' } }
+            }
 
             expect(response).to redirect_to  :edit_site_templated_font_and_colors
       end

--- a/spec/controllers/sites/templates_controller_spec.rb
+++ b/spec/controllers/sites/templates_controller_spec.rb
@@ -11,7 +11,7 @@ describe Sites::TemplatesController do
     let(:affiliate) { affiliates(:usagov_affiliate) }
     let(:template) { Template.find_by_name("IRS") }
     let(:update_template) do
-      put :update, site_id: affiliate.id, site: { template_id: template.id }
+      put :update, params: { site_id: affiliate.id, site: { template_id: template.id } }
     end
 
     it_should_behave_like 'restricted to approved user', :put, :update, site_id: 100

--- a/spec/controllers/sites/twitter_profiles_controller_spec.rb
+++ b/spec/controllers/sites/twitter_profiles_controller_spec.rb
@@ -16,7 +16,7 @@ describe Sites::TwitterProfilesController do
 
       before do
         expect(site).to receive(:twitter_profiles).and_return(twitter_profiles)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -52,9 +52,14 @@ describe Sites::TwitterProfilesController do
                    show_lists: '1')
 
           post :create,
-               site_id: site.id,
-               twitter_profile: { screen_name: 'usasearch', not_allowed_key: 'not allowed value' },
-               show_lists: 1
+               params: {
+                 site_id: site.id,
+                 twitter_profile: {
+                   screen_name: 'usasearch',
+                   not_allowed_key: 'not allowed value'
+                 },
+                 show_lists: 1
+               }
         end
 
         it { is_expected.to redirect_to(site_twitter_handles_path(site)) }
@@ -82,8 +87,13 @@ describe Sites::TwitterProfilesController do
               and_return(new_twitter_profile)
 
           post :create,
-               site_id: site.id,
-               twitter_profile: { screen_name: 'usasearch', not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 twitter_profile: {
+                   screen_name: 'usasearch',
+                   not_allowed_key: 'not allowed value'
+                 }
+               }
         end
 
         it { is_expected.to assign_to(:profile).with(new_twitter_profile) }
@@ -101,8 +111,12 @@ describe Sites::TwitterProfilesController do
               and_return(new_twitter_profile)
 
           post :create,
-               site_id: site.id,
-               twitter_profile: { screen_name: 'invalid handle', not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 twitter_profile: { screen_name: 'invalid handle',
+                                    not_allowed_key: 'not allowed value'
+                 }
+               }
         end
 
         it { is_expected.to assign_to(:profile).with(new_twitter_profile) }
@@ -126,7 +140,7 @@ describe Sites::TwitterProfilesController do
             and_return(twitter_profile)
         expect(twitter_profiles).to receive(:delete).with(twitter_profile)
 
-        delete :destroy, site_id: site.id, id: 100
+        delete :destroy, params: { site_id: site.id, id: 100 }
       end
 
       it { is_expected.to redirect_to(site_twitter_handles_path(site)) }

--- a/spec/controllers/sites/users_controller_spec.rb
+++ b/spec/controllers/sites/users_controller_spec.rb
@@ -16,7 +16,7 @@ describe Sites::UsersController do
 
       before do
         expect(site).to receive(:users).and_return site_users
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with site }
@@ -30,7 +30,7 @@ describe Sites::UsersController do
     context 'when logged in as affiliate' do
       include_context 'approved user logged in to a site'
 
-      before { get :new, site_id: site.id }
+      before { get :new, params: { site_id: site.id } }
 
       it { is_expected.to assign_to(:site).with site }
       it { is_expected.to assign_to(:user).with_kind_of(User) }
@@ -57,10 +57,12 @@ describe Sites::UsersController do
             with(site, "User #{current_user.id}, affiliate_manager@fixtures.org")
 
           post :create,
-               site_id: site.id,
-               user: { contact_name: 'John Doe',
-                       email: 'john@email.gov',
-                       not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 user: { contact_name: 'John Doe',
+                         email: 'john@email.gov',
+                         not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:user).with(new_user) }
@@ -79,10 +81,12 @@ describe Sites::UsersController do
 
           expect(new_user).to receive(:save).and_return(false)
           post :create,
-               site_id: site.id,
-               user: { contact_name: '',
-                       email: 'john@email.gov',
-                       not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 user: { contact_name: '',
+                         email: 'john@email.gov',
+                         not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to assign_to(:user).with(new_user) }
@@ -102,9 +106,11 @@ describe Sites::UsersController do
             with(site, "User #{current_user.id}, affiliate_manager@fixtures.org")
 
           post :create,
-               site_id: site.id,
-               user: { contact_name: 'John Doe',
-                       email: 'john@email.gov' }
+               params: {
+                 site_id: site.id,
+                 user: { contact_name: 'John Doe',
+                         email: 'john@email.gov' }
+               }
         end
 
         it { is_expected.to assign_to(:user).with(new_user) }
@@ -126,9 +132,11 @@ describe Sites::UsersController do
               and_return(new_user)
 
           post :create,
-               site_id: site.id,
-               user: { contact_name: 'John Doe',
-                       email: 'john@email.gov' }
+               params: {
+                 site_id: site.id,
+                 user: { contact_name: 'John Doe',
+                         email: 'john@email.gov' }
+               }
         end
 
         it { is_expected.to assign_to(:user).with(new_user) }
@@ -155,8 +163,10 @@ describe Sites::UsersController do
           with(site, "User #{current_user.id}, affiliate_manager@fixtures.org")
 
         put :destroy,
-            id: 100,
-            site_id: site.id
+            params: {
+              id: 100,
+              site_id: site.id
+            }
       end
     end
   end

--- a/spec/controllers/sites/youtube_profiles_controller_spec.rb
+++ b/spec/controllers/sites/youtube_profiles_controller_spec.rb
@@ -82,12 +82,13 @@ describe Sites::YoutubeProfilesController do
               and_return(new_youtube_profile)
 
           post :create,
-                 params: {
-                   site_id: site.id,
-                   youtube_profile: {
-                     not_allowed_key: 'not allowed value',
-                     url: 'youtube.com/channel/us_government_channel_id' }
+               params: {
+                 site_id: site.id,
+                 youtube_profile: {
+                   not_allowed_key: 'not allowed value',
+                   url: 'youtube.com/channel/us_government_channel_id'
                  }
+               }
         end
 
         it { is_expected.to assign_to(:profile).with(new_youtube_profile) }

--- a/spec/controllers/sites/youtube_profiles_controller_spec.rb
+++ b/spec/controllers/sites/youtube_profiles_controller_spec.rb
@@ -14,7 +14,7 @@ describe Sites::YoutubeProfilesController do
 
       before do
         expect(site).to receive(:youtube_profiles).and_return(youtube_profiles)
-        get :index, site_id: site.id
+        get :index, params: { site_id: site.id }
       end
 
       it { is_expected.to assign_to(:site).with(site) }
@@ -47,10 +47,12 @@ describe Sites::YoutubeProfilesController do
           expect(site).to receive(:enable_video_govbox!)
 
           post :create,
-               site_id: site.id,
-               youtube_profile: {
-                 url: 'youtube.com/channel/us_government_channel_id',
-                 not_allowed_key: 'not allowed value' }
+               params: {
+                 site_id: site.id,
+                 youtube_profile: {
+                   url: 'youtube.com/channel/us_government_channel_id',
+                   not_allowed_key: 'not allowed value' }
+               }
         end
 
         it { is_expected.to redirect_to(site_youtube_channels_path(site)) }
@@ -80,10 +82,12 @@ describe Sites::YoutubeProfilesController do
               and_return(new_youtube_profile)
 
           post :create,
-               site_id: site.id,
-               youtube_profile: {
-                 not_allowed_key: 'not allowed value',
-                 url: 'youtube.com/channel/us_government_channel_id' }
+                 params: {
+                   site_id: site.id,
+                   youtube_profile: {
+                     not_allowed_key: 'not allowed value',
+                     url: 'youtube.com/channel/us_government_channel_id' }
+                 }
         end
 
         it { is_expected.to assign_to(:profile).with(new_youtube_profile) }
@@ -103,10 +107,12 @@ describe Sites::YoutubeProfilesController do
               and_return(new_youtube_profile)
 
           post :create,
-               site_id: site.id,
-               youtube_profile: {
-                 url: 'youtube.com/user/dgsearch',
-                 not_allowed_key: 'not allowed value' }
+               params: { site_id: site.id,
+                         youtube_profile: {
+                           url: 'youtube.com/user/dgsearch',
+                           not_allowed_key: 'not allowed value'
+                         }
+               }
         end
 
         it { is_expected.to assign_to(:profile).with(new_youtube_profile) }
@@ -132,7 +138,7 @@ describe Sites::YoutubeProfilesController do
         expect(youtube_profiles).to receive(:exists?).and_return(false)
         expect(site).to receive(:disable_video_govbox!)
 
-        delete :destroy, site_id: site.id, id: 100
+        delete :destroy, params: { site_id: site.id, id: 100 }
       end
 
       it { is_expected.to redirect_to(site_youtube_channels_path(site)) }

--- a/spec/controllers/statuses_controller_spec.rb
+++ b/spec/controllers/statuses_controller_spec.rb
@@ -11,7 +11,7 @@ describe StatusesController do
       expect(OutboundRateLimitStatus).to receive(:find_by_name).
         with('google_api').
         and_return(rate_limit_status)
-      get :outbound_rate_limit, name: 'google_api', format: 'text'
+      get :outbound_rate_limit, params: { name: 'google_api', format: 'text' }
     end
 
     it { is_expected.to respond_with :success }
@@ -25,7 +25,7 @@ describe StatusesController do
     fixtures :affiliates
 
     before do
-      get :domain_control_validation, affiliate: affiliate.name, format: 'text'
+      get :domain_control_validation, params: { affiliate: affiliate.name, format: 'text' }
     end
 
     context 'when the affiliate does not have a DCV code' do

--- a/spec/controllers/user_sessions_controller_spec.rb
+++ b/spec/controllers/user_sessions_controller_spec.rb
@@ -13,7 +13,13 @@ describe UserSessionsController do
   describe "#create" do
     let(:user) { users(:affiliate_manager) }
     let(:post_create) do
-      post :create, user_session: { email: user.email, password: user.password }
+      post :create,
+           params: {
+             user_session: {
+               email: user.email,
+               password: user.password
+             }
+           }
     end
 
     it 'filters passwords in the logfile' do
@@ -30,18 +36,30 @@ describe UserSessionsController do
       it { is_expected.to render_template(:new) }
     end
 
-    context "when the user session fails to save" do
+    context 'when the user session fails to save' do
       before do
-        post :create, :user_session => {:email => "invalid@fixtures.org", :password => "admin"}
+        post :create,
+             params: {
+               user_session: {
+                 email: 'invalid@fixtures.org',
+                 password: 'admin'
+               }
+             }
       end
 
       it { is_expected.to render_template(:new) }
     end
   end
 
-  describe "do POST on create for developer" do
-    it "should redirect to affiliate home page" do
-      post :create, :user_session => {:email => users("developer").email, :password => "test1234!"}
+  describe 'do POST on create for developer' do
+    it 'should redirect to affiliate home page' do
+      post :create,
+           params: {
+             user_session: {
+               email: users('developer').email,
+               password: 'test1234!'
+             }
+           }
       expect(response).to redirect_to(developer_redirect_url)
     end
   end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -9,7 +9,9 @@ describe UsersController do
   let(:permitted_params) { %i(contact_name organization_name email password) }
 
   describe '#create' do
-    it { is_expected.to permit(*permitted_params).for(:create, params: { user: user_params }) }
+    it do
+      is_expected.to permit(*permitted_params).for(:create, params: { user: user_params })
+    end
 
     context 'when the User#save was successful and User has government affiliated email' do
       let(:user) do
@@ -21,7 +23,7 @@ describe UsersController do
       before do
         expect(User).to receive(:new).and_return(user)
         expect(user).to receive(:save).and_return(true)
-        post :create, user: user_params
+        post :create, params: { user: user_params }
       end
 
       it { is_expected.to assign_to(:user).with(user) }
@@ -39,7 +41,7 @@ describe UsersController do
       before do
         expect(User).to receive(:new).and_return(user)
         expect(user).to receive(:save).and_return(true)
-        post :create, user: user_params
+        post :create, params: { user: user_params }
       end
 
       it { is_expected.to assign_to(:user).with(user) }
@@ -57,7 +59,7 @@ describe UsersController do
       before do
         expect(User).to receive(:new).and_return(user)
         expect(user).to receive(:save).and_return(false)
-        post :create, user: user_params
+        post :create, params: { user: user_params }
       end
 
       it { is_expected.to assign_to(:user).with(user) }
@@ -70,7 +72,7 @@ describe UsersController do
       before { activate_authlogic }
       include_context 'approved user logged in'
 
-      before { get :show, id: current_user.id }
+      before { get :show, params: { id: current_user.id } }
 
       it { is_expected.to assign_to(:user).with(current_user) }
     end
@@ -81,7 +83,7 @@ describe UsersController do
       before { activate_authlogic }
       include_context 'approved user logged in'
 
-      before { get :edit, id: current_user.id }
+      before { get :edit, params: { id: current_user.id } }
 
       it { is_expected.to assign_to(:user).with(current_user) }
     end
@@ -90,8 +92,8 @@ describe UsersController do
   describe '#update' do
     let(:update_user) do
       post :update,
-           id: current_user.id,
-           user: update_params
+           params: { id: current_user.id,
+                     user: update_params }
     end
 
     let(:update_params) do
@@ -103,7 +105,9 @@ describe UsersController do
       before { activate_authlogic }
       include_context 'approved user logged in'
 
-      it { is_expected.to permit(*permitted_params).for(:update, params: { user: update_params }) }
+      it do
+        is_expected.to permit(*permitted_params).for(:update, params: { user: update_params })
+      end
 
       context 'when changing the password' do
         let(:update_params) do
@@ -153,23 +157,23 @@ describe UsersController do
       UserSession.create(@user)
     end
 
-    describe "do GET on show" do
-      it "should redirect the developer to the USA.gov developer page" do
-        get :show, :id => @user.id
+    describe 'do GET on show' do
+      it 'should redirect the developer to the USA.gov developer page' do
+        get :show, params: { id: @user.id }
         expect(response).to redirect_to(developer_redirect_url)
       end
     end
 
-    describe "do GET on edit" do
-      it "should redirect the developer to the USA.gov developer page" do
-        get :edit, :id => @user.id
+    describe 'do GET on edit' do
+      it 'should redirect the developer to the USA.gov developer page' do
+        get :edit, params: { id: @user.id }
         expect(response).to redirect_to(developer_redirect_url)
       end
     end
 
-    describe "do POST on update" do
-      it "should redirect the developer to the USA.gov developer page" do
-        post :update, :id => @user.id, :user => {:email => "changed@foo.com"}
+    describe 'do POST on update' do
+      it 'should redirect the developer to the USA.gov developer page' do
+        post :update, params: { id: @user.id, user: {email: 'changed@foo.com'} }
         expect(response).to redirect_to(developer_redirect_url)
       end
     end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -3,14 +3,20 @@ require 'spec_helper'
 describe UsersController do
   fixtures :users
   let(:user_params) do
-    { contact_name: 'Barack', organization_name: 'White House', email: 'barack@whitehouse.gov', password: 'Michelle2016!' }
+    { contact_name: 'Barack',
+      organization_name: 'White House',
+      email: 'barack@whitehouse.gov',
+      password: 'Michelle2016!' }
   end
 
-  let(:permitted_params) { %i(contact_name organization_name email password) }
+  let(:permitted_params) { %i[contact_name organization_name email password] }
 
   describe '#create' do
     it do
-      is_expected.to permit(*permitted_params).for(:create, params: { user: user_params })
+      # to avoid depreication warning had to put params there twice
+      # https://github.com/thoughtbot/shoulda-matchers/issues/867
+      is_expected.to permit(*permitted_params).
+        for(:create, params: { params: { user: user_params } })
     end
 
     context 'when the User#save was successful and User has government affiliated email' do
@@ -97,8 +103,7 @@ describe UsersController do
     end
 
     let(:update_params) do
-      { 'contact_name': 'BAR',
-        'email': 'changed@foo.com' }
+      { 'contact_name': 'BAR', 'email': 'changed@foo.com' }
     end
 
     context 'when logged in as affiliate' do
@@ -106,7 +111,10 @@ describe UsersController do
       include_context 'approved user logged in'
 
       it do
-        is_expected.to permit(*permitted_params).for(:update, params: { user: update_params })
+      # to avoid depreication warning had to put params there twice
+      # https://github.com/thoughtbot/shoulda-matchers/issues/867
+      is_expected.to permit(*permitted_params).
+          for(:update, params: { params: { user: update_params } })
       end
 
       context 'when changing the password' do

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -114,7 +114,7 @@ describe UsersController do
       # to avoid depreication warning had to put params there twice
       # https://github.com/thoughtbot/shoulda-matchers/issues/867
       is_expected.to permit(*permitted_params).
-          for(:update, params: { params: { user: update_params } })
+        for(:update, params: { params: { user: update_params } })
       end
 
       context 'when changing the password' do

--- a/spec/support/shared_sites_controller_shared_behavior.rb
+++ b/spec/support/shared_sites_controller_shared_behavior.rb
@@ -1,7 +1,15 @@
 shared_examples 'restricted to approved user' do |request_method, action, parameters = nil, sessions = nil, flash = nil|
+
+  let(:args) do
+    { params: parameters,
+    flash: flash }
+  end
+
+  args[:sessions] = sessions if sessions.present?
+
   context 'when user is not logged in' do
     it 'should redirect to login page' do
-      send request_method, action, parameters, sessions, flash
+      send request_method, action, args
       expect(response).to redirect_to(login_path)
     end
   end
@@ -10,7 +18,7 @@ shared_examples 'restricted to approved user' do |request_method, action, parame
     before { UserSession.create(users(:affiliate_manager_with_pending_email_verification_status)) }
 
     it 'should redirect to affiliates page' do
-      send request_method, action, parameters, sessions, flash
+      send request_method, action, args
       expect(response).to redirect_to(account_path)
     end
   end
@@ -19,7 +27,7 @@ shared_examples 'restricted to approved user' do |request_method, action, parame
     before { UserSession.create(users(:affiliate_manager_with_pending_approval_status)) }
 
     it 'should redirect to affiliates page' do
-      self.send request_method, action, parameters, sessions, flash
+      self.send request_method, action, args
       expect(response).to redirect_to(account_path)
     end
   end
@@ -28,7 +36,7 @@ shared_examples 'restricted to approved user' do |request_method, action, parame
     before { UserSession.create(users(:affiliate_manager_with_pending_contact_information_status)) }
 
     it 'should redirect to affiliates page' do
-      self.send request_method, action, parameters, sessions, flash
+      self.send request_method, action, args
       expect(response).to redirect_to(account_path)
     end
   end

--- a/spec/support/shared_sites_controller_shared_behavior.rb
+++ b/spec/support/shared_sites_controller_shared_behavior.rb
@@ -1,14 +1,8 @@
-shared_examples 'restricted to approved user' do |request_method, action, parameters = nil, sessions = nil, flash = nil|
-
-  let(:args) do
-    { params: parameters, flash: flash }
-  end
-
-  args[:sessions] = sessions if sessions.present?
+shared_examples 'restricted to approved user' do |request_method, action, parameters = nil|
 
   context 'when user is not logged in' do
     it 'should redirect to login page' do
-      send request_method, action, args
+      send request_method, action, params: parameters
       expect(response).to redirect_to(login_path)
     end
   end
@@ -17,7 +11,7 @@ shared_examples 'restricted to approved user' do |request_method, action, parame
     before { UserSession.create(users(:affiliate_manager_with_pending_email_verification_status)) }
 
     it 'should redirect to affiliates page' do
-      send request_method, action, args
+      send request_method, action, params: parameters
       expect(response).to redirect_to(account_path)
     end
   end
@@ -26,7 +20,7 @@ shared_examples 'restricted to approved user' do |request_method, action, parame
     before { UserSession.create(users(:affiliate_manager_with_pending_approval_status)) }
 
     it 'should redirect to affiliates page' do
-      self.send request_method, action, args
+      self.send request_method, action, params: parameters
       expect(response).to redirect_to(account_path)
     end
   end
@@ -35,7 +29,7 @@ shared_examples 'restricted to approved user' do |request_method, action, parame
     before { UserSession.create(users(:affiliate_manager_with_pending_contact_information_status)) }
 
     it 'should redirect to affiliates page' do
-      self.send request_method, action, args
+      send request_method, action, params: parameters
       expect(response).to redirect_to(account_path)
     end
   end

--- a/spec/support/shared_sites_controller_shared_behavior.rb
+++ b/spec/support/shared_sites_controller_shared_behavior.rb
@@ -20,7 +20,7 @@ shared_examples 'restricted to approved user' do |request_method, action, parame
     before { UserSession.create(users(:affiliate_manager_with_pending_approval_status)) }
 
     it 'should redirect to affiliates page' do
-      self.send request_method, action, params: parameters
+      send request_method, action, params: parameters
       expect(response).to redirect_to(account_path)
     end
   end

--- a/spec/support/shared_sites_controller_shared_behavior.rb
+++ b/spec/support/shared_sites_controller_shared_behavior.rb
@@ -1,8 +1,7 @@
 shared_examples 'restricted to approved user' do |request_method, action, parameters = nil, sessions = nil, flash = nil|
 
   let(:args) do
-    { params: parameters,
-    flash: flash }
+    { params: parameters, flash: flash }
   end
 
   args[:sessions] = sessions if sessions.present?


### PR DESCRIPTION
Update test http request methods. In Rails_5 request methods will accept only keyword arguments in future Rails versions.