### PR TITLE
SRCH-780 - Rails 5 -rspec site_clone returning errors

### DIFF
--- a/spec/models/site_cloner_spec.rb
+++ b/spec/models/site_cloner_spec.rb
@@ -320,9 +320,10 @@ describe SiteCloner do
             and_raise(StandardError)
         end
 
-        xit 're-enables the routed_query_keyword_observer' do
-          expect(ActiveRecord::Base.observers).to receive(:enable).with(:routed_query_keyword_observer).and_call_original
-          expect{cloner.clone}.to raise_error
+        it 're-enables the routed_query_keyword_observer' do
+          expect(ApplicationRecord.observers).to receive(:enable).
+            with(:routed_query_keyword_observer).and_call_original
+          expect{ cloner.clone }.to raise_error
         end
       end
     end


### PR DESCRIPTION
SRCH-780 - Rails 5 -rspec site_clone returning errors.  The test was using ActiveRecord::Base.observers instead of ApplicationRecord.observers. Rails 5 we use ApplicationRecord which inherits from ActiveRecord::Base
