### PR TITLE
Release 1.15.14

### DIFF
--- a/app/controllers/help_docs_controller.rb
+++ b/app/controllers/help_docs_controller.rb
@@ -10,7 +10,7 @@ class HelpDocsController < ApplicationController
   private
 
   def require_usasearch_url_param
-    unless help_docs_params[:url] =~ %r[^https?://search\.gov/.+]i
+    unless help_docs_params[:url] =~ %r{\Ahttps?://search\.gov/.+\z}i
       redirect_to(Rails.application.secrets.organization['page_not_found_url'])
     end
   end

--- a/spec/controllers/help_docs_controller_spec.rb
+++ b/spec/controllers/help_docs_controller_spec.rb
@@ -30,6 +30,19 @@ describe HelpDocsController do
       it { is_expected.to redirect_to('https://www.usa.gov/search-error') }
     end
 
+    context 'when url does match search.gov with newline characters' do
+      let(:url) do
+        "https://search.gov/manual/site-information.html\n<script>dangerous_stuff();</script>"
+      end
+
+      before do
+        expect(HelpDoc).not_to receive(:extract_article)
+        get :show, url: url, format: :json
+      end
+      it { is_expected.to redirect_to('https://www.usa.gov/search-error') }
+    end
+
+
     context 'when user is not logged in' do
       let(:url) { 'https://search.gov/manual/site-information.html' }
 


### PR DESCRIPTION
[SRCH-779] - update validations to use \A instead of ^