### PR TITLE
SRCH-539 set size to 100 for news item terms aggregations

### DIFF
--- a/app/models/elastic_news_item_query.rb
+++ b/app/models/elastic_news_item_query.rb
@@ -34,7 +34,7 @@ class ElasticNewsItemQuery < ElasticTextFilterByPublishedAtQuery
     json.set! field do |agg_json|
       agg_json.terms do
         agg_json.field field
-        agg_json.size 0
+        agg_json.size 100
       end
     end
   end

--- a/spec/models/elastic_news_item_spec.rb
+++ b/spec/models/elastic_news_item_spec.rb
@@ -48,10 +48,8 @@ describe ElasticNewsItem do
     ElasticNewsItem.commit
   end
 
-  # Temporarily disabling these specs during ES56 upgrade
-  # https://cm-jira.usa.gov/browse/SRCH-826
-  pending ".search_for" do
-    describe "results structure" do
+  describe '.search_for' do
+    describe 'results structure' do
       context 'when there are results' do
 
         it 'should return results in an easy to access structure' do
@@ -105,7 +103,9 @@ describe ElasticNewsItem do
 
     end
 
-    describe "filters" do
+    # Temporarily disabling these specs during ES56 upgrade
+    # https://cm-jira.usa.gov/browse/SRCH-826
+    pending 'filters' do
 
       context 'when RSS feeds are specified' do
         it "should restrict results to the RSS feed URLS belonging to the specified collection of RSS feeds" do
@@ -260,7 +260,9 @@ describe ElasticNewsItem do
       end
     end
 
-    describe "synonyms and protected words" do
+    # Temporarily disabling these specs during ES56 upgrade
+    # https://cm-jira.usa.gov/browse/SRCH-826
+    pending 'synonyms and protected words' do
       it "should use both" do
         search = ElasticNewsItem.search_for(q: "gas", rss_feeds: [blog, gallery], language: 'en')
         expect(search.total).to eq(1)


### PR DESCRIPTION
@peggles2, these aggregations appear to have been used in the sidebar of the legacy SERP - I don't believe they are used at all by the current SERPs, but for safety's sake I'm going to leave them as part of this query. The story above indicates that we set `size: 0`  to return the max. number of bucketed aggregations in order to "make it easy for users to see all ...DC subjects in the left nav". 100 should be plenty for this likely deprecated feature.

This PR fixes the above, and sets the remaining failing news item specs to `pending`.