### PR TITLE
SRCH-822 use `prefix_length` in Elasticsearch phrase suggester

### DIFF
--- a/app/models/elastic_suggest.rb
+++ b/app/models/elastic_suggest.rb
@@ -10,7 +10,7 @@ module ElasticSuggest
           json.direct_generator do
             json.child! do
               json.field 'bigram'
-              json.prefix_len 1
+              json.prefix_length 1
             end
           end
           json.highlight do

--- a/spec/models/site_search_spec.rb
+++ b/spec/models/site_search_spec.rb
@@ -80,9 +80,7 @@ describe SiteSearch do
         ElasticIndexedDocument.commit
       end
 
-      # Temporarily disabling these specs during ES56 upgrade
-      # https://cm-jira.usa.gov/browse/SRCH-822
-      xit 'includes SPEL and LOVER in the modules' do
+      it 'includes SPEL and LOVER in the modules' do
         search = SiteSearch.new({ affiliate: affiliate, document_collection: collection, query: 'Scientost' })
         search.run
         expect(search.modules).to include('SPEL', 'LOVER')


### PR DESCRIPTION
This PR fixes and re-enables a failing spec in spec/models/site_search_spec.rb.

The issue was that our phrase suggester was using an outdated field name "prefix_len" instead of the current "prefix_length":
```
        "direct_generator": [
          {
            "field": "bigram",
            "prefix_len": 1
          }
        ] 
```
https://www.elastic.co/guide/en/elasticsearch/reference/5.6/search-suggesters-phrase.html#_direct_generators