### PR TITLE
SRCH-828 re-enable ElasticBoostedContent specs where possible

### DIFF
--- a/spec/models/elastic_boosted_content_spec.rb
+++ b/spec/models/elastic_boosted_content_spec.rb
@@ -10,10 +10,11 @@ describe ElasticBoostedContent do
       q: query,
       affiliate_id: affiliate.id,
       size: 1,
-      offset: 1,
+      offset: 0,
       language: affiliate.indexing_locale
     }
   end
+  let(:search) { ElasticBoostedContent.search_for(search_params) }
 
   before do
     ElasticBoostedContent.recreate_index
@@ -76,7 +77,7 @@ describe ElasticBoostedContent do
     end
   end
 
-  describe "highlighting results" do
+  describe 'highlighting results' do
     before do
       affiliate.boosted_contents.create!(title: 'Tropical Hurricane Names',
                                          status: 'active',
@@ -87,8 +88,11 @@ describe ElasticBoostedContent do
     end
 
     context 'when no highlight param is sent in' do
-      it 'should highlight appropriate fields with <strong> by default' do
-        search = ElasticBoostedContent.search_for(q: 'Tropical', affiliate_id: affiliate.id, language: affiliate.indexing_locale)
+      let(:search) do
+        ElasticBoostedContent.search_for(search_params.except(:highlighting))
+      end
+
+      it 'highlights appropriate fields with <strong> by default' do
         first = search.results.first
         expect(first.title).to eq("<strong>Tropical</strong> Hurricane Names")
         expect(first.description).to eq("Worldwide <strong>Tropical</strong> Cyclone Names")
@@ -96,6 +100,8 @@ describe ElasticBoostedContent do
     end
 
     context 'when field has HTML entity like an ampersand' do
+      let(:query) { 'carrots' }
+
       before do
         affiliate.boosted_contents.create!(title: 'Peas & Carrots',
                                            status: 'active',
@@ -105,19 +111,18 @@ describe ElasticBoostedContent do
         ElasticBoostedContent.commit
       end
 
-      it 'should escape the entity but show the highlight' do
-        search = ElasticBoostedContent.search_for(q: 'carrots', affiliate_id: affiliate.id, language: affiliate.indexing_locale)
+      it 'escapes the entity but shows the highlight' do
         first = search.results.first
         expect(first.title).to eq("Peas &amp; <strong>Carrots</strong>")
-        search = ElasticBoostedContent.search_for(q: 'entities', affiliate_id: affiliate.id, language: affiliate.indexing_locale)
-        first = search.results.first
-        expect(first.title).to eq("Peas &amp; Carrots")
       end
     end
 
     context 'when highlight is turned off' do
+      let(:search) do
+        ElasticBoostedContent.search_for(search_params.merge(highlighting: false))
+      end
+
       it 'should not highlight matches' do
-        search = ElasticBoostedContent.search_for(q: 'Tropical', affiliate_id: affiliate.id, language: affiliate.indexing_locale, highlighting: false)
         first = search.results.first
         expect(first.title).to eq("Tropical Hurricane Names")
         expect(first.description).to eq("Worldwide Tropical Cyclone Names")
@@ -324,8 +329,8 @@ describe ElasticBoostedContent do
 
     describe "title and description" do
       it 'is case insentitive' do
-        expect(ElasticBoostedContent.search_for(search_params.merge(q: 'YOSEMITE')).total)
-          .to eq(1)
+        expect(ElasticBoostedContent.search_for(search_params.merge(q: 'YOSEMITE')).total).
+          to eq(1)
       end
 
       it 'should perform ASCII folding' do
@@ -343,8 +348,8 @@ describe ElasticBoostedContent do
 
         %w(+++yosemite --yosemite +-yosemite).each do |query|
           specify do
-            expect(ElasticBoostedContent.search_for(search_params.merge(q: query)).total)
-              .to eq(1)
+            expect(ElasticBoostedContent.search_for(search_params.merge(q: query)).total).
+              to eq(1)
           end
         end
       end


### PR DESCRIPTION
This PR fixes and re-enables specs that were failing erroneously. Several of the specs in elastic_boosted_content_spec.rb were failing because we have temporarily switched from per-language analyzers to the `standard` analyzer. This broke specs where, for example, a query for `carrot` is not returning results for `carrots`. The specs in question were not intended to test language analysis, so it's preferred to simplify those specs; language analysis has its own specs, which have been commented out temporarily. 