### PR TITLE
SRCH-815 re-enable WebSearch spec

### DIFF
--- a/spec/models/web_search_spec.rb
+++ b/spec/models/web_search_spec.rb
@@ -302,9 +302,7 @@ describe WebSearch do
         expect(ElasticIndexedDocument.search_for(q:'indexed', affiliate_id: @non_affiliate.id, language: @non_affiliate.indexing_locale).total).to eq(15)
       end
 
-      # Temporarily disabling these specs during ES56 upgrade
-      # https://cm-jira.usa.gov/browse/SRCH-815
-      xit "should fill the results with the Odie docs" do
+      it 'fills the results with the Odie docs' do
         search = WebSearch.new(:query => 'no_results', :affiliate => @non_affiliate)
         search.run
         expect(search.total).to eq(15)


### PR DESCRIPTION
This PR re-enables a failing WebSearch spec, which was likely fixed by https://github.com/GSA/search-gov/pull/354. 