### PR TITLE
SRCH-817 use 'keyword' for non-analyzed fields

### DIFF
--- a/app/models/elastic_federal_register_document_query.rb
+++ b/app/models/elastic_federal_register_document_query.rb
@@ -2,6 +2,7 @@ class ElasticFederalRegisterDocumentQuery < ElasticTextFilteredQuery
   def initialize(options)
     super(options.merge({ sort: 'comments_close_on:desc' }))
     self.highlighted_fields = %i(abstract title)
+    @text_analyzer = 'en_analyzer'
     @federal_register_agency_ids = options[:federal_register_agency_ids]
   end
 

--- a/lib/elastic_settings.rb
+++ b/lib/elastic_settings.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 module ElasticSettings
-  KEYWORD = { type: 'text',
-              analyzer: 'case_insensitive_keyword_analyzer' }.freeze
+  KEYWORD = { type: 'keyword',
+              normalizer: 'keyword_normalizer' }.freeze
 
   COMMON = {
     index: {
@@ -25,31 +25,37 @@ module ElasticSettings
           babel_analyzer: {
             type: 'custom',
             tokenizer: 'standard',
-            filter: %w(standard asciifolding lowercase) },
+            filter: %w(asciifolding lowercase) },
           default: {
             type: 'custom',
             tokenizer: 'standard',
-            filter: %w(standard asciifolding lowercase) },
+            filter: %w(asciifolding lowercase) },
           en_analyzer: {
             type: 'custom',
             tokenizer: 'standard',
             char_filter: %w(ignore_chars),
-            filter: %w(standard asciifolding lowercase en_stop_filter en_protected_filter en_stem_filter en_synonym) },
+            filter: %w(asciifolding lowercase en_stop_filter en_protected_filter en_stem_filter en_synonym) },
           es_analyzer: {
             type: 'custom',
             tokenizer: 'standard',
             char_filter: %w(ignore_chars),
-            filter: %w(standard asciifolding lowercase es_stop_filter es_protected_filter es_stem_filter es_synonym) },
+            filter: %w(asciifolding lowercase es_stop_filter es_protected_filter es_stem_filter es_synonym) },
           bigram_analyzer: {
             type: 'custom',
             tokenizer: 'standard',
             char_filter: %w(ignore_chars),
-            filter: %w(standard asciifolding lowercase bigram_filter)
-          },
-          case_insensitive_keyword_analyzer: {
-            tokenizer: 'keyword',
+            filter: %w(asciifolding lowercase bigram_filter)
+          }
+        },
+        normalizer: {
+          keyword_normalizer: {
+            type: 'custom',
             char_filter: %w(ignore_chars),
-            filter: %w(standard asciifolding lowercase) } } } }
+            filter: %w(asciifolding lowercase)
+          }
+        }
+      }
+    }
   }.freeze
 
 end

--- a/spec/models/elastic_federal_register_document_spec.rb
+++ b/spec/models/elastic_federal_register_document_spec.rb
@@ -5,9 +5,7 @@ describe ElasticFederalRegisterDocument do
 
   let!(:fr_noaa) { federal_register_agencies(:fr_noaa) }
 
-  # Temporarily disabling these specs during ES56 upgrade
-  # https://cm-jira.usa.gov/browse/SRCH-817
-  pending '.search_for' do
+  describe '.search_for' do
     before do
       FederalRegisterDocument.all.each(&:save!)
       ElasticFederalRegisterDocument.commit


### PR DESCRIPTION
This PR ensures that all our fields using the `ElasticSettings::KEYWORD` mapping are set to the `keyword` data type instead of `text`. It:
- adds a keyword normalizer, to replace the `case_insensitive_keyword_analyzer`
- specifies the `en_analyzer` for federal register docs (which are all in English)
- re-enables elastic_federal_register_document_spec.rb

It also removes the deprecated `standard` token filter, which does nothing in 5.6 and is removed entirely in 7.0:
https://www.elastic.co/guide/en/elasticsearch/reference/5.6/analysis-standard-tokenfilter.html