### PR TITLE
SRCH-362 - Halt callback chain

### DIFF
--- a/config/initializers/callback_terminator.rb
+++ b/config/initializers/callback_terminator.rb
@@ -1,0 +1,1 @@
+ActiveSupport.halt_callback_chains_on_return_false = true


### PR DESCRIPTION
Before Rails 5, returning false from any before_ callback in ActiveModel or ActiveModel::Validations, ActiveRecord and ActiveSupport resulted in halting of callback chain.

Rails 5 fixed this issue by adding throw(:abort) to explicitly halt callbacks.

To opt out of behavior update the initializer. But it will have to be addressed before we upgrade to Rails 5.2