### PR TITLE
SRCH-820 - remove the template_not_found method not needed for rails 5

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,7 +6,6 @@ class ApplicationController < ActionController::Base
   helper :all
   helper_method :current_user_session, :current_user, :permitted_params
   protect_from_forgery with: :exception
-  VALID_FORMATS = %w{html rss json xml mobile}
   SERP_RESULTS_PER_PAGE = 20
   PAGE_NOT_FOUND = 'https://www.usa.gov/search-error'
 
@@ -35,8 +34,6 @@ class ApplicationController < ActionController::Base
   ).concat(ADVANCED_PARAM_KEYS).
     concat(DUBLIN_CORE_PARAM_KEYS).
     concat(FILTER_PARAM_KEYS).freeze
-
-  rescue_from ActionView::MissingTemplate, :with => :template_not_found
 
   def handle_unverified_request
     raise ActionController::InvalidAuthenticityToken
@@ -71,14 +68,6 @@ class ApplicationController < ActionController::Base
   end
 
   private
-
-  def template_not_found(error)
-    if VALID_FORMATS.include?(request.format)
-      raise error
-    else
-      render text: '406 Not Acceptable', status: 406
-    end
-  end
 
   def set_default_locale
     I18n.locale = :en


### PR DESCRIPTION
The proper way to return 406 error for wrong format is through defining the format in the controller then anything else will return a 406. Currently what is on production is not working and we get 500 errors for the wrong format. Rails 5 does not even go through this method anyway so taking it out. 