### PR TITLE
 SRCH-?? use basic auth for elasticsearch client

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3349,7 +3349,7 @@ Style/MethodCallWithArgsParentheses:
   VersionAdded: 0.47
   VersionChanged: 0.48
   IgnoreMacros: true
-  IgnoredMethods: []
+  IgnoredMethods: ['require']
   Exclude:
     - 'spec/**/*'
     - 'Gemfile'

--- a/config/secrets.yml.dev
+++ b/config/secrets.yml.dev
@@ -63,16 +63,30 @@ dev_settings: &DEV_SETTINGS
     enabled: false
   analytics:
     elasticsearch:
-      reader: localhost
+      reader:
+        host: http://localhost:9200
+        user: elastic
+        password: changeme
+        log: false
       writers:
-        - localhost
+        - host: http://localhost:9200
+          user: elastic
+          password: changeme
+          log: false
   asis:
     host: http://localhost:8080
   custom_indices:
     elasticsearch:
-      reader: localhost
+      reader:
+        host: http://localhost:9200
+        user: elastic
+        password: changeme
+        log: false
       writers:
-        - localhost
+        - host: http://localhost:9200
+          user: elastic
+          password: changeme
+          log: false
   jobs:
     <<: *JOBS_SECRETS
     host: 'https://data.usajobs.gov'

--- a/lib/es.rb
+++ b/lib/es.rb
@@ -1,26 +1,30 @@
+# frozen_string_literal: true
+
 require 'typhoeus/adapters/faraday'
 
 module ES
-  INDEX_PREFIX = "#{Rails.env}-usasearch".freeze
+  INDEX_PREFIX = "#{Rails.env}-usasearch"
 
   def client_reader
-    @client_reader ||= Elasticsearch::Client.new(log: Rails.env == 'development', host: reader_host)
+    @client_reader ||= initialize_client(reader_config)
   end
 
   def client_writers
-    @client_writers ||= writer_hosts.collect do |writer_host|
-      Elasticsearch::Client.new(log: Rails.env == 'development', host: writer_host)
-    end
+    @client_writers ||= writer_config.map { |config| initialize_client(config) }
   end
 
   private
 
-  def reader_host
-    self.client_config 'reader'
+  def reader_config
+    client_config('reader')
   end
 
-  def writer_hosts
-    self.client_config 'writers'
+  def writer_config
+    client_config('writers')
+  end
+
+  def initialize_client(config)
+    Elasticsearch::Client.new(config.symbolize_keys)
   end
 
   module ELK

--- a/spec/lib/es_spec.rb
+++ b/spec/lib/es_spec.rb
@@ -1,16 +1,16 @@
 require 'spec_helper'
 
 describe ES do
-  context "when working in ES submodules" do
+  context 'when working in ES submodules' do
     let(:elk_objs) { Array.new(3, ES::ELK.client_reader) }
     let(:ci_objs) { Array.new(3, ES::ELK.client_reader) }
 
-    describe ".client_reader" do
-      it "should return a different object in different submodules" do
+    describe '.client_reader' do
+      it 'returns a different object in different submodules' do
         expect(ES::ELK.client_reader).to_not eq(ES::CustomIndices.client_reader)
       end
 
-      it "should return the same object given successive invocations" do
+      it 'returns the same object given successive invocations' do
         2.times do |i|
           expect(elk_objs[i]).to eq(elk_objs[i+1])
           expect(ci_objs[i]).to eq(ci_objs[i+1])
@@ -18,12 +18,12 @@ describe ES do
       end
     end
 
-    describe ".client_writers" do
-      it "should return a different object in different submodules" do
+    describe '.client_writers' do
+      it 'returns a different object in different submodules' do
         expect(ES::ELK.client_writers).to_not eq(ES::CustomIndices.client_writers)
       end
 
-      it "should return the same object given successive invocations" do
+      it 'returns the same object given successive invocations' do
         2.times do |i|
           expect(elk_objs[i]).to eq(elk_objs[i+1])
           expect(ci_objs[i]).to eq(ci_objs[i+1])
@@ -32,37 +32,51 @@ describe ES do
     end
   end
 
-  context "when working in ES::ELK submodule" do
-    describe ".client_reader" do
-      it 'should use the value from the secrets.yml analytics[elasticsearch][reader] entry' do
-        expect(ES::ELK.client_reader.transport.hosts.first[:host]).to eq(Rails.application.secrets.analytics['elasticsearch']['reader'])
+  context 'when working in ES::ELK submodule' do
+    let(:es_config) { Rails.application.secrets.analytics['elasticsearch'] }
+
+    describe '.client_reader' do
+      let(:host) { ES::ELK.client_reader.transport.hosts.first }
+
+      it 'uses the values from the secrets.yml analytics[elasticsearch][reader] entry' do
+        expect(host[:host]).to eq(URI(es_config['reader']['host']).host)
+        expect(host[:user]).to eq(es_config['reader']['user'])
       end
     end
 
-    describe ".client_writers" do
-      it 'should use the value(s) from the secrets.yml analytics[elasticsearch][writers] entry' do
+    describe '.client_writers' do
+      it 'uses the value(s) from the secrets.yml analytics[elasticsearch][writers] entry' do
         count = Rails.application.secrets.analytics['elasticsearch']['writers'].count
         expect(ES::ELK.client_writers.size).to eq(count)
         count.times do |i|
-          expect(ES::ELK.client_writers.first.transport.hosts[i][:host]).to eq(Rails.application.secrets.analytics['elasticsearch']['writers'][i])
+          host = ES::ELK.client_writers.first.transport.hosts[i]
+          expect(host[:host]).to eq(URI(es_config['writers'][i]['host']).host)
+          expect(host[:user]).to eq(es_config['writers'][i]['user'])
         end
       end
     end
   end
 
-  context "when working in ES::CustomIndices submodule" do
-    describe ".client_reader" do
-      it 'should use the value from the secrets.yml custom_indices[elasticsearch][reader] entry' do
-        expect(ES::CustomIndices.client_reader.transport.hosts.first[:host]).to eq(Rails.application.secrets.custom_indices['elasticsearch']['reader'])
+  describe 'when working in ES::CustomIndices submodule' do
+    let(:es_config) { Rails.application.secrets.custom_indices['elasticsearch'] }
+
+    describe '.client_reader' do
+      let(:host) { ES::CustomIndices.client_reader.transport.hosts.first }
+
+      it 'uses the values from the secrets.yml custom_indices[elasticsearch][reader] entry' do
+        expect(host[:host]).to eq(URI(es_config['reader']['host']).host)
+        expect(host[:user]).to eq(es_config['reader']['user'])
       end
     end
 
-    describe ".client_writers" do
-      it 'should use the value(s) from the secrets.yml custom_indices[elasticsearch][writers] entry' do
+    describe '.client_writers' do
+      it 'uses the value(s) from the secrets.yml custom_indices[elasticsearch][writers] entry' do
         count = Rails.application.secrets.custom_indices['elasticsearch']['writers'].count
         expect(ES::CustomIndices.client_writers.size).to eq(count)
         count.times do |i|
-          expect(ES::CustomIndices.client_writers.first.transport.hosts[i][:host]).to eq(Rails.application.secrets.custom_indices['elasticsearch']['writers'][i])
+          host = ES::CustomIndices.client_writers.first.transport.hosts[i]
+          expect(host[:host]).to eq(URI(es_config['writers'][i]['host']).host)
+          expect(host[:user]).to eq(es_config['writers'][i]['user'])
         end
       end
     end

--- a/spec/support/shared_vcr_setup.rb
+++ b/spec/support/shared_vcr_setup.rb
@@ -36,7 +36,7 @@ VCR.configure do |config|
     /codeclimate.com/ ===  URI(request.uri).host
   end
 
-  config.ignore_request { |request| URI(request.uri).port == 9200 } #Elasticsearch
+  config.ignore_request { |request| URI(request.uri).port.between?(9200,9299) } #Elasticsearch
 
   secrets = YAML.load(ERB.new(File.read(Rails.root.join('config', 'secrets.yml'))).result)
   secrets['secret_keys'].each do |service, keys|


### PR DESCRIPTION
(Note: I'll update the JIRA story ID once we regain access to JIRA.)

This PR is intended to allow us to access Elasticsearch using basic authorization. I have added a DNM label, as it will need to be released in tandem with https://github.com/GSA/usasearch-cookbooks/pull/375.

I also tweaked rubocop.yml not to require parentheses around args passed to `require`.
