### PR TITLE
SRCH-474 enable multilingual searching in Elasticsearch 5.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,14 +260,12 @@ workflows:
             - setup_elasticsearch
             - bundle_install
 
-# Temporarily disabling Cucumber tests & coverage check until Rspec is passing
-# https://cm-jira.usa.gov/browse/SRCH-825
-#     - cucumber:
-#         requires:
-#           - setup_elasticsearch
-#           - bundle_install
-#
-#     - report_coverage:
-#         requires:
-#           - rspec
-#           - cucumber
+      - cucumber:
+          requires:
+            - setup_elasticsearch
+            - bundle_install
+
+      - report_coverage:
+          requires:
+            - rspec
+            - cucumber

--- a/app/models/elastic_best_bet_query.rb
+++ b/app/models/elastic_best_bet_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticBestBetQuery < ElasticTextFilteredQuery
 
   def initialize(options)

--- a/app/models/elastic_blended_query.rb
+++ b/app/models/elastic_blended_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticBlendedQuery < ElasticTextFilterByPublishedAtQuery
   include ElasticSuggest
   include ElasticTitleDescriptionBodyHighlightFields
@@ -7,7 +9,7 @@ class ElasticBlendedQuery < ElasticTextFilterByPublishedAtQuery
     super(options)
     @affiliate_id = options[:affiliate_id]
     @rss_feed_url_ids = options[:rss_feed_url_ids]
-    self.highlighted_fields = %w(title description body)
+    @text_fields = %w[title description body]
   end
 
   def body

--- a/app/models/elastic_boosted_content.rb
+++ b/app/models/elastic_boosted_content.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticBoostedContent
   extend Indexable
   OPTIMIZING_INCLUDES = [:affiliate, :boosted_content_keywords].freeze
@@ -7,7 +9,7 @@ class ElasticBoostedContent
   self.mappings = {
     index_type => ElasticMappings::BEST_BET.deep_merge(
       properties: {
-        description: { type: 'text', term_vector: 'with_positions_offsets' },
+        description: ElasticSettings::TEXT,
         url: ElasticSettings::KEYWORD
       }
     )

--- a/app/models/elastic_boosted_content_data.rb
+++ b/app/models/elastic_boosted_content_data.rb
@@ -1,15 +1,28 @@
+# frozen_string_literal: true
+
 class ElasticBoostedContentData
+  attr_reader :language, :boosted_content
 
   def initialize(boosted_content)
     @boosted_content = boosted_content
+    @language = boosted_content.affiliate.indexing_locale
   end
 
   def to_builder
     Jbuilder.new do |json|
-      json.(@boosted_content, :id, :affiliate_id, :title, :description, :status, :publish_start_on, :publish_end_on, :match_keyword_values_only)
-      json.url UrlParser.strip_http_protocols(@boosted_content.url)
-      json.language "#{@boosted_content.affiliate.indexing_locale}_analyzer"
-      json.keyword_values @boosted_content.boosted_content_keywords.collect(&:value)
+      json.(boosted_content,
+            :id,
+            :affiliate_id,
+            :status,
+            :publish_start_on,
+            :publish_end_on,
+            :match_keyword_values_only)
+      %w[title description].each do |field|
+        json.set! "#{field}.#{language}", boosted_content.send(field)
+      end
+      json.url UrlParser.strip_http_protocols(boosted_content.url)
+      json.language language
+      json.keyword_values boosted_content.boosted_content_keywords.pluck(:value)
     end
   end
 

--- a/app/models/elastic_boosted_content_query.rb
+++ b/app/models/elastic_boosted_content_query.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class ElasticBoostedContentQuery < ElasticBestBetQuery
   def initialize(options)
     super(options)
-    self.highlighted_fields = %w(title description)
+    @text_fields = %w[title description]
     @site_limits = options[:site_limits]
   end
 

--- a/app/models/elastic_featured_collection.rb
+++ b/app/models/elastic_featured_collection.rb
@@ -6,8 +6,7 @@ class ElasticFeaturedCollection
 
   self.mappings = {
     index_type => ElasticMappings::BEST_BET.deep_merge(
-      properties: { link_titles: { type: 'text',
-                                   term_vector: 'with_positions_offsets' } }
+      properties: { link_titles: ElasticSettings::TEXT }
     )
   }
 

--- a/app/models/elastic_featured_collection_data.rb
+++ b/app/models/elastic_featured_collection_data.rb
@@ -1,14 +1,27 @@
+# frozen_string_literal: true
+
 class ElasticFeaturedCollectionData
+  attr_reader :featured_collection, :language
+
   def initialize(featured_collection)
     @featured_collection = featured_collection
+    @language = featured_collection.affiliate.indexing_locale
   end
 
   def to_builder
     Jbuilder.new do |json|
-      json.(@featured_collection, :id, :affiliate_id, :title, :status, :publish_start_on, :publish_end_on, :match_keyword_values_only)
-      json.language "#{@featured_collection.affiliate.indexing_locale}_analyzer"
-      json.link_titles @featured_collection.featured_collection_links.collect(&:title)
-      json.keyword_values @featured_collection.featured_collection_keywords.collect(&:value)
+      json.(featured_collection,
+            :id,
+            :affiliate_id,
+            :status,
+            :publish_start_on,
+            :publish_end_on,
+            :match_keyword_values_only)
+      json.language language
+      json.set! "title.#{language}", featured_collection.title
+      json.set! "link_titles.#{language}",
+                featured_collection.featured_collection_links.pluck(:title)
+      json.keyword_values featured_collection.featured_collection_keywords.pluck(:value)
     end
   end
 

--- a/app/models/elastic_featured_collection_data.rb
+++ b/app/models/elastic_featured_collection_data.rb
@@ -10,19 +10,30 @@ class ElasticFeaturedCollectionData
 
   def to_builder
     Jbuilder.new do |json|
-      json.(featured_collection,
-            :id,
-            :affiliate_id,
-            :status,
-            :publish_start_on,
-            :publish_end_on,
-            :match_keyword_values_only)
+      json.(featured_collection, *attributes)
       json.language language
       json.set! "title.#{language}", featured_collection.title
-      json.set! "link_titles.#{language}",
-                featured_collection.featured_collection_links.pluck(:title)
-      json.keyword_values featured_collection.featured_collection_keywords.pluck(:value)
+      json.set! "link_titles.#{language}", titles
+      json.keyword_values keyword_values
     end
   end
 
+  private
+
+  def attributes
+    %i[id
+       affiliate_id
+       status
+       publish_start_on
+       publish_end_on
+       match_keyword_values_only]
+  end
+
+  def titles
+    featured_collection.featured_collection_links.pluck(:title)
+  end
+
+  def keyword_values
+    featured_collection.featured_collection_keywords.pluck(:value)
+  end
 end

--- a/app/models/elastic_featured_collection_query.rb
+++ b/app/models/elastic_featured_collection_query.rb
@@ -1,6 +1,8 @@
+# frozen_string_literal: true
+
 class ElasticFeaturedCollectionQuery < ElasticBestBetQuery
   def initialize(options)
     super(options)
-    self.highlighted_fields = %w(title link_titles)
+    @text_fields = %w[title link_titles]
   end
 end

--- a/app/models/elastic_federal_register_document.rb
+++ b/app/models/elastic_federal_register_document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticFederalRegisterDocument
   extend Indexable
   OPTIMIZING_INCLUDES = [:federal_register_agencies].freeze
@@ -5,25 +7,19 @@ class ElasticFederalRegisterDocument
   self.settings = ElasticSettings::COMMON
 
   self.mappings = {
-    index_type => {
-      dynamic: :strict,
+    index_type => ElasticMappings::COMMON.deep_merge(
       properties: {
-        abstract: { type: 'text',
-                    term_vector: 'with_positions_offsets',
-                    analyzer: 'en_analyzer' },
+        abstract: ElasticSettings::TEXT,
         comments_close_on: { type: 'date', format: 'date' },
         publication_date: { type: 'date', format: 'date' },
         group_id: ElasticSettings::KEYWORD,
         document_number: ElasticSettings::KEYWORD,
         document_type: ElasticSettings::KEYWORD,
         federal_register_agency_ids: { type: 'integer' },
-        title: { type: 'text',
-                 term_vector: 'with_positions_offsets',
-                 analyzer: 'en_analyzer' },
+        title: ElasticSettings::TEXT,
         significant: { type: 'boolean' },
-        id: { type: 'integer' }
       }
-    }
+    )
   }
 
 end

--- a/app/models/elastic_federal_register_document_data.rb
+++ b/app/models/elastic_federal_register_document_data.rb
@@ -1,14 +1,26 @@
+# frozen_string_literal: true
+
 class ElasticFederalRegisterDocumentData
+  attr_reader :document
+
   def initialize(federal_register_document)
-    @federal_register_document = federal_register_document
+    @document = federal_register_document
   end
 
   def to_builder
     Jbuilder.new do |json|
-      json.(@federal_register_document, :abstract, :comments_close_on, :document_number,
-        :federal_register_agency_ids, :id, :publication_date, :title, :significant, :document_type)
-      json.group_id @federal_register_document.docket_id? ? @federal_register_document.docket_id : @federal_register_document.document_number
+      json.(document,
+            :comments_close_on,
+            :document_number,
+            :federal_register_agency_ids,
+            :id,
+            :publication_date,
+            :significant,
+            :document_type)
+      json.group_id (document.docket_id || document.document_number)
+      %w[title abstract].each do |field|
+        json.set! "#{field}.en", document.send(field)
+      end
     end
   end
-
 end

--- a/app/models/elastic_federal_register_document_query.rb
+++ b/app/models/elastic_federal_register_document_query.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 class ElasticFederalRegisterDocumentQuery < ElasticTextFilteredQuery
   def initialize(options)
     super(options.merge({ sort: 'comments_close_on:desc' }))
-    self.highlighted_fields = %i(abstract title)
+    @text_fields = %w[abstract title]
     @text_analyzer = 'en_analyzer'
     @federal_register_agency_ids = options[:federal_register_agency_ids]
   end

--- a/app/models/elastic_indexed_document.rb
+++ b/app/models/elastic_indexed_document.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticIndexedDocument
   extend Indexable
 
@@ -6,18 +8,12 @@ class ElasticIndexedDocument
   self.mappings = {
     index_type => ElasticMappings::COMMON.deep_merge(
       properties: {
-        title: { type: 'text',
-                 term_vector: 'with_positions_offsets',
-                 copy_to: 'bigram' },
-        description: { type: 'text',
-                       term_vector: 'with_positions_offsets',
-                       copy_to: 'bigram' },
-        body: { type: 'text',
-                term_vector: 'with_positions_offsets',
-                copy_to: 'bigram' },
+        affiliate_id: { type: 'integer' },
+        title: ElasticSettings::TEXT,
+        description: ElasticSettings::TEXT,
+        body: ElasticSettings::TEXT,
         published_at: { type: 'date' },
         popularity: { type: 'integer' },
-        bigram: { type: 'text', analyzer: 'bigram_analyzer'},
         url: ElasticSettings::KEYWORD
       }
     )

--- a/app/models/elastic_indexed_document_data.rb
+++ b/app/models/elastic_indexed_document_data.rb
@@ -1,17 +1,27 @@
+# frozen_string_literal: true
+
 class ElasticIndexedDocumentData
   DAYS_BACK = 7
 
+  attr_reader :language, :indexed_document
+
   def initialize(indexed_document)
     @indexed_document = indexed_document
+    @language = indexed_document.affiliate.indexing_locale
   end
 
   def to_builder
+    return if indexed_document.last_crawl_status_error?
+
     Jbuilder.new do |json|
-      json.(@indexed_document, :id, :affiliate_id, :title, :description, :body, :url)
-      json.language "#{@indexed_document.affiliate.indexing_locale}_analyzer"
-      json.popularity LinkPopularity.popularity_for(@indexed_document.url, DAYS_BACK)
-      json.published_at @indexed_document.published_at.strftime("%Y-%m-%dT%H:%M:%S") if @indexed_document.published_at?
-    end unless @indexed_document.last_crawl_status_error?
+      json.(indexed_document, :id, :affiliate_id, :url)
+      json.language language
+      %w[title description body].each do |field|
+        json.set! "#{field}.#{language}", indexed_document.send(field)
+      end
+      json.popularity LinkPopularity.popularity_for(indexed_document.url, DAYS_BACK)
+      json.published_at indexed_document.published_at&.strftime("%Y-%m-%dT%H:%M:%S")
+    end
   end
 
 end

--- a/app/models/elastic_indexed_document_query.rb
+++ b/app/models/elastic_indexed_document_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticIndexedDocumentQuery < ElasticTextFilteredQuery
   include ElasticSuggest
   include ElasticTitleDescriptionBodyHighlightFields
@@ -8,7 +10,7 @@ class ElasticIndexedDocumentQuery < ElasticTextFilteredQuery
     @affiliate_id = options[:affiliate_id]
     @document_collection = options[:document_collection]
     @include_suggestion = options[:include_suggestion]
-    self.highlighted_fields = %w(title description body)
+    @text_fields = %w[title description body]
   end
 
   def body

--- a/app/models/elastic_news_item.rb
+++ b/app/models/elastic_news_item.rb
@@ -2,7 +2,7 @@
 
 class ElasticNewsItem
   extend Indexable
-  DUBLIN_CORE_AGG_NAMES = [:contributor, :subject, :publisher]
+  DUBLIN_CORE_AGG_NAMES = %i[contributor subject publisher].freeze
 
   self.settings = ElasticSettings::COMMON
 
@@ -19,9 +19,8 @@ class ElasticNewsItem
         contributor: { type: 'keyword' },
         subject: { type: 'keyword' },
         publisher: { type: 'keyword' },
-        tags: { type: 'keyword' },
+        tags: { type: 'keyword' }
       }
     )
   }
-
 end

--- a/app/models/elastic_news_item.rb
+++ b/app/models/elastic_news_item.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticNewsItem
   extend Indexable
   DUBLIN_CORE_AGG_NAMES = [:contributor, :subject, :publisher]
@@ -5,30 +7,21 @@ class ElasticNewsItem
   self.settings = ElasticSettings::COMMON
 
   self.mappings = {
-    index_type => {
-      dynamic: :strict,
+    index_type => ElasticMappings::COMMON.deep_merge(
       properties: {
-        language: { type: 'keyword', index: true },
         rss_feed_url_id: { type: 'integer' },
-        title: { type: 'text',
-                 term_vector: 'with_positions_offsets',
-                 copy_to: 'bigram' },
-        description: { type: 'text',
-                       term_vector: 'with_positions_offsets',
-                       copy_to: 'bigram' },
-        body: { type: 'text',
-                term_vector: 'with_positions_offsets',
-                copy_to: 'bigram' },
+        title: ElasticSettings::TEXT,
+        description: ElasticSettings::TEXT,
+        body: ElasticSettings::TEXT,
         published_at: { type: 'date' },
         popularity: { type: 'integer' },
         link: ElasticSettings::KEYWORD,
         contributor: { type: 'keyword' },
         subject: { type: 'keyword' },
         publisher: { type: 'keyword' },
-        bigram: { type: 'text', analyzer: 'bigram_analyzer' },
         tags: { type: 'keyword' },
-        id: { type: 'integer' } }
-    }
+      }
+    )
   }
 
 end

--- a/app/models/elastic_news_item_data.rb
+++ b/app/models/elastic_news_item_data.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticNewsItemData
   DAYS_BACK = 7
 
@@ -11,19 +13,28 @@ class ElasticNewsItemData
   def to_builder
     Jbuilder.new do |json|
       json.(news_item, :id, :rss_feed_url_id, :link, :tags)
-      ElasticNewsItem::DUBLIN_CORE_AGG_NAMES.each do |dublin_core_field|
-        if news_item.send(dublin_core_field).present?
-          value = news_item.send(dublin_core_field).split(',').map(&:squish)
-          json.set! dublin_core_field, value
-        end
+      dublin_core_values(json)
+      %w[title description body].each do |field|
+        json.set! "#{field}.#{language}", news_item.send(field)
       end
-       %w[title description body].each do |field|
-         json.set! "#{field}.#{language}", news_item.send(field)
-       end
-      json.published_at news_item.published_at.strftime("%Y-%m-%dT%H:%M:%S")
-      json.popularity LinkPopularity.popularity_for(news_item.link, DAYS_BACK)
+      json.published_at news_item.published_at.strftime('%Y-%m-%dT%H:%M:%S')
+      json.popularity popularity
       json.language language
     end
   end
 
+  private
+
+  def dublin_core_values(json)
+    ElasticNewsItem::DUBLIN_CORE_AGG_NAMES.each do |dublin_core_field|
+      if news_item.send(dublin_core_field).present?
+        value = news_item.send(dublin_core_field).split(',').map(&:squish)
+        json.set! dublin_core_field, value
+      end
+    end
+  end
+
+  def popularity
+    LinkPopularity.popularity_for(news_item.link, DAYS_BACK)
+  end
 end

--- a/app/models/elastic_news_item_query.rb
+++ b/app/models/elastic_news_item_query.rb
@@ -8,8 +8,8 @@ class ElasticNewsItemQuery < ElasticTextFilterByPublishedAtQuery
     @excluded_urls = options[:excluded_urls].try(:collect, &:url)
     @tags = options[:tags]
     @dublin_core_aggs = options.slice(*ElasticNewsItem::DUBLIN_CORE_AGG_NAMES).delete_if { |agg_name, agg_value| agg_value.nil? }
-    self.highlighted_fields = %w(title)
-    self.highlighted_fields += %w(body description) unless options[:title_only]
+    @text_fields = %w[title]
+    @text_fields += %w[body description] unless options[:title_only]
   end
 
   def query(json)

--- a/app/models/elastic_news_item_query.rb
+++ b/app/models/elastic_news_item_query.rb
@@ -8,8 +8,7 @@ class ElasticNewsItemQuery < ElasticTextFilterByPublishedAtQuery
     @excluded_urls = options[:excluded_urls].try(:collect, &:url)
     @tags = options[:tags]
     @dublin_core_aggs = options.slice(*ElasticNewsItem::DUBLIN_CORE_AGG_NAMES).delete_if { |agg_name, agg_value| agg_value.nil? }
-    @text_fields = %w[title]
-    @text_fields += %w[body description] unless options[:title_only]
+    @text_fields = (options[:title_only] ? ['title'] : %w[body description title])
   end
 
   def query(json)

--- a/app/models/elastic_sayt_suggestion.rb
+++ b/app/models/elastic_sayt_suggestion.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticSaytSuggestion
   extend Indexable
 
@@ -6,9 +8,12 @@ class ElasticSaytSuggestion
   self.mappings = {
     index_type => ElasticMappings::COMMON.deep_merge(
       properties: {
+        affiliate_id: { type: 'integer' },
         phrase: {
-          type: 'text', term_vector: 'with_positions_offsets',
-          fields: { keyword: ElasticSettings::KEYWORD } },
+          properties: { keyword: ElasticSettings::KEYWORD }.merge(
+            ElasticSettings::TEXT[:properties]
+          )
+        },
         popularity: { type: 'integer' }
       }
     )

--- a/app/models/elastic_sayt_suggestion_data.rb
+++ b/app/models/elastic_sayt_suggestion_data.rb
@@ -1,14 +1,21 @@
+# frozen_string_literal: true
+
 class ElasticSaytSuggestionData
+  attr_reader :sayt_suggestion, :language
 
   def initialize(sayt_suggestion)
     @sayt_suggestion = sayt_suggestion
+    @language = sayt_suggestion.affiliate.indexing_locale
   end
 
   def to_builder
-    Jbuilder.new do |json|
-      json.(@sayt_suggestion, :id, :affiliate_id, :phrase, :popularity)
-      json.language "#{@sayt_suggestion.affiliate.indexing_locale}_analyzer"
-    end unless @sayt_suggestion.deleted_at.present?
-  end
+    return if sayt_suggestion.deleted_at.present?
 
+    Jbuilder.new do |json|
+      json.(sayt_suggestion, :id, :affiliate_id, :popularity)
+      json.set! 'phrase.keyword', sayt_suggestion.phrase
+      json.set! "phrase.#{language}", sayt_suggestion.phrase
+      json.language language
+    end
+  end
 end

--- a/app/models/elastic_sayt_suggestion_query.rb
+++ b/app/models/elastic_sayt_suggestion_query.rb
@@ -3,7 +3,7 @@ class ElasticSaytSuggestionQuery < ElasticTextFilteredQuery
   def initialize(options)
     super(options.merge({ sort: 'popularity:desc' }))
     @affiliate_id = options[:affiliate_id]
-    self.highlighted_fields = %w(phrase)
+    @text_fields = ['phrase']
   end
 
   def filtered_query_filter(json)

--- a/app/models/elastic_title_description_body_highlight_fields.rb
+++ b/app/models/elastic_title_description_body_highlight_fields.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module ElasticTitleDescriptionBodyHighlightFields
   def highlight_fields(json)
     json.fields do
-      json.set! :title, { number_of_fragments: 0 }
-      json.set! :description, { fragment_size: 75, number_of_fragments: 2 }
-      json.set! :body, { fragment_size: 75, number_of_fragments: 2 }
+      json.set! "title.#{language}", { number_of_fragments: 0 }
+      json.set! "description.#{language}", { fragment_size: 75, number_of_fragments: 2 }
+      json.set! "body.#{language}", { fragment_size: 75, number_of_fragments: 2 }
     end
   end
 

--- a/app/models/elastic_tweet.rb
+++ b/app/models/elastic_tweet.rb
@@ -1,19 +1,18 @@
+# frozen_string_literal: true
+
 class ElasticTweet
   extend Indexable
 
   self.settings = ElasticSettings::COMMON
 
   self.mappings = {
-    index_type => {
-      dynamic: :strict,
+    index_type => ElasticMappings::COMMON.deep_merge(
       properties: {
-        language: { type: 'keyword', index: true },
         twitter_profile_id: { type: 'long' },
-        tweet_text: { type: 'text', term_vector: 'with_positions_offsets' },
+        tweet_text: ElasticSettings::TEXT,
         published_at: { type: 'date' },
-        id: { type: 'long' }
       }
-    }
+    )
   }
 
 end

--- a/app/models/elastic_tweet.rb
+++ b/app/models/elastic_tweet.rb
@@ -10,9 +10,8 @@ class ElasticTweet
       properties: {
         twitter_profile_id: { type: 'long' },
         tweet_text: ElasticSettings::TEXT,
-        published_at: { type: 'date' },
+        published_at: { type: 'date' }
       }
     )
   }
-
 end

--- a/app/models/elastic_tweet_data.rb
+++ b/app/models/elastic_tweet_data.rb
@@ -1,15 +1,19 @@
+# frozen_string_literal: true
+
 class ElasticTweetData
+  attr_reader :tweet, :language
 
   def initialize(tweet)
     @tweet = tweet
+    @language = tweet.language
   end
 
   def to_builder
     Jbuilder.new do |json|
-      json.(@tweet, :id, :twitter_profile_id, :tweet_text)
-      json.published_at @tweet.published_at.strftime("%Y-%m-%dT%H:%M:%S")
-      json.language "#{@tweet.language}_analyzer"
+      json.(tweet, :id, :twitter_profile_id)
+      json.set! "tweet_text.#{language}", tweet.tweet_text
+      json.published_at tweet.published_at.strftime("%Y-%m-%dT%H:%M:%S")
+      json.language language
     end
   end
-
 end

--- a/app/models/elastic_tweet_query.rb
+++ b/app/models/elastic_tweet_query.rb
@@ -4,7 +4,7 @@ class ElasticTweetQuery < ElasticTextFilteredQuery
     super({ sort: 'published_at:desc' }.merge(options))
     @twitter_profile_ids = options[:twitter_profile_ids]
     @since_ts = options[:since]
-    self.highlighted_fields = %w(tweet_text)
+    @text_fields = ['tweet_text']
   end
 
   def filtered_query_filter(json)

--- a/lib/elastic_mappings.rb
+++ b/lib/elastic_mappings.rb
@@ -1,18 +1,22 @@
+# frozen_string_literal: true
+
 module ElasticMappings
   COMMON = {
     dynamic: :strict,
     properties: {
       language: { type: 'keyword', index: true },
-      affiliate_id: { type: 'integer' },
-      id: { type: 'integer' } }
+      id: { type: 'integer' },
+      bigram: { type: 'text', analyzer: 'bigram_analyzer'}
+    }
   }.freeze
 
   BEST_BET = COMMON.deep_merge(
     properties: {
+      affiliate_id: { type: 'integer' },
       status: { type: 'keyword', index: true },
       publish_start_on: { type: 'date', format: 'YYYY-MM-dd' },
       publish_end_on: { type: 'date', format: 'YYYY-MM-dd', null_value: '9999-12-31' },
-      title: { type: 'text', term_vector: 'with_positions_offsets' },
+      title: ElasticSettings::TEXT,
       match_keyword_values_only: { type: 'boolean',
                                    null_value: 'false' },
       keyword_values: ElasticSettings::KEYWORD }

--- a/lib/elastic_query.rb
+++ b/lib/elastic_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticQuery
 
   DEFAULT_SIZE = 10.freeze
@@ -5,7 +7,7 @@ class ElasticQuery
   DEFAULT_PRE_TAGS = %w(<strong>).freeze
   DEFAULT_POST_TAGS = %w(</strong>).freeze
   attr_reader :offset, :size, :sort
-  attr_accessor :highlighted_fields
+  attr_accessor :text_fields, :language
 
   def initialize(options)
     options.reverse_merge!(size: DEFAULT_SIZE)
@@ -13,7 +15,8 @@ class ElasticQuery
     @size = [options[:size].to_i, MAX_SIZE].min
     @q = options[:q]
     @highlighting = !(options[:highlighting] == false)
-    @text_analyzer = 'default'
+    @language = options[:language]
+    @text_analyzer = "#{options[:language]}_analyzer"
     @sort = options[:sort]
     @pre_tags = options[:pre_tags]
     @post_tags = options[:post_tags]
@@ -69,4 +72,7 @@ class ElasticQuery
     end
   end
 
+  def highlighted_fields
+    @highlighted_fields ||= text_fields.map{ |field| "#{field}.#{language}" }
+  end
 end

--- a/lib/elastic_query.rb
+++ b/lib/elastic_query.rb
@@ -73,6 +73,6 @@ class ElasticQuery
   end
 
   def highlighted_fields
-    @highlighted_fields ||= text_fields.map{ |field| "#{field}.#{language}" }
+    @highlighted_fields ||= text_fields.map { |field| "#{field}.#{language}" }
   end
 end

--- a/lib/elastic_results.rb
+++ b/lib/elastic_results.rb
@@ -33,7 +33,7 @@ class ElasticResults
 
   def highlight(highlight, instance)
     if highlight.present? and instance.present?
-      highlight.transform_keys!{ |key| key.remove(/\..*/) }
+      highlight.transform_keys! { |key| key.remove(/\..*/) }
       highlight_instance(highlight, instance)
     end
     instance

--- a/lib/elastic_results.rb
+++ b/lib/elastic_results.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ElasticResults
   attr_reader :total, :offset, :results, :aggregations, :suggestion
 
@@ -16,7 +18,7 @@ class ElasticResults
   private
 
   def extract_suggestion(suggestions)
-    Hashie::Mash::Rash.new(suggestions.first['options'].first) rescue nil
+    Hashie::Mash::Rash.new(suggestions.first['options'].first)
   end
 
   def extract_results(hits)
@@ -31,6 +33,7 @@ class ElasticResults
 
   def highlight(highlight, instance)
     if highlight.present? and instance.present?
+      highlight.transform_keys!{ |key| key.remove(/\..*/) }
       highlight_instance(highlight, instance)
     end
     instance

--- a/lib/elastic_settings.rb
+++ b/lib/elastic_settings.rb
@@ -4,6 +4,29 @@ module ElasticSettings
   KEYWORD = { type: 'keyword',
               normalizer: 'keyword_normalizer' }.freeze
 
+  TEXT = {
+           properties: {
+             en: {
+               type: 'text',
+               analyzer: 'en_analyzer',
+               copy_to: 'bigram',
+               term_vector: 'with_positions_offsets'
+             },
+             es: {
+               type: 'text',
+               analyzer: 'es_analyzer',
+               copy_to: 'bigram',
+               term_vector: 'with_positions_offsets'
+             },
+             babel: {
+               type: 'text',
+               analyzer: 'babel_analyzer',
+               copy_to: 'bigram',
+               term_vector: 'with_positions_offsets'
+             }
+           }
+         }
+
   COMMON = {
     index: {
       analysis: {

--- a/lib/elastic_settings.rb
+++ b/lib/elastic_settings.rb
@@ -5,27 +5,27 @@ module ElasticSettings
               normalizer: 'keyword_normalizer' }.freeze
 
   TEXT = {
-           properties: {
-             en: {
-               type: 'text',
-               analyzer: 'en_analyzer',
-               copy_to: 'bigram',
-               term_vector: 'with_positions_offsets'
-             },
-             es: {
-               type: 'text',
-               analyzer: 'es_analyzer',
-               copy_to: 'bigram',
-               term_vector: 'with_positions_offsets'
-             },
-             babel: {
-               type: 'text',
-               analyzer: 'babel_analyzer',
-               copy_to: 'bigram',
-               term_vector: 'with_positions_offsets'
-             }
-           }
-         }
+    properties: {
+      en: {
+        type: 'text',
+        analyzer: 'en_analyzer',
+        copy_to: 'bigram',
+        term_vector: 'with_positions_offsets'
+      },
+      es: {
+        type: 'text',
+        analyzer: 'es_analyzer',
+        copy_to: 'bigram',
+        term_vector: 'with_positions_offsets'
+      },
+      babel: {
+        type: 'text',
+        analyzer: 'babel_analyzer',
+        copy_to: 'bigram',
+        term_vector: 'with_positions_offsets'
+      }
+    }
+  }.freeze
 
   COMMON = {
     index: {
@@ -80,5 +80,4 @@ module ElasticSettings
       }
     }
   }.freeze
-
 end

--- a/spec/models/elastic_boosted_content_spec.rb
+++ b/spec/models/elastic_boosted_content_spec.rb
@@ -277,9 +277,7 @@ describe ElasticBoostedContent do
       end
     end
 
-    # Disabling until we re-implement per-language analysis:
-    # https://cm-jira.usa.gov/browse/SRCH-474
-    pending 'when various apostrophes are present in title/desc/keywords' do
+    context 'when various apostrophes are present in title/desc/keywords' do
       before do
         apostrophe_1 = affiliate.boosted_contents.build(title: "hawai`i o'reilly",
                                                            status: 'active',
@@ -354,9 +352,7 @@ describe ElasticBoostedContent do
         end
       end
 
-      # Disabling until we re-implement per-language analysis:
-      # https://cm-jira.usa.gov/browse/SRCH-474
-      pending 'when affiliate is English' do
+      context 'when affiliate is English' do
         before do
           affiliate.boosted_contents.create!(title: 'The affiliate interns use powerful engineering computers',
                                              status: 'active',
@@ -374,9 +370,7 @@ describe ElasticBoostedContent do
         end
       end
 
-      # Disabling until we re-implement per-language analysis:
-      # https://cm-jira.usa.gov/browse/SRCH-474
-      pending 'when affiliate is Spanish' do
+      context 'when affiliate is Spanish' do
         before do
           affiliate.locale = 'es'
           affiliate.boosted_contents.create!(title: 'Leyes y el rey',

--- a/spec/models/elastic_featured_collection_spec.rb
+++ b/spec/models/elastic_featured_collection_spec.rb
@@ -282,9 +282,7 @@ describe ElasticFeaturedCollection do
         end
       end
 
-      # Disabling until we re-implement per-language analysis:
-      # https://cm-jira.usa.gov/browse/SRCH-474
-      pending 'when affiliate is English' do
+      context 'when affiliate is English' do
         before do
           featured_collection = affiliate.featured_collections.build(title: 'The affiliate interns use powerful engineering computers',
                                                                      status: 'active',
@@ -304,9 +302,7 @@ describe ElasticFeaturedCollection do
         end
       end
 
-      # Disabling until we re-implement per-language analysis:
-      # https://cm-jira.usa.gov/browse/SRCH-474
-      pending 'when affiliate is Spanish' do
+      context 'when affiliate is Spanish' do
         before do
           affiliate.locale = 'es'
           featured_collection = affiliate.featured_collections.build(title: 'Leyes y el rey',

--- a/spec/models/elastic_indexed_document_spec.rb
+++ b/spec/models/elastic_indexed_document_spec.rb
@@ -110,7 +110,7 @@ describe ElasticIndexedDocument do
         ElasticIndexedDocument.commit
       end
 
-      it 'should show everything in two 75 char fragments joined by ellipses' do
+      it 'shows everything in two 75 char fragments joined by ellipses' do
         search = ElasticIndexedDocument.search_for(q: 'president', affiliate_id: affiliate.id, language: affiliate.indexing_locale)
         first = search.results.first
         ellipsized_results = "\uE000President\uE001 Obama overcame furious lobbying by big banks to pass Dodd-Frank Wall...snippets. This sentence ends with \uE000President\uE001 Obama. Excessive risk-taking led"
@@ -234,30 +234,18 @@ describe ElasticIndexedDocument do
           expect(ElasticIndexedDocument.search_for(q: 'Brad Miller -yellowstone', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(1)
         end
 
-        context 'when query contains specific field queries using "field:" followed by query term or grouped phrase or quoted string' do
-          it 'should find documents in the specified field based on term, advanced query or exact string' do
-            expect(ElasticIndexedDocument.search_for(q: 'Miller body:dolphins', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(1)
-            expect(ElasticIndexedDocument.search_for(q: 'Miller body:porpoises', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(0)
-            expect(ElasticIndexedDocument.search_for(q: 'Miller body:(dolphins OR whales)', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(2)
-            expect(ElasticIndexedDocument.search_for(q: 'Miller body:"text about dolphins"', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(1)
-          end
-        end
-
         context 'when query contains a wildcard' do
           it 'should find documents in the specified field based on truncation' do
             expect(ElasticIndexedDocument.search_for(q: 'dolphn*', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(0)
             expect(ElasticIndexedDocument.search_for(q: 'tx?', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(0)
             expect(ElasticIndexedDocument.search_for(q: 'dolph*', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(1)
-            expect(ElasticIndexedDocument.search_for(q: 'dolph?ns', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(1)
+            expect(ElasticIndexedDocument.search_for(q: 'dolph?n', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(1)
             expect(ElasticIndexedDocument.search_for(q: 'do*', affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to eq(2)
           end
         end
       end
 
-      # Elasticsearch 5x and higher does not support per-document analyzers therefore this
-      # test does not work at this time. Standard analyzers uses _none_ for stopwords.
-      # It also does not use stemming.  See https://cm-jira.usa.gov/browse/SRCH-474
-      pending 'when affiliate is English' do
+      context 'when affiliate is English' do
         before do
           affiliate.indexed_documents.create!(title: 'The affiliate interns use powerful engineering computers',
                                               description: 'Organic feet symbolize with oceanic views',
@@ -274,10 +262,7 @@ describe ElasticIndexedDocument do
         end
       end
 
-      # Elastic search 5x and higher does not support per-document analyzers therefore
-      # this test does not work at this time.  See https://cm-jira.usa.gov/browse/SRCH-474
-      # Standard analyzers uses _none_ for stopwords. It also does not use stemming.
-      pending 'when affiliate is Spanish' do
+      context 'when affiliate is Spanish' do
         before do
           affiliate.locale = 'es'
           affiliate.indexed_documents.create!(title: 'Leyes y el rey',

--- a/spec/models/elastic_news_item_spec.rb
+++ b/spec/models/elastic_news_item_spec.rb
@@ -260,9 +260,7 @@ describe ElasticNewsItem do
       end
     end
 
-    # Temporarily disabling these specs during ES56 upgrade
-    # https://cm-jira.usa.gov/browse/SRCH-836
-    pending 'synonyms and protected words' do
+    context 'synonyms and protected words' do
       it "should use both" do
         search = ElasticNewsItem.search_for(q: "gas", rss_feeds: [blog, gallery], language: 'en')
         expect(search.total).to eq(1)

--- a/spec/models/elastic_sayt_suggestion_spec.rb
+++ b/spec/models/elastic_sayt_suggestion_spec.rb
@@ -167,9 +167,7 @@ describe ElasticSaytSuggestion do
         end
       end
 
-      # Disabling until we re-implement per-language analysis:
-      # https://cm-jira.usa.gov/browse/SRCH-474
-      pending 'when affiliate is English' do
+      context 'when affiliate is English' do
         before do
           affiliate.sayt_suggestions.create!(phrase: 'the affiliate interns use powerful engineering computers', popularity: 45)
           affiliate.sayt_suggestions.create!(phrase: 'organic feet symbolize with oceanic views', popularity: 44)
@@ -184,9 +182,7 @@ describe ElasticSaytSuggestion do
         end
       end
 
-      # Disabling until we re-implement per-language analysis:
-      # https://cm-jira.usa.gov/browse/SRCH-474
-      pending 'when affiliate is Spanish' do
+      context 'when affiliate is Spanish' do
         before do
           affiliate.locale = 'es'
           affiliate.sayt_suggestions.create!(phrase: 'Leyes y el rey', popularity: 45)

--- a/spec/models/news_search_spec.rb
+++ b/spec/models/news_search_spec.rb
@@ -90,7 +90,7 @@ describe NewsSearch do
         expect(@search.run).to be true
       end
 
-      it 'has more than 0 results' do
+      it 'returns more than 0 results' do
         @search.run
         expect(@search.results.size).to be > 0
       end


### PR DESCRIPTION
This PR:
- re-enables the cucumber tests & code coverage check
- re-enables multi-lingual indexing & searching