### PR TITLE
SRCH-914 index news items in non-standard languages

### DIFF
--- a/app/models/elastic_data/elastic_news_item_data.rb
+++ b/app/models/elastic_data/elastic_news_item_data.rb
@@ -7,7 +7,7 @@ class ElasticNewsItemData
 
   def initialize(news_item)
     @news_item = news_item
-    @language = news_item.language
+    @language = news_item.owner_language_guess
   end
 
   def to_builder

--- a/spec/models/elastic_news_item_spec.rb
+++ b/spec/models/elastic_news_item_spec.rb
@@ -7,6 +7,13 @@ describe ElasticNewsItem do
   let(:gallery) { rss_feeds(:white_house_press_gallery) }
   let(:white_house_blog_url) { rss_feed_urls(:white_house_blog_url) }
   let(:white_house_press_gallery_url) { rss_feed_urls(:white_house_press_gallery_url) }
+  let(:search_params) do
+    {
+      q: 'Obama',
+      rss_feeds: [blog]
+    }
+  end
+  let(:search) { ElasticNewsItem.search_for(search_params) }
 
   before do
     ElasticNewsItem.recreate_index
@@ -215,7 +222,8 @@ describe ElasticNewsItem do
           {
             rss_feeds: [blog],
             language: affiliate.indexing_locale,
-            title_only: true
+            title_only: true,
+            q: 'superknuller'
           }
         end
         let(:news_item_params) do
@@ -241,10 +249,8 @@ describe ElasticNewsItem do
           end
 
           it 'does downcasing and ASCII folding only' do
-            appropriate_stemming = ['superknuller', 'woche']
-            appropriate_stemming.each do |query|
-              expect(ElasticNewsItem.search_for(search_params.merge(q: query)).total).to eq(1)
-            end
+            expect(search.total).to eq(1)
+            expect(search.results.first.title).to match(/Angebote/)
           end
         end
 
@@ -257,10 +263,8 @@ describe ElasticNewsItem do
           end
 
           it 'does downcasing and ASCII folding only' do
-            appropriate_stemming = ['superknuller', 'woche']
-            appropriate_stemming.each do |query|
-              expect(ElasticNewsItem.search_for(search_params.merge(q: query)).total).to eq(1)
-            end
+            expect(search.total).to eq(1)
+            expect(search.results.first.title).to match(/Angebote/)
           end
         end
       end


### PR DESCRIPTION
This PR resolves a production bug that I discovered during migration testing. News items need to be indexed using the associated affiliate's "indexing locale" (accessible via the `NewsItem#owner_language_guess` method), rather than the `news_item.language` method. This ensures that news items that are not in English or Spanish will be indexed using the `babel` analyzer.