### PR TITLE
SRCH-948 freeze secrets for Elasticsearch config

### DIFF
--- a/lib/es.rb
+++ b/lib/es.rb
@@ -32,7 +32,7 @@ module ES
     private
 
     def self.client_config(mode)
-      Rails.application.secrets['analytics']['elasticsearch'][mode]
+      Rails.application.secrets['analytics']['elasticsearch'][mode].freeze
     end
   end
 
@@ -41,7 +41,7 @@ module ES
     private
 
     def self.client_config(mode)
-      Rails.application.secrets['custom_indices']['elasticsearch'][mode]
+      Rails.application.secrets['custom_indices']['elasticsearch'][mode].freeze
     end
   end
 end

--- a/spec/lib/es_spec.rb
+++ b/spec/lib/es_spec.rb
@@ -36,7 +36,8 @@ describe ES do
     let(:es_config) { Rails.application.secrets.analytics['elasticsearch'] }
 
     describe '.client_reader' do
-      let(:host) { ES::ELK.client_reader.transport.hosts.first }
+      subject(:client_reader) { ES::ELK.client_reader }
+      let(:host) { client_reader.transport.hosts.first }
 
       it 'uses the values from the secrets.yml analytics[elasticsearch][reader] entry' do
         expect(host[:host]).to eq(URI(es_config['reader']['host']).host)
@@ -45,6 +46,8 @@ describe ES do
     end
 
     describe '.client_writers' do
+      subject(:client_writers) { ES::ELK.client_writers }
+
       it 'uses the value(s) from the secrets.yml analytics[elasticsearch][writers] entry' do
         count = Rails.application.secrets.analytics['elasticsearch']['writers'].count
         expect(ES::ELK.client_writers.size).to eq(count)
@@ -54,6 +57,11 @@ describe ES do
           expect(host[:user]).to eq(es_config['writers'][i]['user'])
         end
       end
+
+      it 'freezes the secrets' do
+        client_writers
+        expect(es_config['writers']).to be_frozen
+      end
     end
   end
 
@@ -61,7 +69,8 @@ describe ES do
     let(:es_config) { Rails.application.secrets.custom_indices['elasticsearch'] }
 
     describe '.client_reader' do
-      let(:host) { ES::CustomIndices.client_reader.transport.hosts.first }
+      subject(:client_reader) { ES::CustomIndices.client_reader }
+      let(:host) { client_reader.transport.hosts.first }
 
       it 'uses the values from the secrets.yml custom_indices[elasticsearch][reader] entry' do
         expect(host[:host]).to eq(URI(es_config['reader']['host']).host)
@@ -70,14 +79,21 @@ describe ES do
     end
 
     describe '.client_writers' do
+      subject(:client_writers) { ES::CustomIndices.client_writers }
+
       it 'uses the value(s) from the secrets.yml custom_indices[elasticsearch][writers] entry' do
         count = Rails.application.secrets.custom_indices['elasticsearch']['writers'].count
-        expect(ES::CustomIndices.client_writers.size).to eq(count)
+        expect(client_writers.size).to eq(count)
         count.times do |i|
-          host = ES::CustomIndices.client_writers.first.transport.hosts[i]
+          host = client_writers.first.transport.hosts[i]
           expect(host[:host]).to eq(URI(es_config['writers'][i]['host']).host)
           expect(host[:user]).to eq(es_config['writers'][i]['user'])
         end
+      end
+
+      it 'freezes the secrets' do
+        client_writers
+        expect(es_config['writers']).to be_frozen
       end
     end
   end


### PR DESCRIPTION
These changes ensure that the secrets used to configure Elasticsearch cannot be mutated.