### PR TITLE
SRCH-955 pass an array of hosts to Elasticsearch client

### DIFF
--- a/config/elasticsearch_client.yml
+++ b/config/elasticsearch_client.yml
@@ -1,6 +1,6 @@
 default: &DEFAULT
   log: false
-  randomize_connections: true
+  randomize_hosts: true
   reload_connections: true
   reload_on_failure: true
   retry_on_failure: 1

--- a/config/elasticsearch_client.yml
+++ b/config/elasticsearch_client.yml
@@ -1,0 +1,16 @@
+default: &DEFAULT
+  log: false
+  randomize_connections: true
+  reload_connections: true
+  reload_on_failure: true
+  retry_on_failure: 1
+
+development:
+  <<: *DEFAULT
+  retry_on_failure: false
+
+test:
+  <<: *DEFAULT
+
+production:
+  <<: *DEFAULT

--- a/config/secrets.yml.dev
+++ b/config/secrets.yml.dev
@@ -78,15 +78,15 @@ dev_settings: &DEV_SETTINGS
   custom_indices:
     elasticsearch:
       reader:
-        host: http://localhost:9200
+        hosts:
+          - http://localhost:9200
         user: elastic
         password: changeme
-        log: false
       writers:
-        - host: http://localhost:9200
+        - hosts:
+            - http://localhost:9200
           user: elastic
           password: changeme
-          log: false
   jobs:
     <<: *JOBS_SECRETS
     host: 'https://data.usajobs.gov'

--- a/lib/es.rb
+++ b/lib/es.rb
@@ -4,6 +4,7 @@ require 'typhoeus/adapters/faraday'
 
 module ES
   INDEX_PREFIX = "#{Rails.env}-usasearch"
+  CLIENT_CONFIG = Rails.application.config_for(:elasticsearch_client).freeze
 
   def client_reader
     @client_reader ||= initialize_client(reader_config)
@@ -24,7 +25,7 @@ module ES
   end
 
   def initialize_client(config)
-    Elasticsearch::Client.new(config.symbolize_keys)
+    Elasticsearch::Client.new(config.merge(CLIENT_CONFIG).symbolize_keys)
   end
 
   module ELK

--- a/spec/lib/es_spec.rb
+++ b/spec/lib/es_spec.rb
@@ -61,24 +61,31 @@ describe ES do
     let(:es_config) { Rails.application.secrets.custom_indices['elasticsearch'] }
 
     describe '.client_reader' do
+      let(:client) { ES::CustomIndices.client_reader }
       let(:host) { ES::CustomIndices.client_reader.transport.hosts.first }
 
       it 'uses the values from the secrets.yml custom_indices[elasticsearch][reader] entry' do
-        expect(host[:host]).to eq(URI(es_config['reader']['host']).host)
+        expect(host[:host]).to eq(URI(es_config['reader']['hosts'].first).host)
         expect(host[:user]).to eq(es_config['reader']['user'])
       end
+
+      it_behaves_like 'an Elasticsearch client'
     end
 
     describe '.client_writers' do
+      let(:client) { ES::CustomIndices.client_writers.first }
+
       it 'uses the value(s) from the secrets.yml custom_indices[elasticsearch][writers] entry' do
         count = Rails.application.secrets.custom_indices['elasticsearch']['writers'].count
         expect(ES::CustomIndices.client_writers.size).to eq(count)
         count.times do |i|
           host = ES::CustomIndices.client_writers.first.transport.hosts[i]
-          expect(host[:host]).to eq(URI(es_config['writers'][i]['host']).host)
+          expect(host[:host]).to eq(URI(es_config['writers'][i]['hosts'].first).host)
           expect(host[:user]).to eq(es_config['writers'][i]['user'])
         end
       end
+
+      it_behaves_like 'an Elasticsearch client'
     end
   end
 end

--- a/spec/support/elasticsearch_client_behavior.rb
+++ b/spec/support/elasticsearch_client_behavior.rb
@@ -8,7 +8,7 @@ shared_examples 'an Elasticsearch client' do
     it 'uses the specified options' do
       options = {
         log: false,
-        randomize_connections: true,
+        randomize_hosts: true,
         reload_connections: true,
         reload_on_failure: true,
         retry_on_failure: 1

--- a/spec/support/elasticsearch_client_behavior.rb
+++ b/spec/support/elasticsearch_client_behavior.rb
@@ -1,0 +1,23 @@
+shared_examples 'an Elasticsearch client' do
+  describe 'configuration' do
+    it 'uses an adapter that supports persistent connections' do
+      handler = client.transport.connections.first.connection.builder.handlers.first
+      expect(handler).to eq(Faraday::Adapter::Typhoeus)
+    end
+
+    it 'uses the specified options' do
+      options = {
+        log: false,
+        randomize_connections: true,
+        reload_connections: true,
+        reload_on_failure: true,
+        retry_on_failure: 1
+      }
+      expect(client.transport.options).to include(options)
+    end
+
+    it 'can connect to Elasticsearch' do
+      expect(client.ping).to eq(true)
+    end
+  end
+end


### PR DESCRIPTION
This PR updates the configuration for the ES client used by the custom indices. This allows us to pass all the ES hosts directly to the client, rather than a single haproxy listener.

I am adding a "Do Not Merge" label, as this depends on a corresponding update in the cookbooks.