### PR TITLE
SRCH-892 - remove password fields for edit my account page

### DIFF
--- a/app/views/users/_form.haml
+++ b/app/views/users/_form.haml
@@ -7,8 +7,3 @@
 = form.text_field :organization_name
 = form.label :email, 'Email', class: 'required'
 = form.email_field :email, class: 'required'
-= form.label :password, 'New Password'
-= form.password_field :password, class: 'required'
-= form.label :current_password, "Current Password (Required for password changes)"
-= form.password_field :current_password, class: 'required'
-= render partial: 'users/password_requirements'

--- a/features/step_definitions/affiliate_steps.rb
+++ b/features/step_definitions/affiliate_steps.rb
@@ -3,7 +3,6 @@ Given /^the following( legacy| search consumer| SearchGov)? Affiliates exist:$/ 
   table.hashes.each do |hash|
     valid_options = {
         email: hash[:contact_email],
-        password: 'test1234!',
         contact_name: hash[:contact_name],
         organization_name: 'Agency'
     }


### PR DESCRIPTION
This pull request removes the password fields for edit account page. 
cleaned up a cucumber test.
Note: A lot of cucumber and rspec tests will need to be cleaned up. I am leaving this for the end. Jira ticket # SRCH-993