### PR TITLE
SRCH-628 resolve deprecation warnings re. positional arguments

### DIFF
--- a/spec/controllers/help_docs_controller_spec.rb
+++ b/spec/controllers/help_docs_controller_spec.rb
@@ -37,7 +37,7 @@ describe HelpDocsController do
 
       before do
         expect(HelpDoc).not_to receive(:extract_article)
-        get :show, url: url, format: :json
+        get :show, params: { url: url }, format: :json
       end
       it { is_expected.to redirect_to('https://www.usa.gov/search-error') }
     end

--- a/spec/requests/api/v2/search_spec.rb
+++ b/spec/requests/api/v2/search_spec.rb
@@ -100,7 +100,9 @@ describe '/api/v2/search' do
       end
 
       it 'returns JSON results with highlighting' do
-        get '/api/v2/search', access_key: 'usagov_key', affiliate: 'usagov', query: 'api'
+        get '/api/v2/search', params: { access_key: 'usagov_key',
+                                        affiliate: 'usagov',
+                                        query: 'api' }
         expect(response.status).to eq(200)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -130,7 +132,10 @@ describe '/api/v2/search' do
       end
 
       it 'returns JSON results without highlighting' do
-        get '/api/v2/search', access_key: 'usagov_key', affiliate: 'usagov', query: 'api', enable_highlighting: 'false'
+        get '/api/v2/search', params: { access_key: 'usagov_key',
+                                        affiliate: 'usagov',
+                                        query: 'api',
+                                        enable_highlighting: 'false' }
         expect(response.status).to eq(200)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -159,7 +164,10 @@ describe '/api/v2/search' do
       end
 
       it 'returns JSON results without highlighting' do
-        get '/api/v2/search', access_key: 'usagov_key', affiliate: 'usagov', query: 'api', limit: '1'
+        get '/api/v2/search', params: { access_key: 'usagov_key',
+                                        affiliate: 'usagov',
+                                        query: 'api',
+                                        limit: '1' }
         expect(response.status).to eq(200)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -184,7 +192,10 @@ describe '/api/v2/search' do
 
     context 'when offset = 3' do
       it 'returns JSON results without highlighting' do
-        get '/api/v2/search', access_key: 'usagov_key', affiliate: 'usagov', query: 'api', offset: '2'
+        get '/api/v2/search', params: { access_key: 'usagov_key',
+                                        affiliate: 'usagov',
+                                        query: 'api',
+                                        offset: '2' }
         expect(response.status).to eq(200)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -203,7 +214,10 @@ describe '/api/v2/search' do
       end
 
       it 'returns JSON results sorted by published_at in descending order' do
-        get '/api/v2/search', access_key: 'usagov_key', affiliate: 'usagov', query: 'api', sort_by: 'date'
+        get '/api/v2/search', params: { access_key: 'usagov_key',
+                                        affiliate: 'usagov',
+                                        query: 'api',
+                                        sort_by: 'date' }
         expect(response.status).to eq(200)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -227,7 +241,10 @@ describe '/api/v2/search' do
 
     context 'when query contains spelling error' do
       it 'returns JSON results with spelling correction' do
-        get '/api/v2/search', access_key: 'usagov_key', affiliate: 'usagov', query: 'descripton', sort_by: 'date'
+        get '/api/v2/search', params: { access_key: 'usagov_key',
+                                        affiliate: 'usagov',
+                                        query: 'descripton',
+                                        sort_by: 'date' }
         expect(response.status).to eq(200)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -238,7 +255,10 @@ describe '/api/v2/search' do
         before { SuggestionBlock.create!(query: 'descripton') }
 
         it 'returns JSON results with nil spelling correction' do
-          get '/api/v2/search', access_key: 'usagov_key', affiliate: 'usagov', query: 'descripton', sort_by: 'date'
+          get '/api/v2/search', params: { access_key: 'usagov_key',
+                                          affiliate: 'usagov',
+                                          query: 'descripton',
+                                          sort_by: 'date' }
           expect(response.status).to eq(200)
 
           hash_response = JSON.parse response.body, symbolize_names: true
@@ -251,7 +271,7 @@ describe '/api/v2/search' do
   context 'when one of the parameter is invalid' do
     context 'when access_key is not present' do
       it 'returns errors' do
-        get '/api/v2/search', affiliate: 'not-usagov', query: 'api'
+        get '/api/v2/search', params: { affiliate: 'not-usagov', query: 'api' }
         expect(response.status).to eq(400)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -261,7 +281,9 @@ describe '/api/v2/search' do
 
     context 'when access_key is invalid' do
       it 'returns errors' do
-        get '/api/v2/search', access_key: 'not_usagov_key', affiliate: 'usagov', query: 'api'
+        get '/api/v2/search', params: { access_key: 'not_usagov_key',
+                                        affiliate: 'usagov',
+                                        query: 'api' }
         expect(response.status).to eq(400)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -271,7 +293,9 @@ describe '/api/v2/search' do
 
     context 'when affiliate is invalid' do
       it 'returns errors' do
-        get '/api/v2/search', access_key: 'usagov_key', affiliate: 'not-usagov', query: 'api'
+        get '/api/v2/search', params: { access_key: 'usagov_key',
+                                        affiliate: 'not-usagov',
+                                        query: 'api' }
         expect(response.status).to eq(400)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -281,7 +305,10 @@ describe '/api/v2/search' do
 
     context 'when limit is invalid' do
       it 'returns errors' do
-        get '/api/v2/search', access_key: 'usagov_key', affiliate: 'usagov', limit: '5000', query: 'api'
+        get '/api/v2/search', params: { access_key: 'usagov_key',
+                                        affiliate: 'usagov',
+                                        limit: '5000',
+                                        query: 'api' }
         expect(response.status).to eq(400)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -291,7 +318,10 @@ describe '/api/v2/search' do
 
     context 'when offset is invalid' do
       it 'returns errors' do
-        get '/api/v2/search', access_key: 'usagov_key', affiliate: 'usagov', offset: '5000', query: 'api'
+        get '/api/v2/search', params: { access_key: 'usagov_key',
+                                        affiliate: 'usagov',
+                                        offset: '5000',
+                                        query: 'api' }
         expect(response.status).to eq(400)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -301,7 +331,9 @@ describe '/api/v2/search' do
 
     context 'when query is blank' do
       it 'returns errors' do
-        get '/api/v2/search', access_key: 'usagov_key', affiliate: 'usagov', query: ''
+        get '/api/v2/search', params: { access_key: 'usagov_key',
+                                        affiliate: 'usagov',
+                                        query: '' }
         expect(response.status).to eq(400)
 
         hash_response = JSON.parse response.body, symbolize_names: true
@@ -325,7 +357,7 @@ describe '/api/v2/search' do
     let(:hash_response) { JSON.parse response.body, symbolize_names: true }
 
     it 'returns the formatted query' do
-      get '/api/v2/search', advanced_search_params
+      get '/api/v2/search', params: advanced_search_params
       expect(hash_response[:query]).to eq 'taxes site:irs.gov "exact phrase" -exclude (alternative) filetype:pdf'
     end
   end

--- a/spec/requests/clicked_spec.rb
+++ b/spec/requests/clicked_spec.rb
@@ -17,21 +17,44 @@ describe "Clicked" do
   context "when correct information is passed in" do
 
     it "should return success with a blank message body" do
-      get '/clicked', u: @url, q: @query, t: @timestamp, a: @affiliate_name, p: @position, s: @module, v: @vertical, l: @locale, i: @model_id
+      get '/clicked', params: { u: @url,
+                                q: @query,
+                                t: @timestamp,
+                                a: @affiliate_name,
+                                p: @position,
+                                s: @module,
+                                v: @vertical,
+                                l: @locale,
+                                i: @model_id }
       expect(response.success?).to be(true)
       expect(response.body).to eq('')
     end
 
     it "should log the click" do
       expect(Click).to receive(:log).with(@unescaped_url, @query, '2010-04-22 23:28:25', '127.0.0.1', @affiliate_name, @position, @module, @vertical, @locale, anything(), @model_id)
-      get '/clicked', u: @url, q: @query, t: @timestamp, a: @affiliate_name, p: @position, s: @module, v: @vertical, l: @locale, i: @model_id
+      get '/clicked', params: { u: @url,
+                                q: @query,
+                                t: @timestamp,
+                                a: @affiliate_name,
+                                p: @position,
+                                s: @module,
+                                v: @vertical,
+                                l: @locale,
+                                i: @model_id }
     end
 
   end
 
   context "when click url is missing" do
     before do
-      get '/clicked', q: @query, t: @timestamp, a: @affiliate_name, p: @position, s: @module, v: @vertical, l: @locale, i: @model_id
+      get '/clicked', params: { q: @query,
+                                t: @timestamp,
+                                a: @affiliate_name,
+                                p: @position,
+                                s: @module,
+                                v: @vertical,
+                                l: @locale,
+                                i: @model_id }
     end
 
     it "should return success with a blank message body" do

--- a/spec/requests/clicked_spec.rb
+++ b/spec/requests/clicked_spec.rb
@@ -1,22 +1,22 @@
 require 'spec_helper'
 
-describe "Clicked" do
+describe 'Clicked' do
   before do
-    @url = "http://localhost:3000/search?locale=en&m=false&query=electrocoagulation++%29++%28site%3Awww.uspto.gov+%7C+site%3Aeipweb.uspto.gov%29+"
+    @url = 'http://localhost:3000/search?locale=en&m=false&query=electrocoagulation++%29++%28site%3Awww.uspto.gov+%7C+site%3Aeipweb.uspto.gov%29+'
     @unescaped_url = CGI::unescape(@url).gsub(' ', '+')
-    @query = "chicken & beef recall"
-    @timestamp = "1271978905"
-    @affiliate_name = "some affiliate"
-    @position = "7"
-    @module = "RECALL"
-    @vertical = "web"
-    @locale = "en"
+    @query = 'chicken & beef recall'
+    @timestamp = '1271978905'
+    @affiliate_name = 'some affiliate'
+    @position = '7'
+    @module = 'RECALL'
+    @vertical = 'web'
+    @locale = 'en'
     @model_id = '1234'
   end
 
-  context "when correct information is passed in" do
+  context 'when correct information is passed in' do
 
-    it "should return success with a blank message body" do
+    it 'returns success with a blank message body' do
       get '/clicked', params: { u: @url,
                                 q: @query,
                                 t: @timestamp,
@@ -30,8 +30,18 @@ describe "Clicked" do
       expect(response.body).to eq('')
     end
 
-    it "should log the click" do
-      expect(Click).to receive(:log).with(@unescaped_url, @query, '2010-04-22 23:28:25', '127.0.0.1', @affiliate_name, @position, @module, @vertical, @locale, anything(), @model_id)
+    it 'logs the click' do
+      expect(Click).to receive(:log).with(@unescaped_url,
+                                          @query,
+                                          '2010-04-22 23:28:25',
+                                          '127.0.0.1',
+                                          @affiliate_name,
+                                          @position,
+                                          @module,
+                                          @vertical,
+                                          @locale,
+                                          anything(),
+                                          @model_id)
       get '/clicked', params: { u: @url,
                                 q: @query,
                                 t: @timestamp,
@@ -45,7 +55,7 @@ describe "Clicked" do
 
   end
 
-  context "when click url is missing" do
+  context 'when click url is missing' do
     before do
       get '/clicked', params: { q: @query,
                                 t: @timestamp,
@@ -57,12 +67,12 @@ describe "Clicked" do
                                 i: @model_id }
     end
 
-    it "should return success with a blank message body" do
+    it 'returns success with a blank message body' do
       expect(response.success?).to be(true)
       expect(response.body).to eq('')
     end
 
-    it "should not log the click information" do
+    it 'does not log the click information' do
       expect(Click).not_to receive(:log)
     end
   end

--- a/spec/requests/image_searches_spec.rb
+++ b/spec/requests/image_searches_spec.rb
@@ -23,7 +23,7 @@ describe '/search/images' do
 
     context 'when query is present' do
       before do
-        get '/search/images.json', { affiliate: affiliate.name, query: 'white house' }
+        get '/search/images.json', params: { affiliate: affiliate.name, query: 'white house' }
       end
 
       it 'responds with search results from Oasis' do
@@ -41,7 +41,7 @@ describe '/search/images' do
 
     context 'when query is blank' do
       before do
-        get '/search/images.json', { affiliate: affiliate.name, query: ' ' }
+        get '/search/images.json', params: { affiliate: affiliate.name, query: ' ' }
       end
 
       it 'responds with error message' do
@@ -55,7 +55,7 @@ describe '/search/images' do
     let(:affiliate) { affiliates(:bing_image_search_enabled_affiliate) }
 
     before do
-      get '/search/images.json', { affiliate: affiliate.name, query: 'white house' }
+      get '/search/images.json', params: { affiliate: affiliate.name, query: 'white house' }
     end
 
     it 'renders JSON response' do

--- a/spec/requests/sayt_spec.rb
+++ b/spec/requests/sayt_spec.rb
@@ -6,7 +6,9 @@ describe 'sayt' do
   let(:affiliate) { affiliates(:usagov_affiliate) }
   let(:phrases) { ['lorem ipsum dolor sit amet', 'lorem ipsum sic transit gloria'].freeze }
   let(:phrases_in_json) { phrases.to_json.freeze }
-  let(:phrases_with_section_and_label_in_json) { phrases.collect { |p| { section: 'default', label: p } }.to_json.freeze }
+  let(:phrases_with_section_and_label_in_json) do
+    phrases.collect { |p| { section: 'default', label: p } }.to_json.freeze
+  end
 
   before do
     SaytController.class_eval {
@@ -22,24 +24,35 @@ describe 'sayt' do
 
   context 'when name and query are present' do
     it 'should return an array of suggestions' do
-      get '/sayt', :q => 'lorem  \\  ipsum', :callback => 'jsonp1234', :aid => affiliate.id
+      get '/sayt', params: { q: 'lorem  \\  ipsum',
+                             callback: 'jsonp1234',
+                             aid: affiliate.id }
       expect(response.body).to eq(%Q{/**/jsonp1234(#{phrases_in_json})})
     end
 
     it "should return empty JSONP if nothing matches the 'q' param string" do
-      get '/sayt', :q => "who moved my cheese", :callback => 'jsonp1276290049647', :aid => affiliate.id
+      get '/sayt', params: { q: "who moved my cheese",
+                             callback: 'jsonp1276290049647',
+                             aid: affiliate.id }
       expect(response.body).to eq('/**/jsonp1276290049647([])')
     end
 
     it "should not completely melt down when strange characters are present" do
-      expect { get '/sayt', :q => "foo\\", :callback => 'jsonp1276290049647', :aid => affiliate.id }.not_to raise_error
-      expect { get '/sayt', :q => "foo's", :callback => 'jsonp1276290049647', :aid => affiliate.id }.not_to raise_error
+      expect do
+        get '/sayt', params: { q: "foo\\", callback: 'jsonp1276290049647', aid: affiliate.id }
+      end.not_to raise_error
+      expect do
+        get '/sayt', params: { q: "foo's", callback: 'jsonp1276290049647', aid: affiliate.id }
+      end.not_to raise_error
     end
   end
 
   context 'when extras is present' do
     it 'should return jsonp with section and label' do
-      get '/sayt', :name => affiliate.name, :q => 'lorem \\ ipsum', :callback => 'jsonp1234', :extras => 'true'
+      get '/sayt', params: { name: affiliate.name,
+                             q: 'lorem \\ ipsum',
+                             callback: 'jsonp1234',
+                             extras: 'true' }
       expect(response.body).to eq(%Q{/**/jsonp1234(#{phrases_with_section_and_label_in_json})})
     end
 
@@ -68,19 +81,28 @@ describe 'sayt' do
       end
 
       it 'should return results with SaytSuggestions and Boosted Contents' do
-        get '/sayt', :name => affiliate.name, :q => 'lorem', :callback => 'jsonp1234', :extras => 'true'
+        get '/sayt', params: { name: affiliate.name,
+                               q: 'lorem',
+                               callback: 'jsonp1234',
+                               extras: 'true' }
         results = phrases.collect { |p| { section: 'default', label: p } }
         results << { section: 'Recommended Pages', label: 'Lorem Boosted Content 1', data: 'http://agency.gov/boosted_content1.html'}
         expect(response.body).to eq(%Q{/**/jsonp1234(#{results.to_json})})
       end
 
       it 'should not return SAYT results that do not start with query' do
-        get '/sayt', :name => affiliate.name, :q => 'orem', :callback => 'jsonp1234', :extras => 'true'
+        get '/sayt', params: { name: affiliate.name,
+                               q: 'orem',
+                               callback: 'jsonp1234',
+                               extras: 'true' }
         expect(response.body).to eq('/**/jsonp1234([])')
       end
 
       it 'should not return Boosted Contents that do not start with query' do
-        get '/sayt', :name => affiliate.name, :q => 'Boosted', :callback => 'jsonp1234', :extras => 'true'
+        get '/sayt', params: { name: affiliate.name,
+                               q: 'Boosted',
+                               callback: 'jsonp1234',
+                               extras: 'true' }
         expect(response.body).to eq('/**/jsonp1234([])')
       end
     end
@@ -97,7 +119,9 @@ describe 'sayt' do
     end
 
     it 'should search for suggestions' do
-      get '/sayt', :name => affiliate.name, :q => 'lorem \\ ipsum', :callback => 'jsonp1234'
+      get '/sayt', params: { name: affiliate.name,
+                             q: 'lorem \\ ipsum',
+                             callback: 'jsonp1234' }
       expect(response.body).to eq(%Q{/**/jsonp1234(#{phrases_in_json})})
     end
   end

--- a/spec/requests/sayt_spec.rb
+++ b/spec/requests/sayt_spec.rb
@@ -23,21 +23,21 @@ describe 'sayt' do
   end
 
   context 'when name and query are present' do
-    it 'should return an array of suggestions' do
+    it 'returns an array of suggestions' do
       get '/sayt', params: { q: 'lorem  \\  ipsum',
                              callback: 'jsonp1234',
                              aid: affiliate.id }
       expect(response.body).to eq(%Q{/**/jsonp1234(#{phrases_in_json})})
     end
 
-    it "should return empty JSONP if nothing matches the 'q' param string" do
-      get '/sayt', params: { q: "who moved my cheese",
+    it "returns empty JSONP if nothing matches the 'q' param string" do
+      get '/sayt', params: { q: 'who moved my cheese',
                              callback: 'jsonp1276290049647',
                              aid: affiliate.id }
       expect(response.body).to eq('/**/jsonp1276290049647([])')
     end
 
-    it "should not completely melt down when strange characters are present" do
+    it 'does not completely melt down when strange characters are present' do
       expect do
         get '/sayt', params: { q: "foo\\", callback: 'jsonp1276290049647', aid: affiliate.id }
       end.not_to raise_error
@@ -48,7 +48,7 @@ describe 'sayt' do
   end
 
   context 'when extras is present' do
-    it 'should return jsonp with section and label' do
+    it 'returns jsonp with section and label' do
       get '/sayt', params: { name: affiliate.name,
                              q: 'lorem \\ ipsum',
                              callback: 'jsonp1234',
@@ -80,7 +80,7 @@ describe 'sayt' do
                                publish_start_on: Date.today)
       end
 
-      it 'should return results with SaytSuggestions and Boosted Contents' do
+      it 'returns results with SaytSuggestions and Boosted Contents' do
         get '/sayt', params: { name: affiliate.name,
                                q: 'lorem',
                                callback: 'jsonp1234',
@@ -90,7 +90,7 @@ describe 'sayt' do
         expect(response.body).to eq(%Q{/**/jsonp1234(#{results.to_json})})
       end
 
-      it 'should not return SAYT results that do not start with query' do
+      it 'does not return SAYT results that do not start with query' do
         get '/sayt', params: { name: affiliate.name,
                                q: 'orem',
                                callback: 'jsonp1234',
@@ -98,7 +98,7 @@ describe 'sayt' do
         expect(response.body).to eq('/**/jsonp1234([])')
       end
 
-      it 'should not return Boosted Contents that do not start with query' do
+      it 'does not return Boosted Contents that do not start with query' do
         get '/sayt', params: { name: affiliate.name,
                                q: 'Boosted',
                                callback: 'jsonp1234',
@@ -118,7 +118,7 @@ describe 'sayt' do
       end
     end
 
-    it 'should search for suggestions' do
+    it 'searches for suggestions' do
       get '/sayt', params: { name: affiliate.name,
                              q: 'lorem \\ ipsum',
                              callback: 'jsonp1234' }

--- a/spec/requests/searches_spec.rb
+++ b/spec/requests/searches_spec.rb
@@ -8,7 +8,10 @@ describe SearchesController do
     context "when the request is from a mobile device" do
       before do
         iphone_user_agent = "Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3"
-        get "/search/news", {:query => 'element', :affiliate => affiliate.name, :channel => rss_feeds(:white_house_blog).id}, { "HTTP_USER_AGENT" => iphone_user_agent }
+        get "/search/news", params:  { query: 'element',
+                                       affiliate: affiliate.name,
+                                       channel: rss_feeds(:white_house_blog).id },
+                            headers: { "HTTP_USER_AGENT" => iphone_user_agent }
       end
 
       it "should set format to mobile" do
@@ -25,7 +28,9 @@ describe SearchesController do
     context "when the request is from a mobile device" do
       before do
         iphone_user_agent = "Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3"
-        get "/search/docs", {:query => "pdf", :affiliate => affiliate.name}, { "HTTP_USER_AGENT" => iphone_user_agent }
+        get "/search/docs", params: { query: "pdf",
+                                      affiliate: affiliate.name },
+                            headers:  { "HTTP_USER_AGENT" => iphone_user_agent }
       end
 
       it "should set format to mobile" do

--- a/spec/requests/searches_spec.rb
+++ b/spec/requests/searches_spec.rb
@@ -4,40 +4,40 @@ describe SearchesController do
   fixtures :affiliates, :rss_feeds, :news_items
   let(:affiliate) { affiliates(:basic_affiliate) }
 
-  context "#news" do
-    context "when the request is from a mobile device" do
+  context '#news' do
+    context 'when the request is from a mobile device' do
       before do
-        iphone_user_agent = "Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3"
-        get "/search/news", params:  { query: 'element',
+        iphone_user_agent = 'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3'
+        get '/search/news', params:  { query: 'element',
                                        affiliate: affiliate.name,
                                        channel: rss_feeds(:white_house_blog).id },
-                            headers: { "HTTP_USER_AGENT" => iphone_user_agent }
+                            headers: { 'HTTP_USER_AGENT' => iphone_user_agent }
       end
 
-      it "should set format to mobile" do
+      it 'sets the format to mobile' do
         expect(request.format.to_sym).to eq(:mobile)
       end
 
-      it "should sucessfully response" do
+      it 'responds sucessfully' do
         expect(response.status).to eq(200)
       end
     end
   end
 
-  context "#docs" do
-    context "when the request is from a mobile device" do
+  context '#docs' do
+    context 'when the request is from a mobile device' do
       before do
-        iphone_user_agent = "Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3"
-        get "/search/docs", params: { query: "pdf",
+        iphone_user_agent = 'Mozilla/5.0 (iPhone; U; CPU like Mac OS X; en) AppleWebKit/420+ (KHTML, like Gecko) Version/3.0 Mobile/1A543a Safari/419.3'
+        get '/search/docs', params: { query: 'pdf',
                                       affiliate: affiliate.name },
-                            headers:  { "HTTP_USER_AGENT" => iphone_user_agent }
+                            headers:  { 'HTTP_USER_AGENT' => iphone_user_agent }
       end
 
-      it "should set format to mobile" do
+      it 'sets the format to mobile' do
         expect(request.format.to_sym).to eq(:mobile)
       end
 
-      it "should respond with success" do
+      it 'responds with success' do
         expect(response.status).to eq(200)
       end
     end

--- a/spec/requests/statuses_spec.rb
+++ b/spec/requests/statuses_spec.rb
@@ -9,7 +9,7 @@ describe '/status/outbound_rate_limit' do
   end
 
   it 'returns used_percentage' do
-    get '/status/outbound_rate_limit.txt', name: 'my_api'
+    get '/status/outbound_rate_limit.txt', params: { name: 'my_api' }
 
     expect(response.status).to eq(200)
     expect(response.body).to eq('name:my_api;limit:500;used_count:100;used_percentage:20%')


### PR DESCRIPTION
This PR resolves these deprecation warnings in our specs:
```
DEPRECATION WARNING: Using positional arguments in integration tests has been deprecated,
in favor of keyword arguments, and will be removed in Rails 5.1.
```