### PR TITLE
SRCH-629 - hashing params where expected for 5.1 compliance

### DIFF
--- a/app/controllers/sites/alerts_controller.rb
+++ b/app/controllers/sites/alerts_controller.rb
@@ -24,6 +24,6 @@ class Sites::AlertsController < Sites::SetupSiteController
   end
 
   def site_alert_params
-    @site_alert_params ||= params.require(:alert).permit(:text, :status, :title)
+    @site_alert_params ||= params.require(:alert).permit(:text, :status, :title).to_h
   end
 end

--- a/app/controllers/sites/best_bets_controller.rb
+++ b/app/controllers/sites/best_bets_controller.rb
@@ -26,7 +26,7 @@ class Sites::BestBetsController < Sites::SetupSiteController
   end
 
   def update_best_bet(best_bet, redirect_path, params)
-    if best_bet.destroy_and_update_attributes(params.to_h)
+    if best_bet.destroy_and_update_attributes(params)
       redirect_to redirect_path, flash: { success: "You have updated #{best_bet.title}." }
     else
       build_children

--- a/app/controllers/sites/best_bets_controller.rb
+++ b/app/controllers/sites/best_bets_controller.rb
@@ -26,7 +26,7 @@ class Sites::BestBetsController < Sites::SetupSiteController
   end
 
   def update_best_bet(best_bet, redirect_path, params)
-    if best_bet.destroy_and_update_attributes(params)
+    if best_bet.destroy_and_update_attributes(params.to_h)
       redirect_to redirect_path, flash: { success: "You have updated #{best_bet.title}." }
     else
       build_children

--- a/app/controllers/sites/boosted_contents_controller.rb
+++ b/app/controllers/sites/boosted_contents_controller.rb
@@ -39,7 +39,7 @@ class Sites::BoostedContentsController < Sites::BestBetsController
         permit(:url, :title, :description, :status,
                :publish_start_on, :publish_end_on,
                :match_keyword_values_only,
-               boosted_content_keywords_attributes: [:id, :value])
+               boosted_content_keywords_attributes: [:id, :value]).to_h
   end
 
 end

--- a/app/controllers/sites/clicks_controller.rb
+++ b/app/controllers/sites/clicks_controller.rb
@@ -9,7 +9,7 @@ class Sites::ClicksController < Sites::AnalyticsController
   end
 
   def create
-    clicks_request_params = params[:rtu_clicks_request].merge(site: @site, filter_bots: @current_user.sees_filtered_totals?)
+    clicks_request_params = params[:rtu_clicks_request].merge(site: @site, filter_bots: @current_user.sees_filtered_totals?).to_unsafe_h
     @clicks_request = RtuClicksRequest.new(clicks_request_params)
     @clicks_request.save
     set_analytics_range(@clicks_request.start_date, @clicks_request.end_date)

--- a/app/controllers/sites/clicks_controller.rb
+++ b/app/controllers/sites/clicks_controller.rb
@@ -9,7 +9,10 @@ class Sites::ClicksController < Sites::AnalyticsController
   end
 
   def create
-    clicks_request_params = params[:rtu_clicks_request].merge(site: @site, filter_bots: @current_user.sees_filtered_totals?).to_unsafe_h
+    clicks_request_params = params[:rtu_clicks_request].merge(
+        site: @site,
+        filter_bots: @current_user.sees_filtered_totals?
+    ).to_unsafe_h
     @clicks_request = RtuClicksRequest.new(clicks_request_params)
     @clicks_request.save
     set_analytics_range(@clicks_request.start_date, @clicks_request.end_date)

--- a/app/controllers/sites/clicks_controller.rb
+++ b/app/controllers/sites/clicks_controller.rb
@@ -10,8 +10,8 @@ class Sites::ClicksController < Sites::AnalyticsController
 
   def create
     clicks_request_params = params[:rtu_clicks_request].merge(
-        site: @site,
-        filter_bots: @current_user.sees_filtered_totals?
+      site: @site,
+      filter_bots: @current_user.sees_filtered_totals?
     ).to_unsafe_h
     @clicks_request = RtuClicksRequest.new(clicks_request_params)
     @clicks_request.save

--- a/app/controllers/sites/document_collections_controller.rb
+++ b/app/controllers/sites/document_collections_controller.rb
@@ -76,7 +76,9 @@ class Sites::DocumentCollectionsController < Sites::SetupSiteController
   end
 
   def collection_params
-    params.require(:document_collection).permit(:name,
-                                                { url_prefixes_attributes: [:id, :prefix] }).to_h
+    params.require(:document_collection).permit(
+        :name,
+        { url_prefixes_attributes: [:id, :prefix] }
+    ).to_h
   end
 end

--- a/app/controllers/sites/document_collections_controller.rb
+++ b/app/controllers/sites/document_collections_controller.rb
@@ -1,7 +1,7 @@
 class Sites::DocumentCollectionsController < Sites::SetupSiteController
   include ::Hintable
 
-  before_filter :setup_collection, only: [:show, :edit, :update, :destroy]
+  before_filter :setup_collection, only: %i[show edit update destroy]
   before_filter :load_hints, only: %i(edit new new_url_prefix)
 
   def index
@@ -77,8 +77,8 @@ class Sites::DocumentCollectionsController < Sites::SetupSiteController
 
   def collection_params
     params.require(:document_collection).permit(
-        :name,
-        { url_prefixes_attributes: [:id, :prefix] }
+      :name,
+      url_prefixes_attributes: %i[id prefix]
     ).to_h
   end
 end

--- a/app/controllers/sites/document_collections_controller.rb
+++ b/app/controllers/sites/document_collections_controller.rb
@@ -77,6 +77,6 @@ class Sites::DocumentCollectionsController < Sites::SetupSiteController
 
   def collection_params
     params.require(:document_collection).permit(:name,
-                                                { url_prefixes_attributes: [:id, :prefix] })
+                                                { url_prefixes_attributes: [:id, :prefix] }).to_h
   end
 end

--- a/app/controllers/sites/excluded_urls_controller.rb
+++ b/app/controllers/sites/excluded_urls_controller.rb
@@ -35,6 +35,6 @@ class Sites::ExcludedUrlsController < Sites::SetupSiteController
   end
 
   def excluded_url_params
-    params.require(:excluded_url).permit(:url)
+    params.require(:excluded_url).permit(:url).to_h
   end
 end

--- a/app/controllers/sites/featured_collections_controller.rb
+++ b/app/controllers/sites/featured_collections_controller.rb
@@ -41,16 +41,15 @@ class Sites::FeaturedCollectionsController < Sites::BestBetsController
   end
 
   def featured_collection_params
-    params.require(:featured_collection).
-      permit(
-        :image,
-        :image_alt_text,
-        :mark_image_for_deletion,
-        :publish_start_on, :publish_end_on,
-        :status, :title, :title_url,
-        :match_keyword_values_only,
-        featured_collection_keywords_attributes: %i[id value],
-        featured_collection_links_attributes: %i[id title url position]
-      ).to_h
+    params.require(:featured_collection).permit(
+      :image,
+      :image_alt_text,
+      :mark_image_for_deletion,
+      :publish_start_on, :publish_end_on,
+      :status, :title, :title_url,
+      :match_keyword_values_only,
+      featured_collection_keywords_attributes: %i[id value],
+      featured_collection_links_attributes: %i[id title url position]
+    ).to_h
   end
 end

--- a/app/controllers/sites/featured_collections_controller.rb
+++ b/app/controllers/sites/featured_collections_controller.rb
@@ -48,6 +48,6 @@ class Sites::FeaturedCollectionsController < Sites::BestBetsController
                :status, :title, :title_url,
                :match_keyword_values_only,
                featured_collection_keywords_attributes: [:id, :value],
-               featured_collection_links_attributes: [:id, :title, :url, :position])
+               featured_collection_links_attributes: [:id, :title, :url, :position]).to_h
   end
 end

--- a/app/controllers/sites/featured_collections_controller.rb
+++ b/app/controllers/sites/featured_collections_controller.rb
@@ -48,6 +48,7 @@ class Sites::FeaturedCollectionsController < Sites::BestBetsController
                :status, :title, :title_url,
                :match_keyword_values_only,
                featured_collection_keywords_attributes: [:id, :value],
-               featured_collection_links_attributes: [:id, :title, :url, :position]).to_h
+               featured_collection_links_attributes: [:id, :title, :url, :position]
+        ).to_h
   end
 end

--- a/app/controllers/sites/featured_collections_controller.rb
+++ b/app/controllers/sites/featured_collections_controller.rb
@@ -1,5 +1,5 @@
 class Sites::FeaturedCollectionsController < Sites::BestBetsController
-  before_filter :setup_featured_collection, only: [:edit, :update, :destroy]
+  before_filter :setup_featured_collection, only: %i[edit update destroy]
 
   def index
     @featured_collections = search_best_bets(FeaturedCollection)
@@ -42,13 +42,15 @@ class Sites::FeaturedCollectionsController < Sites::BestBetsController
 
   def featured_collection_params
     params.require(:featured_collection).
-        permit(:image, :image_alt_text,
-               :mark_image_for_deletion,
-               :publish_start_on, :publish_end_on,
-               :status, :title, :title_url,
-               :match_keyword_values_only,
-               featured_collection_keywords_attributes: [:id, :value],
-               featured_collection_links_attributes: [:id, :title, :url, :position]
-        ).to_h
+      permit(
+        :image,
+        :image_alt_text,
+        :mark_image_for_deletion,
+        :publish_start_on, :publish_end_on,
+        :status, :title, :title_url,
+        :match_keyword_values_only,
+        featured_collection_keywords_attributes: %i[id value],
+        featured_collection_links_attributes: %i[id title url position]
+      ).to_h
   end
 end

--- a/app/controllers/sites/flickr_profiles_controller.rb
+++ b/app/controllers/sites/flickr_profiles_controller.rb
@@ -29,6 +29,6 @@ class Sites::FlickrProfilesController < Sites::SetupSiteController
   private
 
   def flickr_profile_params
-    @flickr_profile_params ||= params.require(:flickr_profile).permit(:url)
+    @flickr_profile_params ||= params.require(:flickr_profile).permit(:url).to_h
   end
 end

--- a/app/controllers/sites/font_and_colors_controller.rb
+++ b/app/controllers/sites/font_and_colors_controller.rb
@@ -40,7 +40,8 @@ class Sites::FontAndColorsController < Sites::SetupSiteController
                               :title_link_color,
                               :url_link_color,
                               :visited_title_link_color] },
-        :theme).to_h
+        :theme
+    ).to_h
     @site_params[:css_property_hash] = @site.css_property_hash.merge(@site_params[:css_property_hash])
     @site_params
   end

--- a/app/controllers/sites/font_and_colors_controller.rb
+++ b/app/controllers/sites/font_and_colors_controller.rb
@@ -40,7 +40,7 @@ class Sites::FontAndColorsController < Sites::SetupSiteController
                               :title_link_color,
                               :url_link_color,
                               :visited_title_link_color] },
-        :theme)
+        :theme).to_h
     @site_params[:css_property_hash] = @site.css_property_hash.merge(@site_params[:css_property_hash])
     @site_params
   end

--- a/app/controllers/sites/font_and_colors_controller.rb
+++ b/app/controllers/sites/font_and_colors_controller.rb
@@ -15,32 +15,36 @@ class Sites::FontAndColorsController < Sites::SetupSiteController
 
   def site_params
     @site_params = params.require(:site).permit(
-        { css_property_hash: [:content_background_color,
-                              :content_border_color,
-                              :content_box_shadow_color,
-                              :description_text_color,
-                              :font_family,
-                              :footer_background_color,
-                              :footer_links_text_color,
-                              :header_links_background_color,
-                              :header_links_text_color,
-                              :header_text_color,
-                              :header_background_color,
-                              :header_tagline_background_color,
-                              :header_tagline_color,
-                              :header_tagline_font_family,
-                              :left_tab_text_color,
-                              :navigation_background_color,
-                              :navigation_link_color,
-                              :page_background_color,
-                              :search_button_background_color,
-                              :search_button_text_color,
-                              :show_content_border,
-                              :show_content_box_shadow,
-                              :title_link_color,
-                              :url_link_color,
-                              :visited_title_link_color] },
-        :theme
+      {
+        css_property_hash: %i[
+          content_background_color
+          content_border_color
+          content_box_shadow_color
+          description_text_color
+          font_family
+          footer_background_color
+          footer_links_text_color
+          header_links_background_color
+          header_links_text_color
+          header_text_color
+          header_background_color
+          header_tagline_background_color
+          header_tagline_color
+          header_tagline_font_family
+          left_tab_text_color
+          navigation_background_color
+          navigation_link_color
+          page_background_color
+          search_button_background_color
+          search_button_text_color
+          show_content_border
+          show_content_box_shadow
+          title_link_color
+          url_link_color
+          visited_title_link_color
+        ]
+      },
+      :theme
     ).to_h
     @site_params[:css_property_hash] = @site.css_property_hash.merge(@site_params[:css_property_hash])
     @site_params

--- a/app/controllers/sites/image_assets_controller.rb
+++ b/app/controllers/sites/image_assets_controller.rb
@@ -18,15 +18,15 @@ class Sites::ImageAssetsController < Sites::SetupSiteController
 
   def site_params
     @site_params = params.require(:image_asset).permit(
-        { css_property_hash: [:logo_alignment, :page_background_image_repeat] },
-        :favicon_url,
-        :header_image,
-        :logo_alt_text,
-        :mark_header_image_for_deletion,
-        :mark_mobile_logo_for_deletion,
-        :mark_page_background_image_for_deletion,
-        :mobile_logo,
-        :page_background_image
+      { css_property_hash: %i[logo_alignment page_background_image_repeat] },
+      :favicon_url,
+      :header_image,
+      :logo_alt_text,
+      :mark_header_image_for_deletion,
+      :mark_mobile_logo_for_deletion,
+      :mark_page_background_image_for_deletion,
+      :mobile_logo,
+      :page_background_image
     ).to_h
     @site_params[:css_property_hash] = @site.css_property_hash.merge(@site_params[:css_property_hash]) if @site_params[:css_property_hash]
     @site_params

--- a/app/controllers/sites/image_assets_controller.rb
+++ b/app/controllers/sites/image_assets_controller.rb
@@ -26,7 +26,8 @@ class Sites::ImageAssetsController < Sites::SetupSiteController
         :mark_mobile_logo_for_deletion,
         :mark_page_background_image_for_deletion,
         :mobile_logo,
-        :page_background_image).to_h
+        :page_background_image
+    ).to_h
     @site_params[:css_property_hash] = @site.css_property_hash.merge(@site_params[:css_property_hash]) if @site_params[:css_property_hash]
     @site_params
   end

--- a/app/controllers/sites/image_assets_controller.rb
+++ b/app/controllers/sites/image_assets_controller.rb
@@ -26,7 +26,7 @@ class Sites::ImageAssetsController < Sites::SetupSiteController
         :mark_mobile_logo_for_deletion,
         :mark_page_background_image_for_deletion,
         :mobile_logo,
-        :page_background_image)
+        :page_background_image).to_h
     @site_params[:css_property_hash] = @site.css_property_hash.merge(@site_params[:css_property_hash]) if @site_params[:css_property_hash]
     @site_params
   end

--- a/app/controllers/sites/indexed_documents_controller.rb
+++ b/app/controllers/sites/indexed_documents_controller.rb
@@ -38,6 +38,6 @@ class Sites::IndexedDocumentsController < Sites::SetupSiteController
   def indexed_document_params
     params.require(:indexed_document).
         permit(:description, :title, :url).
-        merge(source: 'manual', last_crawl_status: IndexedDocument::SUMMARIZED_STATUS)
+        merge(source: 'manual', last_crawl_status: IndexedDocument::SUMMARIZED_STATUS).to_h
   end
 end

--- a/app/controllers/sites/indexed_documents_controller.rb
+++ b/app/controllers/sites/indexed_documents_controller.rb
@@ -38,6 +38,9 @@ class Sites::IndexedDocumentsController < Sites::SetupSiteController
   def indexed_document_params
     params.require(:indexed_document).
         permit(:description, :title, :url).
-        merge(source: 'manual', last_crawl_status: IndexedDocument::SUMMARIZED_STATUS).to_h
+        merge(
+            source: 'manual',
+            last_crawl_status: IndexedDocument::SUMMARIZED_STATUS
+        ).to_h
   end
 end

--- a/app/controllers/sites/indexed_documents_controller.rb
+++ b/app/controllers/sites/indexed_documents_controller.rb
@@ -4,7 +4,7 @@ class Sites::IndexedDocumentsController < Sites::SetupSiteController
 
   def index
     @indexed_documents = @site.indexed_documents.by_matching_url(params[:query]).paginate(
-        page: params[:page]).order('id DESC')
+      page: params[:page]).order('id DESC')
   end
 
   def new
@@ -37,10 +37,10 @@ class Sites::IndexedDocumentsController < Sites::SetupSiteController
 
   def indexed_document_params
     params.require(:indexed_document).
-        permit(:description, :title, :url).
-        merge(
-            source: 'manual',
-            last_crawl_status: IndexedDocument::SUMMARIZED_STATUS
-        ).to_h
+      permit(:description, :title, :url).
+      merge(
+        source: 'manual',
+        last_crawl_status: IndexedDocument::SUMMARIZED_STATUS
+      ).to_h
   end
 end

--- a/app/controllers/sites/no_results_pages_controller.rb
+++ b/app/controllers/sites/no_results_pages_controller.rb
@@ -28,7 +28,7 @@ class Sites::NoResultsPagesController < Sites::SetupSiteController
   def site_params
     @site_params = params.require(:no_results_pages).permit(
         :additional_guidance_text,
-        { managed_no_results_pages_alt_links_attributes: %i(position title url) })
+        { managed_no_results_pages_alt_links_attributes: %i(position title url) }).to_h
     @site_params
   end
 

--- a/app/controllers/sites/no_results_pages_controller.rb
+++ b/app/controllers/sites/no_results_pages_controller.rb
@@ -28,7 +28,8 @@ class Sites::NoResultsPagesController < Sites::SetupSiteController
   def site_params
     @site_params = params.require(:no_results_pages).permit(
         :additional_guidance_text,
-        { managed_no_results_pages_alt_links_attributes: %i(position title url) }).to_h
+        { managed_no_results_pages_alt_links_attributes: %i(position title url) }
+    ).to_h
     @site_params
   end
 

--- a/app/controllers/sites/no_results_pages_controller.rb
+++ b/app/controllers/sites/no_results_pages_controller.rb
@@ -1,7 +1,7 @@
 class Sites::NoResultsPagesController < Sites::SetupSiteController
   include ::Hintable
 
-  before_filter :load_hints, only: %i(edit)
+  before_filter :load_hints, only: %i[edit]
   before_filter :build_no_results_pages_alt_links, only: [:edit, :new_no_results_pages_alt_link]
 
   def edit
@@ -26,11 +26,10 @@ class Sites::NoResultsPagesController < Sites::SetupSiteController
   private
 
   def site_params
-    @site_params = params.require(:no_results_pages).permit(
-        :additional_guidance_text,
-        { managed_no_results_pages_alt_links_attributes: %i(position title url) }
-    ).to_h
-    @site_params
+    params.require(:no_results_pages).permit(
+          :additional_guidance_text,
+          managed_no_results_pages_alt_links_attributes: %i[position title url]
+        ).to_h
   end
 
   def build_no_results_pages_alt_links

--- a/app/controllers/sites/queries_controller.rb
+++ b/app/controllers/sites/queries_controller.rb
@@ -9,8 +9,8 @@ class Sites::QueriesController < Sites::AnalyticsController
 
   def create
     queries_request_params = params[:rtu_queries_request].merge(
-        site: @site,
-        filter_bots: @current_user.sees_filtered_totals?
+      site: @site,
+      filter_bots: @current_user.sees_filtered_totals?
     ).to_unsafe_h
     @queries_request = RtuQueriesRequest.new(queries_request_params)
     @queries_request.save

--- a/app/controllers/sites/queries_controller.rb
+++ b/app/controllers/sites/queries_controller.rb
@@ -8,7 +8,7 @@ class Sites::QueriesController < Sites::AnalyticsController
   end
 
   def create
-    queries_request_params = params[:rtu_queries_request].merge(site: @site, filter_bots: @current_user.sees_filtered_totals?)
+    queries_request_params = params[:rtu_queries_request].merge(site: @site, filter_bots: @current_user.sees_filtered_totals?).to_unsafe_h
     @queries_request = RtuQueriesRequest.new(queries_request_params)
     @queries_request.save
     set_analytics_range(@queries_request.start_date, @queries_request.end_date)

--- a/app/controllers/sites/queries_controller.rb
+++ b/app/controllers/sites/queries_controller.rb
@@ -8,7 +8,10 @@ class Sites::QueriesController < Sites::AnalyticsController
   end
 
   def create
-    queries_request_params = params[:rtu_queries_request].merge(site: @site, filter_bots: @current_user.sees_filtered_totals?).to_unsafe_h
+    queries_request_params = params[:rtu_queries_request].merge(
+        site: @site,
+        filter_bots: @current_user.sees_filtered_totals?
+    ).to_unsafe_h
     @queries_request = RtuQueriesRequest.new(queries_request_params)
     @queries_request.save
     set_analytics_range(@queries_request.start_date, @queries_request.end_date)

--- a/app/controllers/sites/referrers_controller.rb
+++ b/app/controllers/sites/referrers_controller.rb
@@ -9,8 +9,8 @@ class Sites::ReferrersController < Sites::AnalyticsController
 
   def create
     referrers_request_params = params[:rtu_referrers_request].merge(
-        site: @site,
-        filter_bots: @current_user.sees_filtered_totals?
+      site: @site,
+      filter_bots: @current_user.sees_filtered_totals?
     ).to_unsafe_h
     @referrers_request = RtuReferrersRequest.new(referrers_request_params)
     @referrers_request.save

--- a/app/controllers/sites/referrers_controller.rb
+++ b/app/controllers/sites/referrers_controller.rb
@@ -8,7 +8,7 @@ class Sites::ReferrersController < Sites::AnalyticsController
   end
 
   def create
-    referrers_request_params = params[:rtu_referrers_request].merge(site: @site, filter_bots: @current_user.sees_filtered_totals?)
+    referrers_request_params = params[:rtu_referrers_request].merge(site: @site, filter_bots: @current_user.sees_filtered_totals?).to_unsafe_h
     @referrers_request = RtuReferrersRequest.new(referrers_request_params)
     @referrers_request.save
     set_analytics_range(@referrers_request.start_date, @referrers_request.end_date)

--- a/app/controllers/sites/referrers_controller.rb
+++ b/app/controllers/sites/referrers_controller.rb
@@ -8,7 +8,10 @@ class Sites::ReferrersController < Sites::AnalyticsController
   end
 
   def create
-    referrers_request_params = params[:rtu_referrers_request].merge(site: @site, filter_bots: @current_user.sees_filtered_totals?).to_unsafe_h
+    referrers_request_params = params[:rtu_referrers_request].merge(
+        site: @site,
+        filter_bots: @current_user.sees_filtered_totals?
+    ).to_unsafe_h
     @referrers_request = RtuReferrersRequest.new(referrers_request_params)
     @referrers_request.save
     set_analytics_range(@referrers_request.start_date, @referrers_request.end_date)

--- a/app/controllers/sites/routed_queries_controller.rb
+++ b/app/controllers/sites/routed_queries_controller.rb
@@ -1,7 +1,7 @@
 class Sites::RoutedQueriesController < Sites::SetupSiteController
   include ::Hintable
 
-  before_filter :setup_routed_query, only: [:edit, :update, :destroy]
+  before_filter :setup_routed_query, only: %i[edit update destroy]
   before_filter :load_hints, only: %i(edit new create new_routed_query_keyword)
 
   def index
@@ -59,9 +59,9 @@ class Sites::RoutedQueriesController < Sites::SetupSiteController
 
   def routed_query_params
     params.require(:routed_query).permit(
-        :url,
-        :description,
-        routed_query_keywords_attributes: [:id, :keyword]
+      :url,
+      :description,
+      routed_query_keywords_attributes: %i[id keyword]
     ).to_h
   end
 

--- a/app/controllers/sites/routed_queries_controller.rb
+++ b/app/controllers/sites/routed_queries_controller.rb
@@ -58,7 +58,11 @@ class Sites::RoutedQueriesController < Sites::SetupSiteController
   end
 
   def routed_query_params
-    params.require(:routed_query).permit(:url, :description, routed_query_keywords_attributes: [:id, :keyword]).to_h
+    params.require(:routed_query).permit(
+        :url,
+        :description,
+        routed_query_keywords_attributes: [:id, :keyword]
+    ).to_h
   end
 
   def build_routed_query_keyword

--- a/app/controllers/sites/routed_queries_controller.rb
+++ b/app/controllers/sites/routed_queries_controller.rb
@@ -58,7 +58,7 @@ class Sites::RoutedQueriesController < Sites::SetupSiteController
   end
 
   def routed_query_params
-    params.require(:routed_query).permit(:url, :description, routed_query_keywords_attributes: [:id, :keyword])
+    params.require(:routed_query).permit(:url, :description, routed_query_keywords_attributes: [:id, :keyword]).to_h
   end
 
   def build_routed_query_keyword

--- a/app/controllers/sites/rss_feeds_controller.rb
+++ b/app/controllers/sites/rss_feeds_controller.rb
@@ -96,7 +96,7 @@ class Sites::RssFeedsController < Sites::SetupSiteController
   def rss_feed_params
     params.require(:rss_feed).permit(:name,
                                      :show_only_media_content,
-                                     { rss_feed_urls_attributes: [:url] })
+                                     { rss_feed_urls_attributes: [:url] }).to_h
   end
 
   def setup_non_managed_rss_feed

--- a/app/controllers/sites/scaffold_profiles_controller.rb
+++ b/app/controllers/sites/scaffold_profiles_controller.rb
@@ -61,7 +61,7 @@ module Sites::ScaffoldProfilesController
   end
 
   def create_params
-    @create_params ||= params.require(profile_type).permit(primary_attribute_name)
+    @create_params ||= params.require(profile_type).permit(primary_attribute_name).to_h
   end
 
   def add_profile_to_site
@@ -73,7 +73,7 @@ module Sites::ScaffoldProfilesController
   end
 
   def destroy_params
-    params.permit(:id)
+    params.permit(:id).to_h
   end
 
   def after_profile_deleted

--- a/app/controllers/sites/settings_controller.rb
+++ b/app/controllers/sites/settings_controller.rb
@@ -14,6 +14,6 @@ class Sites::SettingsController < Sites::SetupSiteController
   private
 
   def site_params
-    params.require(:site).permit(:display_name, :website)
+    params.require(:site).permit(:display_name, :website).to_h
   end
 end

--- a/app/controllers/sites/site_domains_controller.rb
+++ b/app/controllers/sites/site_domains_controller.rb
@@ -53,7 +53,7 @@ class Sites::SiteDomainsController < Sites::SetupSiteController
   end
 
   def site_domain_params
-    params.require(:site_domain).permit(:domain)
+    params.require(:site_domain).permit(:domain).to_h
   end
 
   def update_site_after_save

--- a/app/controllers/sites/site_feed_urls_controller.rb
+++ b/app/controllers/sites/site_feed_urls_controller.rb
@@ -34,6 +34,6 @@ class Sites::SiteFeedUrlsController < Sites::SetupSiteController
   def site_feed_url_params
     @site_feed_url_params ||= params.require(:site_feed_url).
         permit(:rss_url).
-        merge(last_checked_at: nil, last_fetch_status: 'Pending')
+        merge(last_checked_at: nil, last_fetch_status: 'Pending').to_h
   end
 end

--- a/app/controllers/sites/sites_controller.rb
+++ b/app/controllers/sites/sites_controller.rb
@@ -56,6 +56,6 @@ class Sites::SitesController < Sites::BaseController
       permit(:display_name,
              :locale,
              :name,
-             { site_domains_attributes: [:domain] })
+             { site_domains_attributes: [:domain] }).to_h
   end
 end

--- a/app/controllers/sites/users_controller.rb
+++ b/app/controllers/sites/users_controller.rb
@@ -42,6 +42,6 @@ class Sites::UsersController < Sites::SetupSiteController
   private
 
   def user_params
-    @user_params ||= params.require(:user).permit(:contact_name, :email)
+    @user_params ||= params.require(:user).permit(:contact_name, :email).to_h
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,6 +55,6 @@ class UsersController < ApplicationController
                                  :organization_name,
                                  :email,
                                  :password,
-                                 :current_password)
+                                 :current_password).to_h
   end
 end


### PR DESCRIPTION
mostly changed parameter instantiation to have .to_h or .to_unsafe_h per this article  https://stackoverflow.com/questions/38710904/how-do-i-resolve-the-deprecation-warning-method-to-hash-is-deprecated-and-will