### PR TITLE
SRCH-975 addreesed hash deprecation warnings

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -113,7 +113,7 @@ class ApplicationController < ActionController::Base
   end
 
   def search_options_from_params(*param_keys)
-    h = permitted_params.slice(*param_keys)
+    h = permitted_params.to_h.slice(*param_keys)
     h.merge! affiliate: @affiliate,
              file_type: permitted_params[:filetype],
              page: permitted_params[:page],

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  before_filter :set_default_locale
-  after_filter :set_response_headers
+  before_action :set_default_locale
+  after_action :set_response_headers
   helper :all
   helper_method :current_user_session, :current_user, :permitted_params
   protect_from_forgery with: :exception
@@ -130,7 +130,7 @@ class ApplicationController < ActionController::Base
                                                  :'query-not',
                                                  :'query-or',
                                                  :'query-quote')
-    query_search_params.inject({}) do |hash, kv|
+    query_search_params.to_h.inject({}) do |hash, kv|
       hash[kv.first.to_s.underscore.to_sym] = sanitize_query kv.last
       hash
     end

--- a/app/controllers/sites/rss_feeds_controller.rb
+++ b/app/controllers/sites/rss_feeds_controller.rb
@@ -71,7 +71,6 @@ class Sites::RssFeedsController < Sites::SetupSiteController
     new_urls = []
 
     rss_feed_urls_attributes = attributes.to_h || {}
-    # rss_feed_urls_attributes.each_value do |url_attributes|
     rss_feed_urls_attributes.each_value do |url_attributes|
       url = url_attributes[:url]
       next if url.blank?

--- a/app/controllers/sites/rss_feeds_controller.rb
+++ b/app/controllers/sites/rss_feeds_controller.rb
@@ -70,7 +70,8 @@ class Sites::RssFeedsController < Sites::SetupSiteController
     existing_rss_feed_urls = []
     new_urls = []
 
-    rss_feed_urls_attributes = attributes || {}
+    rss_feed_urls_attributes = attributes.to_h || {}
+    # rss_feed_urls_attributes.each_value do |url_attributes|
     rss_feed_urls_attributes.each_value do |url_attributes|
       url = url_attributes[:url]
       next if url.blank?

--- a/app/models/affiliate.rb
+++ b/app/models/affiliate.rb
@@ -61,7 +61,7 @@ class Affiliate < ApplicationRecord
 
   has_many :users, -> { order 'contact_name' }, through: :memberships
   has_many :default_users, class_name: 'User', foreign_key: 'default_affiliate_id', dependent: :nullify
-  has_many :rss_feed_urls, -> { uniq }, through: :rss_feeds
+  has_many :rss_feed_urls, -> { distinct }, through: :rss_feeds
   has_many :url_prefixes, :through => :document_collections
   has_many :twitter_profiles, -> { order 'twitter_profiles.screen_name ASC' }, through: :affiliate_twitter_settings
   has_and_belongs_to_many :instagram_profiles, -> { order 'instagram_profiles.username ASC' }

--- a/lib/api/docs_search_options.rb
+++ b/lib/api/docs_search_options.rb
@@ -6,6 +6,7 @@ class Api::DocsSearchOptions < Api::CommercialSearchOptions
                         message: 'must be present'
 
   def initialize(params = {})
+    params = params.to_h unless params.is_a?(Hash)
     super(params.reverse_merge(api_key: AZURE_HOSTED_PASSWORD))
     self.dc = params[:dc]
   end


### PR DESCRIPTION
SRCH-975 - This pull request fixes the following deprecation warnings: 
- each_value parameters
- inject deprecation warning
- symbolized_keys deprecation warning