### PR TITLE
remove deprecated `redirect_to :back`

### DIFF
--- a/app/controllers/sites/sites_controller.rb
+++ b/app/controllers/sites/sites_controller.rb
@@ -51,7 +51,8 @@ class Sites::SitesController < Sites::BaseController
       new_site_path,
       flash: {
         success:
-            "Scheduled site '#{@site.display_name}' for deletion. This could take several hours to complete."
+            "Scheduled site '#{@site.display_name}' for deletion.
+              This could take several hours to complete."
       }
     )
   end

--- a/app/controllers/sites/sites_controller.rb
+++ b/app/controllers/sites/sites_controller.rb
@@ -51,8 +51,7 @@ class Sites::SitesController < Sites::BaseController
       new_site_path,
       flash: {
         success:
-            "Scheduled site '#{@site.display_name}' for deletion.
-              This could take several hours to complete."
+            "Scheduled site '#{@site.display_name}' for deletion. This could take several hours to complete."
       }
     )
   end

--- a/app/controllers/sites/sites_controller.rb
+++ b/app/controllers/sites/sites_controller.rb
@@ -30,7 +30,13 @@ class Sites::SitesController < Sites::BaseController
       @site.assign_sitelink_generator_names!
       Emailer.new_affiliate_site(@site, current_user).deliver_now
       SiteAutodiscoverer.new(@site).run
-      redirect_to(site_path(@site), flash: { success: "You have added '#{@site.display_name}' as a site." })
+      redirect_to(
+        site_path(@site),
+        flash: {
+          success:
+              "You have added '#{@site.display_name}' as a site."
+        }
+      )
     else
       @site.site_domains.first.domain = "http://#{@site.site_domains.first.domain}" if @site.site_domains.first.domain.present?
       render(action: :new)
@@ -41,7 +47,13 @@ class Sites::SitesController < Sites::BaseController
     @site.update_attributes!(active: false)
     @site.user_ids = []
     Resque.enqueue_with_priority(:low, SiteDestroyer, @site.id)
-    redirect_to(new_site_path, :flash => { :success => "Scheduled site '#{@site.display_name}' for deletion. This could take several hours to complete." })
+    redirect_to(
+      new_site_path,
+      flash: {
+        success:
+            "Scheduled site '#{@site.display_name}' for deletion. This could take several hours to complete."
+      }
+    )
   end
 
   def pin

--- a/app/controllers/sites/sites_controller.rb
+++ b/app/controllers/sites/sites_controller.rb
@@ -3,13 +3,13 @@ class Sites::SitesController < Sites::BaseController
 
   def index
     if current_user.is_affiliate_admin? and current_user.default_affiliate
-      redirect_to site_path(current_user.default_affiliate)
+      redirect_to(site_path(current_user.default_affiliate))
     elsif current_user.is_affiliate? and current_user.affiliates.exists?(current_user.default_affiliate_id)
-      redirect_to site_path(current_user.default_affiliate)
+      redirect_to(site_path(current_user.default_affiliate))
     elsif current_user.affiliates.first
-      redirect_to site_path(current_user.affiliates.first)
+      redirect_to(site_path(current_user.affiliates.first))
     else
-      redirect_to new_site_path
+      redirect_to(new_site_path)
     end
   end
 
@@ -23,17 +23,17 @@ class Sites::SitesController < Sites::BaseController
   end
 
   def create
-    @site = Affiliate.new site_params
+    @site = Affiliate.new(site_params)
     @site.users << current_user
     if @site.save
       @site.push_staged_changes
       @site.assign_sitelink_generator_names!
       Emailer.new_affiliate_site(@site, current_user).deliver_now
       SiteAutodiscoverer.new(@site).run
-      redirect_to site_path(@site), flash: { success: "You have added '#{@site.display_name}' as a site." }
+      redirect_to(site_path(@site), flash: { success: "You have added '#{@site.display_name}' as a site." })
     else
       @site.site_domains.first.domain = "http://#{@site.site_domains.first.domain}" if @site.site_domains.first.domain.present?
-      render action: :new
+      render(action: :new)
     end
   end
 
@@ -41,12 +41,15 @@ class Sites::SitesController < Sites::BaseController
     @site.update_attributes!(active: false)
     @site.user_ids = []
     Resque.enqueue_with_priority(:low, SiteDestroyer, @site.id)
-    redirect_to new_site_path, :flash => { :success => "Scheduled site '#{@site.display_name}' for deletion. This could take several hours to complete." }
+    redirect_to(new_site_path, :flash => { :success => "Scheduled site '#{@site.display_name}' for deletion. This could take several hours to complete." })
   end
 
   def pin
-    current_user.update_attributes! default_affiliate: @site
-    redirect_to :back, flash: { success: "You have set #{@site.display_name} as your default site." }
+    current_user.update_attributes!(default_affiliate: @site)
+    redirect_back(
+      fallback_location: root_path,
+      flash: { success: "You have set #{@site.display_name} as your default site." }
+    )
   end
 
   private


### PR DESCRIPTION

removed deprecated redirect_to :back call

fixed rubocop warning about method calls without parentheses.