### PR TITLE
SRCH-917 - When user is not persisted, authorized, redirect to error …

### DIFF
--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -5,7 +5,7 @@ class OmniauthCallbacksController < ApplicationController
     @user = User.from_omniauth(request.env['omniauth.auth'])
 
     if @user.persisted? && @user.approval_status != 'not_approved'
-      #reset_session
+      reset_session
       set_user_session
 
       redirect_to(admin_home_page_path)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -5,7 +5,7 @@ class OmniauthCallbacksController < ApplicationController
     @user = User.from_omniauth(request.env['omniauth.auth'])
 
     if @user.persisted? && @user.approval_status != 'not_approved'
-      reset_session
+      #reset_session
       set_user_session
 
       redirect_to(admin_home_page_path)

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -2,14 +2,16 @@
 
 class OmniauthCallbacksController < ApplicationController
   def login_dot_gov
-    auth = request.env['omniauth.auth']
-    @user = User.from_omniauth(auth)
-    return unless @user.persisted?
+    @user = User.from_omniauth(request.env['omniauth.auth'])
 
-    reset_session
-    set_user_session
+    if @user.persisted? && @user.approval_status != 'not_approved'
+      reset_session
+      set_user_session
 
-    redirect_to(admin_home_page_path)
+      redirect_to(admin_home_page_path)
+    else
+      redirect_to('https://search.gov/access-denied')
+    end
   end
 
   private

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -5,6 +5,7 @@ class OmniauthCallbacksController < ApplicationController
     @user = User.from_omniauth(request.env['omniauth.auth'])
 
     if @user.persisted? && @user.approval_status != 'not_approved'
+      reset_session
       set_user_session
       redirect_to(admin_home_page_path)
     else

--- a/app/controllers/omniauth_callbacks_controller.rb
+++ b/app/controllers/omniauth_callbacks_controller.rb
@@ -5,9 +5,7 @@ class OmniauthCallbacksController < ApplicationController
     @user = User.from_omniauth(request.env['omniauth.auth'])
 
     if @user.persisted? && @user.approval_status != 'not_approved'
-      reset_session
       set_user_session
-
       redirect_to(admin_home_page_path)
     else
       redirect_to('https://search.gov/access-denied')

--- a/spec/controllers/admin/affiliates_controller_spec.rb
+++ b/spec/controllers/admin/affiliates_controller_spec.rb
@@ -4,15 +4,15 @@ describe Admin::AffiliatesController do
   fixtures :users, :affiliates, :memberships, :languages
   let(:config) { Admin::AffiliatesController.active_scaffold_config }
 
-  context "when logged in as a non-affiliate admin user" do
+  context 'when logged in as a non-affiliate admin user' do
     before do
       activate_authlogic
-      UserSession.create(users("non_affiliate_admin"))
+      UserSession.create(users('non_affiliate_admin'))
     end
 
-    it "should redirect to the usasearch home page" do
+    it 'should redirect to the usasearch home page' do
       get :index
-      expect(response).to redirect_to(account_path)
+      expect(response).to redirect_to('https://search.gov/access-denied')
     end
   end
 

--- a/spec/controllers/admin/affiliates_controller_spec.rb
+++ b/spec/controllers/admin/affiliates_controller_spec.rb
@@ -10,9 +10,9 @@ describe Admin::AffiliatesController do
       UserSession.create(users('non_affiliate_admin'))
     end
 
-    it 'should redirect to the usasearch home page' do
+    it 'redirects to the usasearch home page' do
       get :index
-      expect(response).to redirect_to('https://search.gov/access-denied')
+      expect(response).to redirect_to(account_path)
     end
   end
 

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -73,7 +73,7 @@ describe OmniauthCallbacksController do
         allow_any_instance_of(User).to receive(:persisted?).and_return(false)
       end
 
-      it 'raises an error' do
+      it 'redirects to access-denied page' do
         expect(get_login_dot_gov).to redirect_to('https://search.gov/access-denied')
       end
     end
@@ -84,7 +84,7 @@ describe OmniauthCallbacksController do
       let(:auth) { mock_user_auth(user.email, email) }
 
       it 'redirects to access-denied page' do
-        expect redirect_to('https://search.gov/access-denied')
+        expect(get_login_dot_gov).to redirect_to('https://search.gov/access-denied')
       end
     end
   end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -77,5 +77,15 @@ describe OmniauthCallbacksController do
         expect(get_login_dot_gov).to redirect_to('https://search.gov/access-denied')
       end
     end
+
+    context 'when a user is not approved' do
+      let(:email) { 'affiliate_manager_with_not_approved_status@fixtures.org' }
+      let(:user) { users(:affiliate_manager_with_not_approved_status) }
+      let(:auth) { mock_user_auth(user.email, email) }
+
+      it 'redirects to access-denied page' do
+        expect redirect_to('https://search.gov/access-denied')
+      end
+    end
   end
 end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -74,7 +74,7 @@ describe OmniauthCallbacksController do
       end
 
       it 'raises an error' do
-        expect { get_login_dot_gov }.to raise_error(ActionController::UnknownFormat)
+        expect(get_login_dot_gov).to redirect_to('https://search.gov/access-denied')
       end
     end
   end

--- a/spec/controllers/omniauth_callbacks_controller_spec.rb
+++ b/spec/controllers/omniauth_callbacks_controller_spec.rb
@@ -79,9 +79,8 @@ describe OmniauthCallbacksController do
     end
 
     context 'when a user is not approved' do
-      let(:email) { 'affiliate_manager_with_not_approved_status@fixtures.org' }
       let(:user) { users(:affiliate_manager_with_not_approved_status) }
-      let(:auth) { mock_user_auth(user.email, email) }
+      let(:auth) { mock_user_auth(user.email,'notapproved12345') }
 
       it 'redirects to access-denied page' do
         expect(get_login_dot_gov).to redirect_to('https://search.gov/access-denied')


### PR DESCRIPTION
This pull request will redirect the user to the access denied error page if they are not persisted,  if their account was not approved, or they are not authorized to access the page. 