### PR TITLE
Feature/admin invite user

### DIFF
--- a/app/mailers/emailer.rb
+++ b/app/mailers/emailer.rb
@@ -70,6 +70,7 @@ class Emailer < ApplicationMailer
     @added_user_email = user.email
     @affiliate_display_name = affiliate.display_name
     @affiliate_site_url = site_url(affiliate)
+    @complete_registration_url = login_url
     @website = affiliate.website
     generic_user_html_email(user, __method__)
   end

--- a/app/mailers/emailer.rb
+++ b/app/mailers/emailer.rb
@@ -54,8 +54,8 @@ class Emailer < ApplicationMailer
   end
 
   def new_affiliate_user(affiliate, user, current_user)
-    @added_by_contact_name = current_user.contact_name
-    @added_user_contact_name = user.contact_name
+    @added_by_contact_name = current_user.contact_name.presence || current_user.email
+    @added_user_contact_name = user.contact_name.presence || user.email
     @affiliate_display_name = affiliate.display_name
     @affiliate_name = affiliate.name
     @affiliate_site_url = site_url(affiliate)
@@ -65,8 +65,8 @@ class Emailer < ApplicationMailer
 
   def welcome_to_new_user_added_by_affiliate(affiliate, user, current_user)
     @account_url = account_url
-    @added_by_contact_name = current_user.contact_name
-    @added_user_contact_name = user.contact_name
+    @added_by_contact_name = current_user.contact_name.presence || current_user.email
+    @added_user_contact_name = user.contact_name.presence || user.email
     @added_user_email = user.email
     @affiliate_display_name = affiliate.display_name
     @affiliate_site_url = site_url(affiliate)

--- a/app/mailers/emailer.rb
+++ b/app/mailers/emailer.rb
@@ -70,6 +70,7 @@ class Emailer < ApplicationMailer
     @added_user_email = user.email
     @affiliate_display_name = affiliate.display_name
     @affiliate_site_url = site_url(affiliate)
+    @complete_registration_url = edit_complete_registration_url(user.email_verification_token)
     @website = affiliate.website
     generic_user_html_email(user, __method__)
   end

--- a/app/mailers/emailer.rb
+++ b/app/mailers/emailer.rb
@@ -70,7 +70,6 @@ class Emailer < ApplicationMailer
     @added_user_email = user.email
     @affiliate_display_name = affiliate.display_name
     @affiliate_site_url = site_url(affiliate)
-    @complete_registration_url = edit_complete_registration_url(user.email_verification_token)
     @website = affiliate.website
     generic_user_html_email(user, __method__)
   end

--- a/app/mailers/emailer.rb
+++ b/app/mailers/emailer.rb
@@ -70,7 +70,7 @@ class Emailer < ApplicationMailer
     @added_user_email = user.email
     @affiliate_display_name = affiliate.display_name
     @affiliate_site_url = site_url(affiliate)
-    @complete_registration_url = login_url
+    @complete_registration_url = sites_url
     @website = affiliate.website
     generic_user_html_email(user, __method__)
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -124,15 +124,6 @@ class User < ApplicationRecord
     Emailer.new_user_to_admin(self).deliver_now
   end
 
-  def assign_email_verification_token!
-    begin
-      update_column(:email_verification_token,
-                    Authlogic::Random.friendly_token.downcase)
-    rescue ActiveRecord::RecordNotUnique
-      retry
-    end
-  end
-
   def deliver_user_email_verification
     Emailer.user_email_verification(self).deliver_now
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,6 +18,8 @@ class User < ApplicationRecord
   before_validation :set_initial_approval_status, on: :create
   after_validation :set_default_flags, on: :create
 
+  after_create :deliver_email_verification
+
   before_update :detect_deliver_welcome_email
   after_create :ping_admin
   after_update :send_welcome_to_new_user_email, if: :deliver_welcome_email_on_update
@@ -92,7 +94,6 @@ class User < ApplicationRecord
 
   def self.new_invited_by_affiliate(inviter, affiliate, attributes)
     new_user = User.new(attributes)
-    new_user.password = SecureRandom.hex(10) + 'MLPFTW2016!!!'
     new_user.inviter = inviter
     new_user.invited = true
     new_user.affiliates << affiliate

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   before_validation :set_initial_approval_status, on: :create
   after_validation :set_default_flags, on: :create
 
-  after_create :deliver_welcome_to_new_user_added_by_affiliate
+  after_create :deliver_welcome_to_new_user_added_by_affiliate, if: :invited
 
   before_update :detect_deliver_welcome_email
   after_create :ping_admin
@@ -129,8 +129,6 @@ class User < ApplicationRecord
   end
 
   def deliver_welcome_to_new_user_added_by_affiliate
-    return unless invited
-
     Emailer.
       welcome_to_new_user_added_by_affiliate(affiliates.first, self, inviter).
       deliver_now

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
   before_validation :set_initial_approval_status, on: :create
   after_validation :set_default_flags, on: :create
 
-  after_create :deliver_email_verification
+  after_create :deliver_welcome_to_new_user_added_by_affiliate
 
   before_update :detect_deliver_welcome_email
   after_create :ping_admin
@@ -124,15 +124,6 @@ class User < ApplicationRecord
     Emailer.new_user_to_admin(self).deliver_now
   end
 
-  def deliver_email_verification
-    assign_email_verification_token!
-    if invited
-      deliver_welcome_to_new_user_added_by_affiliate
-    else
-      deliver_user_email_verification
-    end
-  end
-
   def assign_email_verification_token!
     begin
       update_column(:email_verification_token,
@@ -147,6 +138,8 @@ class User < ApplicationRecord
   end
 
   def deliver_welcome_to_new_user_added_by_affiliate
+    return unless invited
+
     Emailer.
       welcome_to_new_user_added_by_affiliate(affiliates.first, self, inviter).
       deliver_now

--- a/features/admin_center_dashboard.feature
+++ b/features/admin_center_dashboard.feature
@@ -164,12 +164,8 @@ Feature: Dashboard
     Then "jane@admin.org" should receive an email
 
     When I open the email
+    Then show me the page
     And I click the complete registration link in the email
-    Then the "Your full name" field should contain "Jane Admin"
-    Then the "Email" field should contain "jane@admin.org"
-    When I fill in the following:
-      | Federal government agency | My Agency   |
-    And I press "Complete the sign up process"
     Then I should see "Site Overview"
 
   @javascript

--- a/features/admin_center_dashboard.feature
+++ b/features/admin_center_dashboard.feature
@@ -166,7 +166,7 @@ Feature: Dashboard
     When I open the email
     Then show me the page
     And I click the complete registration link in the email
-    Then I should see "Site Overview"
+    Then I should see "Security Notification"
 
   @javascript
   Scenario: Add existing user to site

--- a/features/admin_center_dashboard.feature
+++ b/features/admin_center_dashboard.feature
@@ -149,8 +149,6 @@ Feature: Dashboard
     When I press "Remove" within the first table body row
     Then I should see "You have removed admin@email.gov from this site"
 
-  # to be updated in SRCH-891 for login.gov
-  @wip
   @javascript
   Scenario: Complete sign up process
     Given no emails have been sent
@@ -171,7 +169,6 @@ Feature: Dashboard
     Then the "Email" field should contain "jane@admin.org"
     When I fill in the following:
       | Federal government agency | My Agency   |
-      | Password                  | test1234!   |
     And I press "Complete the sign up process"
     Then I should see "Site Overview"
 

--- a/features/admin_center_dashboard.feature
+++ b/features/admin_center_dashboard.feature
@@ -164,7 +164,6 @@ Feature: Dashboard
     Then "jane@admin.org" should receive an email
 
     When I open the email
-    Then show me the page
     And I click the complete registration link in the email
     Then I should see "Security Notification"
 

--- a/features/step_definitions/user_steps.rb
+++ b/features/step_definitions/user_steps.rb
@@ -24,14 +24,14 @@ Given /^the following Users exist:$/ do |table|
   table.hashes.each do |hash|
     User.create!(hash.merge(password: 'test1234!', organization_name: 'Agency'))
     if hash[:password_updated_at]
-     user = User.find_by_email(hash[:email])
-     user.update_attributes(password_updated_at: hash[:password_updated_at].to_date)
+      user = User.find_by_email(hash[:email])
+      user.update_attributes(password_updated_at: hash[:password_updated_at].to_date)
     end
   end
 end
 
 When /^(?:I|they) click the complete registration link in the email$/ do
-  click_email_link_matching /complete\_registration/
+  click_email_link_matching /sites/
 end
 
 When(/^I visit the password reset page using the perishable token for "(.*?)"$/) do |email_address|

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -158,7 +158,7 @@ affiliate_added_by_another_affiliate_with_pending_email_verification_status:
   is_affiliate_admin: false
   is_affiliate: true
   contact_name: Invited Affiliate Manager
-  approval_status: pending_email_verification
+  approval_status: approved
   requires_manual_approval: false
 
 user_with_expired_password:

--- a/spec/mailers/emailer_spec.rb
+++ b/spec/mailers/emailer_spec.rb
@@ -165,7 +165,7 @@ describe Emailer do
 
     it { should deliver_to("invitee@agency.com") }
     it { should have_subject(/\[Search.gov\] Welcome to Search.gov/) }
-    it { should have_body_text(/https:\/\/localhost:3000\/login/) }
+    it { should have_body_text(/https:\/\/localhost:3000\/sites/) }
   end
 
   describe '#daily_snapshot' do

--- a/spec/mailers/emailer_spec.rb
+++ b/spec/mailers/emailer_spec.rb
@@ -116,8 +116,7 @@ describe Emailer do
       it { is_expected.not_to have_body_text /This user signed up as an affiliate/ }
     end
 
-    # login.gov - commented out till SRCH-891
-    pending 'user got invited by another customer' do
+    context 'user got invited by another customer' do
       let(:user) { users(:affiliate_added_by_another_affiliate_with_pending_email_verification_status) }
 
       before do

--- a/spec/mailers/emailer_spec.rb
+++ b/spec/mailers/emailer_spec.rb
@@ -154,8 +154,8 @@ describe Emailer do
   describe "#welcome_to_new_user_added_by_affiliate" do
     let(:user) do
       mock_model(User,
-           :email => "invitee@agency.com",
-           :contact_name => 'Invitee Joe')
+                 email: 'invitee@agency.com',
+                 contact_name: 'Invitee Joe')
     end
 
     let(:current_user) { mock_model(User, :email => "inviter@agency.com", :contact_name => 'Inviter Jane') }

--- a/spec/mailers/emailer_spec.rb
+++ b/spec/mailers/emailer_spec.rb
@@ -155,8 +155,7 @@ describe Emailer do
     let(:user) do
       mock_model(User,
            :email => "invitee@agency.com",
-           :contact_name => 'Invitee Joe',
-           :email_verification_token => 'some_special_token')
+           :contact_name => 'Invitee Joe')
     end
 
     let(:current_user) { mock_model(User, :email => "inviter@agency.com", :contact_name => 'Inviter Jane') }
@@ -166,7 +165,7 @@ describe Emailer do
 
     it { should deliver_to("invitee@agency.com") }
     it { should have_subject(/\[Search.gov\] Welcome to Search.gov/) }
-    it { should have_body_text(/https:\/\/localhost:3000\/complete_registration\/some_special_token\/edit/) }
+    it { should have_body_text(/https:\/\/localhost:3000\/login/) }
   end
 
   describe '#daily_snapshot' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -460,7 +460,6 @@ describe User do
                                                  { contact_name: 'New User Name',
                                                    email: 'newuser@approvedagency.com' })
         new_user.save!
-        expect(new_user.email_verification_token).not_to be_blank
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -452,7 +452,7 @@ describe User do
         expect(affiliate.users).to include(new_user)
       end
 
-      it 'should receive welcome new user added by affiliate email verification' do
+      it 'receives the welcome new user added by affiliate email verification' do
         expect(Emailer).to receive(:welcome_to_new_user_added_by_affiliate).and_return @emailer
         expect(Emailer).to_not receive(:new_user_email_verification)
         new_user = User.new_invited_by_affiliate(inviter,

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -430,47 +430,55 @@ describe User do
     end
   end
 
-  # login.gov - commented out till SRCH-891.
-  pending "#new_invited_by_affiliate" do
+  describe '#new_invited_by_affiliate' do
     let(:inviter) { users(:affiliate_manager) }
     let(:affiliate) { affiliates(:basic_affiliate) }
 
-    context "when contact_name and email are provided" do
+    context 'when contact_name and email are provided' do
 
-      it "should initialize new user with assign affiliate, contact_name, and email" do
-        new_user = User.new_invited_by_affiliate(inviter, affiliate, { :contact_name => 'New User Name', :email => 'newuser@approvedagency.com' })
+      it 'initializes new user with assign affiliate, contact_name, and email' do
+        new_user = User.new_invited_by_affiliate(inviter,
+                                                 affiliate,
+                                                 { contact_name: 'New User Name',
+                                                   email: 'newuser@approvedagency.com' })
         new_user.save!
         expect(new_user.affiliates.first).to eq(affiliate)
         expect(new_user.contact_name).to eq('New User Name')
         expect(new_user.email).to eq('newuser@approvedagency.com')
         expect(new_user.is_affiliate?).to be true
         expect(new_user.requires_manual_approval).to be false
-        expect(new_user.is_pending_email_verification?).to be true
+        expect(new_user.is_approved?).to be true
         expect(new_user.welcome_email_sent).to be false
         expect(affiliate.users).to include(new_user)
       end
 
-      it "should receive welcome new user added by affiliate email verification" do
+      it 'should receive welcome new user added by affiliate email verification' do
         expect(Emailer).to receive(:welcome_to_new_user_added_by_affiliate).and_return @emailer
         expect(Emailer).to_not receive(:new_user_email_verification)
-        new_user = User.new_invited_by_affiliate(inviter, affiliate, { :contact_name => 'New User Name', :email => 'newuser@approvedagency.com' })
+        new_user = User.new_invited_by_affiliate(inviter,
+                                                 affiliate,
+                                                 { contact_name: 'New User Name',
+                                                   email: 'newuser@approvedagency.com' })
         new_user.save!
         expect(new_user.email_verification_token).not_to be_blank
       end
     end
   end
 
-  describe "#complete_registration" do
+  describe '#complete_registration' do
     let(:inviter) { users(:affiliate_manager) }
     let(:affiliate) { affiliates(:basic_affiliate) }
 
     before do
-      @user = User.new_invited_by_affiliate(inviter, affiliate, { :contact_name => 'New User Name', :email => 'newuser@approvedagency.com' })
+      @user = User.new_invited_by_affiliate(inviter,
+                                            affiliate,
+                                            { contact_name: 'New User Name',
+                                              email: 'newuser@approvedagency.com' })
       @user.save!
     end
 
-    context "when executed" do
-      let(:user) { user = User.find @user.id }
+    context 'when executed' do
+      let(:user) { User.find @user.id }
 
       before do
         expect(user).to receive(:update)
@@ -479,9 +487,6 @@ describe User do
       end
 
       it { expect(user).to be_is_approved }
-      it "should set email_verification_token to nil" do
-        expect(user.email_verification_token).to be_nil
-      end
     end
   end
 


### PR DESCRIPTION
Ensure admin can invite user.
- Created user is set to approved instead of pending email verification
- user does not need a password
- Validations to pass
- fixtures updated to approved user.
- fix rspec tests
- fix cucumber tests
- update email flow