### PR TITLE
Update Logstash queries to run on Elasticsearch 5.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,40 @@ jobs:
           paths:
             - vendor/bundle
 
+  setup_elasticsearch:
+    executor: test_executor
+
+    environment:
+      COVERAGE: true
+
+    steps:
+      - restore_cache:
+          key: repo-{{ .Environment.CIRCLE_SHA1 }}
+
+      - run:
+          name: Install Elasticsearch
+          command: |
+            java -version
+            echo $JAVA_HOME
+            curl -L -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.3.tar.gz
+            tar -xvf elasticsearch-1.7.3.tar.gz
+            PLUGINS=(
+              "elasticsearch/license/latest"
+              "elasticsearch/marvel/latest"
+              "polyfractal/elasticsearch-inquisitor/latest"
+              "elasticsearch/elasticsearch-analysis-kuromoji/2.7.0"
+              "elasticsearch/elasticsearch-analysis-smartcn/2.7.0"
+              "elasticsearch/elasticsearch-analysis-icu/2.7.0"
+              "elasticsearch/watcher/latest"
+            )
+            for plugin in ${PLUGINS[*]}; do /home/circleci/search-gov/elasticsearch-1.7.3/bin/plugin install $plugin; done
+            echo "script.index: on" >> /home/circleci/search-gov/elasticsearch-1.7.3/config/elasticsearch.yml
+            echo "script.inline: on" >> /home/circleci/search-gov/elasticsearch-1.7.3/config/elasticsearch.yml
+
+      - save_cache:
+          key: elasticsearch
+          paths: /home/circleci/search-gov/elasticsearch-1.7.3
+
   rspec:
     executor: test_executor
 
@@ -106,6 +140,8 @@ jobs:
       - run:
           name: Run Tests
           command: |
+            /home/circleci/search-gov/elasticsearch-1.7.3/bin/elasticsearch -d
+            sleep 10
             bundle exec rake usasearch:elasticsearch:create_indexes
 
             mkdir /tmp/test-results
@@ -146,11 +182,16 @@ jobs:
 
       - run: bundle --path vendor/bundle
 
+      - restore_cache:
+          key: elasticsearch
+
       - prepare_database
 
       - run:
           name: Run Tests
           command: |
+            /home/circleci/search-gov/elasticsearch-1.7.3/bin/elasticsearch -d
+            sleep 10
             bundle exec rake usasearch:elasticsearch:create_indexes
 
             bundle exec rake tmp:create
@@ -208,19 +249,24 @@ workflows:
     jobs:
       - checkout_code
 
+      - setup_elasticsearch
+
       - bundle_install:
           requires:
           - checkout_code
 
       - rspec:
           requires:
+            - setup_elasticsearch
             - bundle_install
 
-      - cucumber:
-          requires:
-            - bundle_install
-
-      - report_coverage:
-          requires:
-            - rspec
-            - cucumber
+# Temporarily commenting out until logstash queries are updated
+#      - cucumber:
+#          requires:
+#            - setup_elasticsearch
+#            - bundle_install
+#
+#      - report_coverage:
+#          requires:
+#            - rspec
+#            - cucumber

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,40 +84,6 @@ jobs:
           paths:
             - vendor/bundle
 
-  setup_elasticsearch:
-    executor: test_executor
-
-    environment:
-      COVERAGE: true
-
-    steps:
-      - restore_cache:
-          key: repo-{{ .Environment.CIRCLE_SHA1 }}
-
-      - run:
-          name: Install Elasticsearch
-          command: |
-            java -version
-            echo $JAVA_HOME
-            curl -L -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.3.tar.gz
-            tar -xvf elasticsearch-1.7.3.tar.gz
-            PLUGINS=(
-              "elasticsearch/license/latest"
-              "elasticsearch/marvel/latest"
-              "polyfractal/elasticsearch-inquisitor/latest"
-              "elasticsearch/elasticsearch-analysis-kuromoji/2.7.0"
-              "elasticsearch/elasticsearch-analysis-smartcn/2.7.0"
-              "elasticsearch/elasticsearch-analysis-icu/2.7.0"
-              "elasticsearch/watcher/latest"
-            )
-            for plugin in ${PLUGINS[*]}; do /home/circleci/search-gov/elasticsearch-1.7.3/bin/plugin install $plugin; done
-            echo "script.index: on" >> /home/circleci/search-gov/elasticsearch-1.7.3/config/elasticsearch.yml
-            echo "script.inline: on" >> /home/circleci/search-gov/elasticsearch-1.7.3/config/elasticsearch.yml
-
-      - save_cache:
-          key: elasticsearch
-          paths: /home/circleci/search-gov/elasticsearch-1.7.3
-
   rspec:
     executor: test_executor
 
@@ -140,8 +106,6 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            /home/circleci/search-gov/elasticsearch-1.7.3/bin/elasticsearch -d
-            sleep 10
             bundle exec rake usasearch:elasticsearch:create_indexes
 
             mkdir /tmp/test-results
@@ -182,16 +146,11 @@ jobs:
 
       - run: bundle --path vendor/bundle
 
-      - restore_cache:
-          key: elasticsearch
-
       - prepare_database
 
       - run:
           name: Run Tests
           command: |
-            /home/circleci/search-gov/elasticsearch-1.7.3/bin/elasticsearch -d
-            sleep 10
             bundle exec rake usasearch:elasticsearch:create_indexes
 
             bundle exec rake tmp:create
@@ -249,20 +208,16 @@ workflows:
     jobs:
       - checkout_code
 
-      - setup_elasticsearch
-
       - bundle_install:
           requires:
           - checkout_code
 
       - rspec:
           requires:
-            - setup_elasticsearch
             - bundle_install
 
       - cucumber:
           requires:
-            - setup_elasticsearch
             - bundle_install
 
       - report_coverage:

--- a/app/models/logstash_queries/count_query.rb
+++ b/app/models/logstash_queries/count_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class CountQuery
   include AnalyticsDSL
 
@@ -12,11 +14,9 @@ class CountQuery
   end
 
   def booleans(json)
-    json.must do
-      json.term { json.affiliate @affiliate_name }
+    json.filter do
+      json.term { json.set! 'params.affiliate', @affiliate_name }
     end
     must_not_spider(json)
   end
-
-
 end

--- a/app/models/logstash_queries/date_range_top_n_query.rb
+++ b/app/models/logstash_queries/date_range_top_n_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DateRangeTopNQuery < TopNQuery
 
   def initialize(affiliate_name, start_date, end_date, agg_options = {})
@@ -8,5 +10,4 @@ class DateRangeTopNQuery < TopNQuery
   def booleans(json)
     must_affiliate_date_range(json, @affiliate_name, @start_date, @end_date)
   end
-
 end

--- a/app/models/logstash_queries/overall_top_n_query.rb
+++ b/app/models/logstash_queries/overall_top_n_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OverallTopNQuery
   include AnalyticsDSL
 
@@ -21,5 +23,4 @@ class OverallTopNQuery
       since(json, @since)
     end
   end
-
 end

--- a/app/models/logstash_queries/top_n_exists_query.rb
+++ b/app/models/logstash_queries/top_n_exists_query.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class TopNExistsQuery < TopNModulesQuery
-  def additional_musts(json)
+  def modules_must(json)
     json.child! { json.exists { json.field 'modules' } }
   end
 

--- a/app/models/logstash_queries/top_n_exists_query.rb
+++ b/app/models/logstash_queries/top_n_exists_query.rb
@@ -1,11 +1,11 @@
-class TopNExistsQuery < TopNModulesQuery
+# frozen_string_literal: true
 
-  def modules_must(json)
-    json.child! { json.exists { json.field "modules" } }
+class TopNExistsQuery < TopNModulesQuery
+  def additional_musts(json)
+    json.child! { json.exists { json.field 'modules' } }
   end
 
   def additional_must_nots(json)
-    json.child! { json.term { json.modules "QRTD" } }
+    json.child! { json.term { json.modules 'QRTD' } }
   end
-
 end

--- a/app/models/logstash_queries/top_n_missing_query.rb
+++ b/app/models/logstash_queries/top_n_missing_query.rb
@@ -1,7 +1,7 @@
+# frozen_string_literal: true
+
 class TopNMissingQuery < TopNModulesQuery
-
-  def modules_must(json)
-    json.child! { json.missing { json.field "modules" } }
+  def additional_must_nots(json)
+    json.child! { json.exists { json.field 'modules' } }
   end
-
 end

--- a/app/models/logstash_queries/top_n_modules_query.rb
+++ b/app/models/logstash_queries/top_n_modules_query.rb
@@ -4,6 +4,7 @@ class TopNModulesQuery < TopNQuery
   def booleans(json)
     json.must do
       json.child! { json.term { json.set! 'params.affiliate', @affiliate_name } }
+      modules_must(json)
       additional_musts(json)
     end
     json.must_not do
@@ -16,4 +17,6 @@ class TopNModulesQuery < TopNQuery
   def additional_musts(json); end
 
   def additional_must_nots(json); end
+
+  def modules_must(json); end
 end

--- a/app/models/logstash_queries/top_n_modules_query.rb
+++ b/app/models/logstash_queries/top_n_modules_query.rb
@@ -1,22 +1,19 @@
-class TopNModulesQuery < TopNQuery
+# frozen_string_literal: true
 
+class TopNModulesQuery < TopNQuery
   def booleans(json)
     json.must do
-      json.child! { json.term { json.affiliate @affiliate_name } }
-      modules_must(json)
+      json.child! { json.term { json.set! 'params.affiliate', @affiliate_name } }
       additional_musts(json)
     end
     json.must_not do
-      json.child! { json.term { json.set! "useragent.device", "Spider" } }
-      json.child! { json.term { json.raw "" } }
+      json.child! { json.term { json.set! 'useragent.device', 'Spider' } }
+      json.child! { json.term { json.raw '' } }
       additional_must_nots(json)
     end
   end
 
-  def additional_musts(json)
-  end
+  def additional_musts(json); end
 
-  def additional_must_nots(json)
-  end
-
+  def additional_must_nots(json); end
 end

--- a/app/models/logstash_queries/top_n_modules_query.rb
+++ b/app/models/logstash_queries/top_n_modules_query.rb
@@ -8,7 +8,7 @@ class TopNModulesQuery < TopNQuery
     end
     json.must_not do
       json.child! { json.term { json.set! 'useragent.device', 'Spider' } }
-      json.child! { json.term { json.raw '' } }
+      json.child! { json.term { json.set! 'params.query.raw', '' } }
       additional_must_nots(json)
     end
   end

--- a/app/models/logstash_queries/top_n_query.rb
+++ b/app/models/logstash_queries/top_n_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class TopNQuery
   include AnalyticsDSL
 
@@ -14,10 +16,9 @@ class TopNQuery
   end
 
   def booleans(json)
-    json.must do
-      json.term { json.affiliate @affiliate_name }
+    json.filter do
+      json.term { json.set! 'params.affiliate', @affiliate_name }
     end
     must_not_spider(json)
   end
-
 end

--- a/config/secrets.yml.dev
+++ b/config/secrets.yml.dev
@@ -64,15 +64,15 @@ dev_settings: &DEV_SETTINGS
   analytics:
     elasticsearch:
       reader:
-        host: http://localhost:9200
+        hosts:
+          - http://localhost:9200
         user: elastic
         password: changeme
-        log: false
       writers:
-        - host: http://localhost:9200
+        - hosts:
+            - http://localhost:9200
           user: elastic
           password: changeme
-          log: false
   asis:
     host: http://localhost:8080
   custom_indices:

--- a/config/secrets.yml.dev
+++ b/config/secrets.yml.dev
@@ -65,12 +65,12 @@ dev_settings: &DEV_SETTINGS
     elasticsearch:
       reader:
         hosts:
-          - http://localhost:9200
+          - http://localhost:9256
         user: elastic
         password: changeme
       writers:
         - hosts:
-            - http://localhost:9200
+            - http://localhost:9256
           user: elastic
           password: changeme
   asis:

--- a/features/admin_center_watchers.feature
+++ b/features/admin_center_watchers.feature
@@ -3,6 +3,8 @@ Feature: Watchers (aka Analytics Alerts)
   As a site customer
   I want to set up and manage various alerts
 
+  # SRCH-1038
+  @wip
   Scenario: View watchers
     Given the following Affiliates exist:
       | display_name | name       | contact_email   | contact_name |

--- a/lib/analytics_dsl.rb
+++ b/lib/analytics_dsl.rb
@@ -1,16 +1,6 @@
 module AnalyticsDSL
-  def filter(json)
-    json.query do
-      json.filtered do
-        json.filter do
-          yield json
-        end
-      end
-    end
-  end
-
   def filter_booleans(json)
-    filter(json) do |json|
+    json.query do
       json.bool do
         booleans(json)
       end

--- a/lib/analytics_dsl.rb
+++ b/lib/analytics_dsl.rb
@@ -63,7 +63,7 @@ module AnalyticsDSL
 
   def must_affiliate(json, site_name)
     json.must do
-      json.child! { json.term { json.affiliate site_name } }
+      json.child! { json.term { json.set! 'params.affiliate', site_name } }
     end
   end
 

--- a/spec/lib/es_spec.rb
+++ b/spec/lib/es_spec.rb
@@ -36,24 +36,27 @@ describe ES do
     let(:es_config) { Rails.application.secrets.analytics['elasticsearch'] }
 
     describe '.client_reader' do
-      subject(:client_reader) { ES::ELK.client_reader }
-      let(:host) { client_reader.transport.hosts.first }
+      subject(:client) { ES::ELK.client_reader }
+      let(:host) { client.transport.hosts.first }
 
       it 'uses the values from the secrets.yml analytics[elasticsearch][reader] entry' do
-        expect(host[:host]).to eq(URI(es_config['reader']['host']).host)
+        expect(host[:host]).to eq(URI(es_config['reader']['hosts'].first).host)
         expect(host[:user]).to eq(es_config['reader']['user'])
       end
+
+      it_behaves_like 'an Elasticsearch client'
     end
 
     describe '.client_writers' do
       subject(:client_writers) { ES::ELK.client_writers }
+      let(:client) { client_writers.first }
 
       it 'uses the value(s) from the secrets.yml analytics[elasticsearch][writers] entry' do
         count = Rails.application.secrets.analytics['elasticsearch']['writers'].count
-        expect(ES::ELK.client_writers.size).to eq(count)
+        expect(client_writers.size).to eq(count)
         count.times do |i|
-          host = ES::ELK.client_writers.first.transport.hosts[i]
-          expect(host[:host]).to eq(URI(es_config['writers'][i]['host']).host)
+          host = client.transport.hosts[i]
+          expect(host[:host]).to eq(URI(es_config['writers'][i]['hosts'].first).host)
           expect(host[:user]).to eq(es_config['writers'][i]['user'])
         end
       end
@@ -62,6 +65,8 @@ describe ES do
         client_writers
         expect(es_config['writers']).to be_frozen
       end
+
+      it_behaves_like 'an Elasticsearch client'
     end
   end
 

--- a/spec/models/logstash_queries/count_query_spec.rb
+++ b/spec/models/logstash_queries/count_query_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe CountQuery, "#body" do
+describe CountQuery do
   let(:query) { CountQuery.new('affiliate_name') }
   let(:expected_body) do
     {
@@ -20,8 +20,6 @@ describe CountQuery, "#body" do
       }
     }.to_json
   end
-
-  include_context 'querying logstash indexes'
 
   it_behaves_like 'a logstash query'
 end

--- a/spec/models/logstash_queries/count_query_spec.rb
+++ b/spec/models/logstash_queries/count_query_spec.rb
@@ -2,9 +2,26 @@ require 'spec_helper'
 
 describe CountQuery, "#body" do
   let(:query) { CountQuery.new('affiliate_name') }
+  let(:expected_body) do
+    {
+      "query": {
+        "bool": {
+          "filter": {
+            "term": {
+              "params.affiliate": "affiliate_name"
+            }
+          },
+          "must_not": {
+            "term": {
+              "useragent.device": "Spider"
+            }
+          }
+        }
+      }
+    }.to_json
+  end
 
-  subject(:body) { query.body }
+  include_context 'querying logstash indexes'
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":{"term":{"affiliate":"affiliate_name"}},"must_not":{"term":{"useragent.device":"Spider"}}}}}}}))}
-
+  it_behaves_like 'a logstash query'
 end

--- a/spec/models/logstash_queries/date_range_top_n_field_query_spec.rb
+++ b/spec/models/logstash_queries/date_range_top_n_field_query_spec.rb
@@ -1,10 +1,16 @@
 require 'spec_helper'
 
-describe DateRangeTopNFieldQuery, "#body" do
-  let(:query) { DateRangeTopNFieldQuery.new('foo', Date.parse("2014-06-28"), Date.parse("2014-06-29"), 'params.url', 'some_url', {field: 'raw', size: 0}) }
+describe DateRangeTopNFieldQuery do
+  let(:query) do
+    DateRangeTopNFieldQuery.new('affiliate_name',
+                                Date.parse('2014-06-28'),
+                                Date.parse('2014-06-29'),
+                                'params.url',
+                                'some_url',
+                                { field: 'params.query.raw', size: 0 })
+  end
 
-  subject(:body) { query.body }
-
+  # SRCH-1039
   xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"foo"}},{"term":{"params.url":"some_url"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":0}}}}))}
 
   context 'when the affiliate is nil' do
@@ -17,6 +23,7 @@ describe DateRangeTopNFieldQuery, "#body" do
                                   { field: 'raw', size: 0 })
     end
 
+    # SRCH-1039
     xit 'filters by the field' do
       expect(body).to eq(
         %q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"some_field":"some_value"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":0}}}})

--- a/spec/models/logstash_queries/date_range_top_n_field_query_spec.rb
+++ b/spec/models/logstash_queries/date_range_top_n_field_query_spec.rb
@@ -5,7 +5,7 @@ describe DateRangeTopNFieldQuery, "#body" do
 
   subject(:body) { query.body }
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"foo"}},{"term":{"params.url":"some_url"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":0}}}}))}
+  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"foo"}},{"term":{"params.url":"some_url"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":0}}}}))}
 
   context 'when the affiliate is nil' do
     let(:query) do
@@ -17,7 +17,7 @@ describe DateRangeTopNFieldQuery, "#body" do
                                   { field: 'raw', size: 0 })
     end
 
-    it 'filters by the field' do
+    xit 'filters by the field' do
       expect(body).to eq(
         %q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"some_field":"some_value"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":0}}}})
       )

--- a/spec/models/logstash_queries/date_range_top_n_missing_query_spec.rb
+++ b/spec/models/logstash_queries/date_range_top_n_missing_query_spec.rb
@@ -5,5 +5,5 @@ describe DateRangeTopNMissingQuery, '#body' do
 
   subject(:body) { query.body }
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"aff_name"}},{"missing":{"field":"modules"}},{"range":{"@timestamp":{"gte":"2015-06-01","lte":"2015-06-30"}}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000}}}}))}
+  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"aff_name"}},{"missing":{"field":"modules"}},{"range":{"@timestamp":{"gte":"2015-06-01","lte":"2015-06-30"}}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000}}}}))}
 end

--- a/spec/models/logstash_queries/date_range_top_n_missing_query_spec.rb
+++ b/spec/models/logstash_queries/date_range_top_n_missing_query_spec.rb
@@ -5,5 +5,6 @@ describe DateRangeTopNMissingQuery, '#body' do
 
   subject(:body) { query.body }
 
+  # SRCH-1040
   xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"aff_name"}},{"missing":{"field":"modules"}},{"range":{"@timestamp":{"gte":"2015-06-01","lte":"2015-06-30"}}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000}}}}))}
 end

--- a/spec/models/logstash_queries/date_range_top_n_query_spec.rb
+++ b/spec/models/logstash_queries/date_range_top_n_query_spec.rb
@@ -1,10 +1,48 @@
 require 'spec_helper'
 
-describe DateRangeTopNQuery, "#body" do
-  let(:query) { DateRangeTopNQuery.new('foo', Date.parse("2014-06-28"), Date.parse("2014-06-29"), {field: 'raw', size: 1000}) }
+describe DateRangeTopNQuery do
+  let(:query) do
+    DateRangeTopNQuery.new('affiliate_name',
+                           Date.parse('2019-11-01'),
+                           Date.parse('2019-11-07'),
+                           { field: 'params.query.raw', size: 1000 })
+  end
+  let(:expected_body) do
+    {
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "term": {
+                "params.affiliate": "affiliate_name"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "gte": "2019-11-01",
+                  "lte": "2019-11-07"
+                }
+              }
+            }
+          ],
+          "must_not": {
+            "term": {
+              "useragent.device": "Spider"
+            }
+          }
+        }
+      },
+      "aggs": {
+        "agg": {
+          "terms": {
+            "field": "params.query.raw",
+            "size": 1000
+          }
+        }
+      }
+    }.to_json
+  end
 
-  subject(:body) { query.body }
-
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"foo"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000}}}}))}
-
+  it_behaves_like 'a logstash query'
 end

--- a/spec/models/logstash_queries/module_breakdown_query_spec.rb
+++ b/spec/models/logstash_queries/module_breakdown_query_spec.rb
@@ -5,6 +5,6 @@ describe ModuleBreakdownQuery, "#body" do
 
   subject(:body) { query.body }
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":{"term":{"affiliate":"affiliate_name"}},"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"modules","size":0},"aggs":{"type":{"terms":{"field":"type"}}}}}}))}
+  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":{"term":{"affiliate":"affiliate_name"}},"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"modules","size":0},"aggs":{"type":{"terms":{"field":"type"}}}}}}))}
 
 end

--- a/spec/models/logstash_queries/module_breakdown_query_spec.rb
+++ b/spec/models/logstash_queries/module_breakdown_query_spec.rb
@@ -5,6 +5,7 @@ describe ModuleBreakdownQuery, "#body" do
 
   subject(:body) { query.body }
 
+  # SRCH-1041
   xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":{"term":{"affiliate":"affiliate_name"}},"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"modules","size":0},"aggs":{"type":{"terms":{"field":"type"}}}}}}))}
 
 end

--- a/spec/models/logstash_queries/module_sparkline_query_spec.rb
+++ b/spec/models/logstash_queries/module_sparkline_query_spec.rb
@@ -5,6 +5,7 @@ describe ModuleSparklineQuery, "#body" do
 
   subject(:body) { query.body }
 
+  # SRCH-1042
   xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"range":{"@timestamp":{"gte":"now-60d/d"}}},{"exists":{"field":"modules"}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"modules","size":0},"aggs":{"histogram":{"date_histogram":{"field":"@timestamp","interval":"day","format":"yyyy-MM-dd","min_doc_count":0},"aggs":{"type":{"terms":{"field":"type"}}}}}}}}))}
 
 end

--- a/spec/models/logstash_queries/module_sparkline_query_spec.rb
+++ b/spec/models/logstash_queries/module_sparkline_query_spec.rb
@@ -5,6 +5,6 @@ describe ModuleSparklineQuery, "#body" do
 
   subject(:body) { query.body }
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"range":{"@timestamp":{"gte":"now-60d/d"}}},{"exists":{"field":"modules"}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"modules","size":0},"aggs":{"histogram":{"date_histogram":{"field":"@timestamp","interval":"day","format":"yyyy-MM-dd","min_doc_count":0},"aggs":{"type":{"terms":{"field":"type"}}}}}}}}))}
+  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"range":{"@timestamp":{"gte":"now-60d/d"}}},{"exists":{"field":"modules"}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"modules","size":0},"aggs":{"histogram":{"date_histogram":{"field":"@timestamp","interval":"day","format":"yyyy-MM-dd","min_doc_count":0},"aggs":{"type":{"terms":{"field":"type"}}}}}}}}))}
 
 end

--- a/spec/models/logstash_queries/monthly_histogram_query_spec.rb
+++ b/spec/models/logstash_queries/monthly_histogram_query_spec.rb
@@ -5,6 +5,6 @@ describe MonthlyHistogramQuery, "#body" do
 
   subject(:body) { query.body }
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"range":{"@timestamp":{"gte":"2014-06-28"}}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"date_histogram":{"field":"@timestamp","interval":"month","format":"yyyy-MM","min_doc_count":0}}}}))}
+  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"range":{"@timestamp":{"gte":"2014-06-28"}}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"date_histogram":{"field":"@timestamp","interval":"month","format":"yyyy-MM","min_doc_count":0}}}}))}
 
 end

--- a/spec/models/logstash_queries/monthly_histogram_query_spec.rb
+++ b/spec/models/logstash_queries/monthly_histogram_query_spec.rb
@@ -5,6 +5,7 @@ describe MonthlyHistogramQuery, "#body" do
 
   subject(:body) { query.body }
 
+  # SRCH-1043
   xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"range":{"@timestamp":{"gte":"2014-06-28"}}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"date_histogram":{"field":"@timestamp","interval":"month","format":"yyyy-MM","min_doc_count":0}}}}))}
 
 end

--- a/spec/models/logstash_queries/overall_sparkline_query_spec.rb
+++ b/spec/models/logstash_queries/overall_sparkline_query_spec.rb
@@ -5,6 +5,6 @@ describe OverallSparklineQuery, "#body" do
 
   subject(:body) { query.body }
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"range":{"@timestamp":{"gte":"now-60d/d"}}},{"exists":{"field":"modules"}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"histogram":{"date_histogram":{"field":"@timestamp","interval":"day","format":"yyyy-MM-dd","min_doc_count":0},"aggs":{"type":{"terms":{"field":"type"}}}}}}))}
+  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"range":{"@timestamp":{"gte":"now-60d/d"}}},{"exists":{"field":"modules"}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"histogram":{"date_histogram":{"field":"@timestamp","interval":"day","format":"yyyy-MM-dd","min_doc_count":0},"aggs":{"type":{"terms":{"field":"type"}}}}}}))}
 
 end

--- a/spec/models/logstash_queries/overall_sparkline_query_spec.rb
+++ b/spec/models/logstash_queries/overall_sparkline_query_spec.rb
@@ -5,6 +5,7 @@ describe OverallSparklineQuery, "#body" do
 
   subject(:body) { query.body }
 
+  # SRCH-1044
   xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"range":{"@timestamp":{"gte":"now-60d/d"}}},{"exists":{"field":"modules"}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"histogram":{"date_histogram":{"field":"@timestamp","interval":"day","format":"yyyy-MM-dd","min_doc_count":0},"aggs":{"type":{"terms":{"field":"type"}}}}}}))}
 
 end

--- a/spec/models/logstash_queries/overall_top_n_query_spec.rb
+++ b/spec/models/logstash_queries/overall_top_n_query_spec.rb
@@ -1,10 +1,38 @@
 require 'spec_helper'
 
-describe OverallTopNQuery, "#body" do
-  let(:query) { OverallTopNQuery.new(Date.parse('2014-06-28'), { field: 'raw', size: 1234 }) }
+describe OverallTopNQuery do
+  let(:query) do
+    OverallTopNQuery.new(Date.parse('2014-06-28'),
+                         { field: 'params.query.raw', size: 1234 })
+  end
+  let(:expected_body) do
+    {
+      "query": {
+        "bool": {
+          "must_not": {
+            "term": {
+              "tags": "api"
+            }
+          },
+          "must": {
+            "range": {
+              "@timestamp": {
+                "gte": "2014-06-28"
+              }
+            }
+          }
+        }
+      },
+      "aggs": {
+        "agg": {
+          "terms": {
+            "field": "params.query.raw",
+            "size": 1234
+          }
+        }
+      }
+    }.to_json
+  end
 
-  subject(:body) { query.body }
-
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must_not":{"term":{"tags":"api"}},"must":{"range":{"@timestamp":{"gte":"2014-06-28"}}}}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1234}}}}))}
-
+  it_behaves_like 'a logstash query'
 end

--- a/spec/models/logstash_queries/rtu_date_range_query_spec.rb
+++ b/spec/models/logstash_queries/rtu_date_range_query_spec.rb
@@ -5,6 +5,6 @@ describe RtuDateRangeQuery, "#body" do
 
   subject(:body) { query.body }
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":{"term":{"affiliate":"affiliate_name"}},"must_not":{"term":{"useragent.device":"Spider"}}}}}},"facets":{"stats":{"statistical":{"field":"@timestamp"}}}}))}
+  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":{"term":{"affiliate":"affiliate_name"}},"must_not":{"term":{"useragent.device":"Spider"}}}}}},"facets":{"stats":{"statistical":{"field":"@timestamp"}}}}))}
 
 end

--- a/spec/models/logstash_queries/rtu_date_range_query_spec.rb
+++ b/spec/models/logstash_queries/rtu_date_range_query_spec.rb
@@ -5,6 +5,7 @@ describe RtuDateRangeQuery, "#body" do
 
   subject(:body) { query.body }
 
+  # SRCH-1045
   xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":{"term":{"affiliate":"affiliate_name"}},"must_not":{"term":{"useragent.device":"Spider"}}}}}},"facets":{"stats":{"statistical":{"field":"@timestamp"}}}}))}
 
 end

--- a/spec/models/logstash_queries/top_n_exists_query_spec.rb
+++ b/spec/models/logstash_queries/top_n_exists_query_spec.rb
@@ -1,10 +1,52 @@
 require 'spec_helper'
 
-describe TopNExistsQuery, "#body" do
-  let(:query) { TopNExistsQuery.new('aff_name', {field: 'raw', size: 1000}) }
+describe TopNExistsQuery do
+  let(:query) { TopNExistsQuery.new('affiliate_name', { field: 'type', size: 1000 }) }
+  let(:expected_body) do
+    {
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "term": {
+                "params.affiliate": "affiliate_name"
+              }
+            },
+            {
+              "exists": {
+                "field": "modules"
+              }
+            }
+          ],
+          "must_not": [
+            {
+              "term": {
+                "useragent.device": "Spider"
+              }
+            },
+            {
+              "term": {
+                "params.query.raw": ""
+              }
+            },
+            {
+              "term": {
+                "modules": "QRTD"
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "agg": {
+          "terms": {
+            "field": "type",
+            "size": 1000
+          }
+        }
+      }
+    }.to_json
+  end
 
-  subject(:body) { query.body }
-
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"aff_name"}},{"exists":{"field":"modules"}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}},{"term":{"modules":"QRTD"}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000}}}}))}
-
+  it_behaves_like 'a logstash query'
 end

--- a/spec/models/logstash_queries/top_n_missing_query_spec.rb
+++ b/spec/models/logstash_queries/top_n_missing_query_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe TopNMissingQuery do
-  let(:query) { TopNMissingQuery.new('affiliate_name', { field: 'raw', size: 1000 }) }
+  let(:query) { TopNMissingQuery.new('affiliate_name', { field: 'type', size: 1000 }) }
   let(:expected_body) do
     {
       "query": {
@@ -21,7 +21,7 @@ describe TopNMissingQuery do
             },
             {
               "term": {
-                "raw": ""
+                "params.query.raw": ""
               }
             },
             {
@@ -35,7 +35,7 @@ describe TopNMissingQuery do
       "aggs": {
         "agg": {
           "terms": {
-            "field": "raw",
+            "field": "type",
             "size": 1000
           }
         }

--- a/spec/models/logstash_queries/top_n_missing_query_spec.rb
+++ b/spec/models/logstash_queries/top_n_missing_query_spec.rb
@@ -1,10 +1,47 @@
 require 'spec_helper'
 
-describe TopNMissingQuery, "#body" do
-  let(:query) { TopNMissingQuery.new('aff_name', {field: 'raw', size: 1000}) }
+describe TopNMissingQuery do
+  let(:query) { TopNMissingQuery.new('affiliate_name', { field: 'raw', size: 1000 }) }
+  let(:expected_body) do
+    {
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "term": {
+                "params.affiliate": "affiliate_name"
+              }
+            }
+          ],
+          "must_not": [
+            {
+              "term": {
+                "useragent.device": "Spider"
+              }
+            },
+            {
+              "term": {
+                "raw": ""
+              }
+            },
+            {
+              "exists": {
+                "field": "modules"
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "agg": {
+          "terms": {
+            "field": "raw",
+            "size": 1000
+          }
+        }
+      }
+    }.to_json
+  end
 
-  subject(:body) { query.body }
-
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"aff_name"}},{"missing":{"field":"modules"}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000}}}}))}
-
+  it_behaves_like 'a logstash query'
 end

--- a/spec/models/logstash_queries/top_n_query_spec.rb
+++ b/spec/models/logstash_queries/top_n_query_spec.rb
@@ -29,7 +29,5 @@ describe TopNQuery, "#body" do
     }.to_json
   end
 
-  include_context 'querying logstash indexes'
-
   it_behaves_like 'a logstash query'
 end

--- a/spec/models/logstash_queries/top_n_query_spec.rb
+++ b/spec/models/logstash_queries/top_n_query_spec.rb
@@ -1,10 +1,35 @@
 require 'spec_helper'
 
 describe TopNQuery, "#body" do
-  let(:query) { TopNQuery.new('aff_name', {field: 'raw', size: 1000}) }
+  let(:query) { TopNQuery.new('affiliate_name', { field: 'raw', size: 1000 }) }
+  let(:expected_body) do
+    {
+      "query": {
+        "bool": {
+          "filter": {
+            "term": {
+              "params.affiliate": "affiliate_name"
+            }
+          },
+          "must_not": {
+            "term": {
+              "useragent.device": "Spider"
+            }
+          }
+        }
+      },
+      "aggs": {
+        "agg": {
+          "terms": {
+            "field": "raw",
+            "size": 1000
+          }
+        }
+      }
+    }.to_json
+  end
 
-  subject(:body) { query.body }
+  include_context 'querying logstash indexes'
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":{"term":{"affiliate":"aff_name"}},"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000}}}}))}
-
+  it_behaves_like 'a logstash query'
 end

--- a/spec/models/logstash_queries/top_query_match_query_spec.rb
+++ b/spec/models/logstash_queries/top_query_match_query_spec.rb
@@ -5,6 +5,7 @@ describe TopQueryMatchQuery, "#body" do
 
   subject(:body) { query.body }
 
+  # SRCH-1046
   xit { is_expected.to eq(%q({"query":{"filtered":{"query":{"match":{"query":{"query":"my query term","analyzer":"snowball","operator":"and"}}},"filter":{"bool":{"must":[{"term":{"affiliate":"foo"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000},"aggs":{"type":{"terms":{"field":"type"}}}}}}))}
 
 end

--- a/spec/models/logstash_queries/top_query_match_query_spec.rb
+++ b/spec/models/logstash_queries/top_query_match_query_spec.rb
@@ -5,6 +5,6 @@ describe TopQueryMatchQuery, "#body" do
 
   subject(:body) { query.body }
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"query":{"match":{"query":{"query":"my query term","analyzer":"snowball","operator":"and"}}},"filter":{"bool":{"must":[{"term":{"affiliate":"foo"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000},"aggs":{"type":{"terms":{"field":"type"}}}}}}))}
+  xit { is_expected.to eq(%q({"query":{"filtered":{"query":{"match":{"query":{"query":"my query term","analyzer":"snowball","operator":"and"}}},"filter":{"bool":{"must":[{"term":{"affiliate":"foo"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}],"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000},"aggs":{"type":{"terms":{"field":"type"}}}}}}))}
 
 end

--- a/spec/models/logstash_queries/trending_terms_query_spec.rb
+++ b/spec/models/logstash_queries/trending_terms_query_spec.rb
@@ -5,6 +5,6 @@ describe TrendingTermsQuery, "#body" do
 
   subject(:body) { query.body }
 
-  it { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"term":{"type":"search"}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}},{"exists":{"field":"params.page"}}]}},"query":{"range":{"@timestamp":{"gte":"now-5h/h"}}}}},"aggs":{"agg":{"significant_terms":{"min_doc_count":22,"field":"params.query.raw","background_filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"term":{"type":"search"}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}},{"exists":{"field":"params.page"}}]}}},"aggs":{"clientip_count":{"cardinality":{"field":"clientip"}}}}}}))}
+  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"term":{"type":"search"}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}},{"exists":{"field":"params.page"}}]}},"query":{"range":{"@timestamp":{"gte":"now-5h/h"}}}}},"aggs":{"agg":{"significant_terms":{"min_doc_count":22,"field":"params.query.raw","background_filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"term":{"type":"search"}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}},{"exists":{"field":"params.page"}}]}}},"aggs":{"clientip_count":{"cardinality":{"field":"clientip"}}}}}}))}
 
 end

--- a/spec/models/logstash_queries/trending_terms_query_spec.rb
+++ b/spec/models/logstash_queries/trending_terms_query_spec.rb
@@ -5,6 +5,7 @@ describe TrendingTermsQuery, "#body" do
 
   subject(:body) { query.body }
 
+  # SRCH-1047
   xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"term":{"type":"search"}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}},{"exists":{"field":"params.page"}}]}},"query":{"range":{"@timestamp":{"gte":"now-5h/h"}}}}},"aggs":{"agg":{"significant_terms":{"min_doc_count":22,"field":"params.query.raw","background_filter":{"bool":{"must":[{"term":{"affiliate":"affiliate_name"}},{"term":{"type":"search"}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}},{"exists":{"field":"params.page"}}]}}},"aggs":{"clientip_count":{"cardinality":{"field":"clientip"}}}}}}))}
 
 end

--- a/spec/models/low_query_ctr_watcher_spec.rb
+++ b/spec/models/low_query_ctr_watcher_spec.rb
@@ -22,7 +22,8 @@ describe LowQueryCtrWatcher do
                                             user_id: user.id, time_window: '1w', query_blocklist: "foo, bar, another one",
                                             check_interval: '1m', throttle_period: '24h', name: "low CTR") }
 
-    it "returns a JSON structure representing an Elasticsearch Watcher body" do
+    # SRCH-1047
+    xit "returns a JSON structure representing an Elasticsearch Watcher body" do
       expect(watcher.body).to eq(json_response)
     end
   end

--- a/spec/models/no_results_watcher_spec.rb
+++ b/spec/models/no_results_watcher_spec.rb
@@ -21,7 +21,8 @@ describe NoResultsWatcher do
                                             time_window: '1w', query_blocklist: "foo, bar, another one",
                                             check_interval: '1m', throttle_period: '24h', name: "no rez") }
 
-    it "returns a JSON structure representing an Elasticsearch Watcher body" do
+    # SRCH-1038
+    xit "returns a JSON structure representing an Elasticsearch Watcher body" do
       expect(watcher.body).to eq(json_response)
     end
   end

--- a/spec/models/rtu_queries_request_spec.rb
+++ b/spec/models/rtu_queries_request_spec.rb
@@ -13,7 +13,8 @@ describe RtuQueriesRequest do
 
   let(:site) { affiliates(:basic_affiliate) }
 
-  describe "#save" do
+  # SRCH-1049
+  pending "#save" do
     describe "computing top query stats" do
       let(:rtu_queries_request) { RtuQueriesRequest.new("start_date" => "05/28/2014",
                                                         "end_date" => "05/28/2014",

--- a/spec/support/logstash_query_behavior.rb
+++ b/spec/support/logstash_query_behavior.rb
@@ -1,11 +1,11 @@
-shared_context 'querying logstash indexes' do
-  subject(:body) { query.body }
-end
-
 shared_examples_for 'a logstash query' do
-  it 'does not raise an error' do
-    ES::ELK.client_reader.search(index: 'logstash-*',  body: body)
-  end
+  describe '#body' do
+    subject(:body) { query.body }
 
-  it { is_expected.to eq(expected_body) }
+    it 'does not raise an error' do
+      ES::ELK.client_reader.search(index: 'logstash-*',  body: body)
+    end
+
+    it { is_expected.to eq(expected_body) }
+  end
 end

--- a/spec/support/logstash_query_behavior.rb
+++ b/spec/support/logstash_query_behavior.rb
@@ -3,7 +3,9 @@ shared_examples_for 'a logstash query' do
     subject(:body) { query.body }
 
     it 'does not raise an error' do
-      ES::ELK.client_reader.search(index: 'logstash-*',  body: body)
+      expect {
+        ES::ELK.client_reader.search(index: 'logstash-*',  body: body)
+      }.not_to raise_error
     end
 
     it { is_expected.to eq(expected_body) }

--- a/spec/support/logstash_query_behavior.rb
+++ b/spec/support/logstash_query_behavior.rb
@@ -1,0 +1,11 @@
+shared_context 'querying logstash indexes' do
+  subject(:body) { query.body }
+end
+
+shared_examples_for 'a logstash query' do
+  it 'does not raise an error' do
+    ES::ELK.client_reader.search(index: 'logstash-*',  body: body)
+  end
+
+  it { is_expected.to eq(expected_body) }
+end


### PR DESCRIPTION
@lsamuels-fearless , this is the first batch of changes to the Logstash queries. I batched the first set of changes as they involved some exploration and shared spec setup. The next set of changes will be more granular.   This PR:
- sets up some shared specs for logstash queries to check that they don't cause errors on the specified cluster
- configures the analytics specs to run against the 5.6 cluster
- updates the specs to expect the correct query format
- comments out the currently failing specs, which will be fixed & re-enabled in subsequent PRs