### PR TITLE
Upgraded less-rails-bootstrap gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -100,7 +100,8 @@ gem 'cld3', '~> 3.2.3'
 gem 'coffee-rails', '~> 4.2.2'
 gem 'uglifier', '~> 4.1.2'
 # Using forked copy until https://github.com/metaskills/less-rails-bootstrap/pull/132 is merged
-gem 'less-rails-bootstrap', git: 'https://github.com/veelenga/less-rails-bootstrap', :ref => '7c479c2fdff500dc036c15364aa085332a73c642'
+gem 'less-rails-bootstrap', git: 'https://github.com/veelenga/less-rails-bootstrap',
+                            ref: '7c479c2fdff500dc036c15364aa085332a73c642'
 gem 'compass-rails', '~> 3.1.0'
 gem 'compass-blueprint', '~> 1.0.0'
 gem 'jquery-ui-rails', '~> 6.0.1'

--- a/Gemfile
+++ b/Gemfile
@@ -96,10 +96,11 @@ gem 'active_scheduler', '~> 0.5.0'
 gem 'retriable', '~> 3.1'
 gem 'cld3', '~> 3.2.3'
 
-#Assets-related gems
+# Assets-related gems
 gem 'coffee-rails', '~> 4.2.2'
 gem 'uglifier', '~> 4.1.2'
-gem 'less-rails-bootstrap', '~> 3.3.5'
+# Using forked copy until https://github.com/metaskills/less-rails-bootstrap/pull/132 is merged
+gem 'less-rails-bootstrap', git: 'https://github.com/veelenga/less-rails-bootstrap', :ref => '7c479c2fdff500dc036c15364aa085332a73c642'
 gem 'compass-rails', '~> 3.1.0'
 gem 'compass-blueprint', '~> 1.0.0'
 gem 'jquery-ui-rails', '~> 6.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -76,6 +76,14 @@ GIT
       active_scaffold (>= 3.3.0.rc)
 
 GIT
+  remote: https://github.com/veelenga/less-rails-bootstrap
+  revision: 7c479c2fdff500dc036c15364aa085332a73c642
+  ref: 7c479c2fdff500dc036c15364aa085332a73c642
+  specs:
+    less-rails-bootstrap (3.3.5.0)
+      less-rails (>= 3.0)
+
+GIT
   remote: https://github.com/winston/google_visualr
   revision: 17b97114a345baadd011e7b442b9a6c91a2b7ab5
   ref: 17b97114a345baadd011e7b442b9a6c91a2b7ab5
@@ -229,7 +237,7 @@ GEM
       after_commit_action (~> 1.0)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
-    crass (1.0.4)
+    crass (1.0.5)
     cucumber (3.1.2)
       builder (>= 2.1.2)
       cucumber-core (~> 3.2.0)
@@ -399,13 +407,10 @@ GEM
       addressable (~> 2.3)
     less (2.6.0)
       commonjs (~> 0.2.7)
-    less-rails (2.8.0)
-      actionpack (>= 4.0)
+    less-rails (4.0.0)
+      actionpack (>= 4)
       less (~> 2.6.0)
-      sprockets (> 2, < 4)
-      tilt
-    less-rails-bootstrap (3.3.5.0)
-      less-rails (>= 2.6, <= 2.8)
+      sprockets (>= 2)
     libv8 (3.16.14.19)
     little-plugger (1.1.4)
     logging (2.2.2)
@@ -450,7 +455,7 @@ GEM
     net-http-persistent (2.9.4)
     newrelic_rpm (5.0.0.342)
     nio4r (2.3.1)
-    nokogiri (1.10.4)
+    nokogiri (1.10.5)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
@@ -513,7 +518,7 @@ GEM
     rails-dom-testing (2.0.3)
       activesupport (>= 4.2.0)
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.0.4)
+    rails-html-sanitizer (1.2.0)
       loofah (~> 2.2, >= 2.2.2)
     rails-i18n (5.1.3)
       i18n (>= 0.7, < 2)
@@ -683,7 +688,7 @@ GEM
       rack (>= 1, < 3)
     thor (0.20.3)
     thread_safe (0.3.6)
-    tilt (2.0.9)
+    tilt (2.0.10)
     timecop (0.9.1)
     truncator (0.1.7)
       activesupport
@@ -812,7 +817,7 @@ DEPENDENCIES
   json (~> 1.8.6)
   jwt (~> 1.5.6)
   launchy (~> 2.4.3)
-  less-rails-bootstrap (~> 3.3.5)
+  less-rails-bootstrap!
   lograge (~> 0.7.1)
   loofah (~> 2.2.2)
   medusa!


### PR DESCRIPTION
Upgraded to forked version of less-rails-bootstrap gem to address sprockets deprecation warning. The main build of this gem appears to no longer be maintained 
[https://github.com/metaskills/less-rails-bootstrap/pull/132](https://github.com/metaskills/less-rails-bootstrap/pull/132)