### PR TITLE
SRCH-1053 resolve deprecation related to association reloading

### DIFF
--- a/app/controllers/sites/youtube_profiles_controller.rb
+++ b/app/controllers/sites/youtube_profiles_controller.rb
@@ -12,7 +12,7 @@ class Sites::YoutubeProfilesController < Sites::SetupSiteController
   end
 
   def after_profile_deleted
-    @site.disable_video_govbox! unless @site.youtube_profiles(true).exists?
+    @site.disable_video_govbox! unless @site.youtube_profiles.reload.exists?
   end
 
   def human_profile_name

--- a/spec/controllers/sites/youtube_profiles_controller_spec.rb
+++ b/spec/controllers/sites/youtube_profiles_controller_spec.rb
@@ -136,7 +136,8 @@ describe Sites::YoutubeProfilesController do
         expect(youtube_profiles).to receive(:find_by_id).with('100').
             and_return(youtube_profile)
         expect(youtube_profiles).to receive(:delete).with(youtube_profile)
-        expect(youtube_profiles).to receive(:exists?).and_return(false)
+        expect(youtube_profiles).
+          to receive_message_chain(:reload, :exists?).and_return(false)
         expect(site).to receive(:disable_video_govbox!)
 
         delete :destroy, params: { site_id: site.id, id: 100 }


### PR DESCRIPTION
@peggles2 , this resolves a deprecation warning I missed in SRCH-631 as it only appeared in a cucumber test:
```
DEPRECATION WARNING: Passing an argument to force an association to reload is now deprecated and will be removed in Rails 5.1. Please call `reload` on the result collection proxy instead. (called from after_profile_deleted at /Users/Moth/src/GSA/search-gov-GSA/app/controllers/sites/youtube_profiles_controller.rb:15) 
```
