### PR TITLE
SRCH-1041 update ModuleBreakdownQuery

### DIFF
--- a/app/models/logstash_queries/module_breakdown_query.rb
+++ b/app/models/logstash_queries/module_breakdown_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ModuleBreakdownQuery
   include AnalyticsDSL
 
@@ -8,15 +10,12 @@ class ModuleBreakdownQuery
   def body
     Jbuilder.encode do |json|
       filter_booleans(json)
-      type_terms_agg(json, 'modules', 0)
+      type_terms_agg(json, 'modules', 100)
     end
   end
 
   def booleans(json)
-    json.must do
-      json.term { json.affiliate @affiliate_name }
-    end if @affiliate_name.present?
+    must_affiliate(json, @affiliate_name) if @affiliate_name.present?
     must_not_spider(json)
   end
-
 end

--- a/spec/models/logstash_queries/module_breakdown_query_spec.rb
+++ b/spec/models/logstash_queries/module_breakdown_query_spec.rb
@@ -1,11 +1,76 @@
 require 'spec_helper'
 
-describe ModuleBreakdownQuery, "#body" do
+describe ModuleBreakdownQuery do
   let(:query) { ModuleBreakdownQuery.new('affiliate_name') }
+  let(:expected_body) do
+    {
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "term": {
+                "params.affiliate": "affiliate_name"
+              }
+            }
+          ],
+          "must_not": {
+            "term": {
+              "useragent.device": "Spider"
+            }
+          }
+        }
+      },
+      "aggs": {
+        "agg": {
+          "terms": {
+            "field": "modules",
+            "size": 100
+          },
+          "aggs": {
+            "type": {
+              "terms": {
+                "field": "type"
+              }
+            }
+          }
+        }
+      }
+    }.to_json
+  end
 
-  subject(:body) { query.body }
+  it_behaves_like 'a logstash query'
 
-  # SRCH-1041
-  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":{"term":{"affiliate":"affiliate_name"}},"must_not":{"term":{"useragent.device":"Spider"}}}}}},"aggs":{"agg":{"terms":{"field":"modules","size":0},"aggs":{"type":{"terms":{"field":"type"}}}}}}))}
+  context 'when the affiliate_name is missing' do
+    let(:query) { ModuleBreakdownQuery.new }
+    let(:expected_body) do
+      {
+        "query": {
+          "bool": {
+            "must_not": {
+              "term": {
+                "useragent.device": "Spider"
+              }
+            }
+          }
+        },
+        "aggs": {
+          "agg": {
+            "terms": {
+              "field": "modules",
+              "size": 100
+            },
+            "aggs": {
+              "type": {
+                "terms": {
+                  "field": "type"
+                }
+              }
+            }
+          }
+        }
+      }.to_json
+    end
 
+    it_behaves_like 'a logstash query'
+  end
 end


### PR DESCRIPTION
This PR updates the ModuleBreakdownQuery to run on Elasticsearch 5.6.