### PR TITLE
    SRCH-1059 - remove uniq index from UID

### DIFF
--- a/db/migrate/20191113214448_change_uid_index.rb
+++ b/db/migrate/20191113214448_change_uid_index.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class ChangeUidIndex < ActiveRecord::Migration[5.0]
+  def change
+    change_table :users, bulk: true do
+      remove_index :users, :uid
+      add_index :users, :uid
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1484,8 +1484,8 @@ CREATE TABLE `users` (
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_api_key` (`api_key`),
   UNIQUE KEY `index_users_on_email_verification_token` (`email_verification_token`),
-  UNIQUE KEY `index_users_on_uid` (`uid`),
-  KEY `index_users_on_perishable_token` (`perishable_token`)
+  KEY `index_users_on_perishable_token` (`perishable_token`),
+  KEY `index_users_on_uid` (`uid`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci ROW_FORMAT=DYNAMIC;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
@@ -1583,7 +1583,7 @@ CREATE TABLE `youtube_profiles` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2019-09-24 15:49:59
+-- Dump completed on 2019-11-13 21:24:34
 INSERT INTO `schema_migrations` (version) VALUES
 ('20090818003200'),
 ('20090827135344'),
@@ -2309,6 +2309,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20181109212904'),
 ('20181213153332'),
 ('20190205200912'),
-('20190920181828');
+('20190920181828'),
+('20191113214448');
 
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -26,7 +26,6 @@ describe User do
     it { is_expected.to have_db_column(:failed_login_count).of_type(:integer).with_options(default: 0, null: false) }
     it { is_expected.to have_db_column(:password_updated_at).of_type(:datetime).with_options(null: true) }
     it { should have_db_column(:uid).of_type(:string) }
-    it { should have_db_index(:uid).unique(true) }
   end
 
   describe "when validating" do


### PR DESCRIPTION
This pull request removes the uniq index so that if a user has multiple emails per uid they can still login. 

Migration file included