### PR TITLE
SRCH-1039 SRCH-1040 update DateRangeTopN queries to run on ES 5.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -162,7 +162,6 @@ group :test do
   gem 'vcr', '~> 4.0'
   gem 'webmock', '~> 3.1.1'
   gem 'rspec-activemodel-mocks', '~> 1.0.3'
-  gem 'timecop', '~> 0.9.1'
   gem 'rspec_junit_formatter', '~> 0.3.0'
   gem 'rails-controller-testing', '~> 1.0.4'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -684,7 +684,6 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
-    timecop (0.9.1)
     truncator (0.1.7)
       activesupport
     turbolinks (5.0.1)
@@ -868,7 +867,6 @@ DEPENDENCIES
   test-unit (~> 3.2.7)
   therubyracer (~> 0.12.3)
   thin (~> 1.7)
-  timecop (~> 0.9.1)
   truncator (~> 0.1.7)
   turbolinks (~> 5.0.1)
   tweetstream (~> 2.6.1)

--- a/app/controllers/sites/analytics_controller.rb
+++ b/app/controllers/sites/analytics_controller.rb
@@ -1,6 +1,8 @@
 class Sites::AnalyticsController < Sites::SetupSiteController
   before_action :setup_site_analytics, :setup_date_range
 
+  MAX_RESULTS = 10000
+
   private
 
   def setup_site_analytics

--- a/app/controllers/sites/click_queries_controller.rb
+++ b/app/controllers/sites/click_queries_controller.rb
@@ -1,13 +1,20 @@
+# frozen_string_literal: true
+
 class Sites::ClickQueriesController < Sites::AnalyticsController
   def show
-    @url = request["url"]
+    @url = request['url']
     @top_queries = top_queries
   end
 
   private
 
   def top_queries
-    query = DateRangeTopNFieldQuery.new(@site.name, @start_date, @end_date, 'params.url', @url, {field: 'raw', size: 0})
+    query = DateRangeTopNFieldQuery.new(@site.name,
+                                        @start_date,
+                                        @end_date,
+                                        'params.url',
+                                        @url,
+                                        { field: 'params.query.raw', size: MAX_RESULTS })
     rtu_top_clicks = RtuTopClicks.new(query.body, @current_user.sees_filtered_totals?)
     rtu_top_clicks.top_n
   end

--- a/app/controllers/sites/query_clicks_controller.rb
+++ b/app/controllers/sites/query_clicks_controller.rb
@@ -1,15 +1,21 @@
+# frozen_string_literal: true
+
 class Sites::QueryClicksController < Sites::AnalyticsController
   def show
-    @query = request["query"]
+    @query = request['query']
     @top_urls = top_urls
   end
 
   private
 
   def top_urls
-    query = DateRangeTopNFieldQuery.new(@site.name, @start_date, @end_date, 'raw', @query, { field: 'url', size: 0 })
+    query = DateRangeTopNFieldQuery.new(@site.name,
+                                        @start_date,
+                                        @end_date,
+                                        'params.query.raw',
+                                        @query,
+                                        { field: 'params.url', size: MAX_RESULTS })
     rtu_top_clicks = RtuTopClicks.new(query.body, @current_user.sees_filtered_totals?)
     rtu_top_clicks.top_n
   end
-
 end

--- a/app/controllers/sites/query_referrers_controller.rb
+++ b/app/controllers/sites/query_referrers_controller.rb
@@ -1,15 +1,21 @@
+# frozen_string_literal: true
+
 class Sites::QueryReferrersController < Sites::AnalyticsController
   def show
-    @query = request["query"]
+    @query = request['query']
     @top_urls = top_urls
   end
 
   private
 
   def top_urls
-    query = DateRangeTopNFieldQuery.new(@site.name, @start_date, @end_date, 'raw', @query, { field: 'referrer', size: 0 })
+    query = DateRangeTopNFieldQuery.new(@site.name,
+                                        @start_date,
+                                        @end_date,
+                                        'params.query.raw',
+                                        @query,
+                                        { field: 'referrer', size: MAX_RESULTS })
     rtu_top_referrers = RtuTopQueries.new(query.body, @current_user.sees_filtered_totals?)
     rtu_top_referrers.top_n
   end
-
 end

--- a/app/controllers/sites/referrer_queries_controller.rb
+++ b/app/controllers/sites/referrer_queries_controller.rb
@@ -1,13 +1,20 @@
+# frozen_string_literal: true
+
 class Sites::ReferrerQueriesController < Sites::AnalyticsController
   def show
-    @url = request["url"]
+    @url = request['url']
     @top_queries = top_queries
   end
 
   private
 
   def top_queries
-    query = DateRangeTopNFieldQuery.new(@site.name, @start_date, @end_date, 'referrer', @url, {field: 'raw', size: 0})
+    query = DateRangeTopNFieldQuery.new(@site.name,
+                                        @start_date,
+                                        @end_date,
+                                        'referrer',
+                                        @url,
+                                        { field: 'params.query.raw', size: MAX_RESULTS })
     rtu_top_queries = RtuTopQueries.new(query.body, @current_user.sees_filtered_totals?)
     rtu_top_queries.top_n
   end

--- a/app/models/click_counter.rb
+++ b/app/models/click_counter.rb
@@ -25,7 +25,7 @@ class ClickCounter
                                         Time.current,
                                         'click_domain',
                                         domain,
-                                        field: 'params.url', size: 0)
+                                        { field: 'params.url', size: 100000 })
 
     RtuTopClicks.new(query.body, true).
       top_n_to_percentage(SIGNIFICANT_PERCENTAGE)

--- a/app/models/logstash_queries/date_range_top_n_field_query.rb
+++ b/app/models/logstash_queries/date_range_top_n_field_query.rb
@@ -3,17 +3,18 @@ class DateRangeTopNFieldQuery < DateRangeTopNQuery
 
   def initialize(affiliate_name, start_date, end_date, filter_field, filter_value, agg_options = {})
     super(affiliate_name, start_date, end_date, agg_options)
-    @filters = { 'affiliate' => @affiliate_name, filter_field => filter_value }.compact
+    @filters = { 'params.affiliate' => @affiliate_name,
+                 filter_field => filter_value }.compact
   end
 
   def booleans(json)
     filters.each do |field, value|
-      json.must do
+      json.filter do
         json.child! { json.term { json.set! field, value } }
       end
     end
 
-    json.must do
+    json.filter do
       json.child! { date_range(json, @start_date, @end_date) }
     end
   end

--- a/app/models/logstash_queries/date_range_top_n_missing_query.rb
+++ b/app/models/logstash_queries/date_range_top_n_missing_query.rb
@@ -1,5 +1,6 @@
-class DateRangeTopNMissingQuery < TopNMissingQuery
+# frozen_string_literal: true
 
+class DateRangeTopNMissingQuery < TopNMissingQuery
   def initialize(affiliate_name, start_date, end_date, agg_options = {})
     super(affiliate_name, agg_options)
     @start_date, @end_date = start_date, end_date

--- a/app/models/rtu_monthly_report.rb
+++ b/app/models/rtu_monthly_report.rb
@@ -25,8 +25,7 @@ class RtuMonthlyReport
       query = DateRangeTopNMissingQuery.new(@site.name,
                                             @month_range.begin,
                                             @month_range.end,
-                                            field: 'params.query.raw',
-                                            min_doc_count: 20)
+                                            { field: 'params.query.raw', min_doc_count: 20 })
       rtu_top_queries = RtuTopQueries.new(query.body, @filter_bots)
       rtu_top_queries.top_n
     end

--- a/features/step_definitions/time_travel_steps.rb
+++ b/features/step_definitions/time_travel_steps.rb
@@ -1,3 +1,3 @@
 When /^the (?:date|time) (?:is|becomes) "?(\d{4}-\d{2}-\d{2}(?: \d{1,2}:\d{2})?)"?$/ do |time|
-  Timecop.travel(Time.parse(time))
+  travel_to(Time.parse(time))
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -11,5 +11,5 @@ end
 
 After do |scenario|
   ScenarioStatusTracker.success = false if scenario.failed?
-  Timecop.return
+  travel_back
 end

--- a/spec/controllers/human_sessions_controller_spec.rb
+++ b/spec/controllers/human_sessions_controller_spec.rb
@@ -53,8 +53,8 @@ describe HumanSessionsController do
       let(:challenge_outcome) { true }
 
       before { allow(Digest::SHA256).to receive(:hexdigest).and_return('sha-na-na') }
-      before { Timecop.freeze(Time.gm(1997, 8, 4, 5, 14)) }
-      after { Timecop.return }
+      before { travel_to(Time.gm(1997, 8, 4, 5, 14)) }
+      after { travel_back }
 
       it 'records the "success" captcha activity' do
         expect(subject).to receive(:record_captcha_activity).with('success')

--- a/spec/controllers/sites/click_queries_controller_spec.rb
+++ b/spec/controllers/sites/click_queries_controller_spec.rb
@@ -11,20 +11,33 @@ describe Sites::ClickQueriesController do
       include_context 'approved user logged in to a site'
       let(:top_n) { [['query1', 10], ['query2', 5]] }
       let(:rtu_top_clicks) { double(RtuTopClicks, top_n: top_n) }
+      let(:query_args) do
+        [
+          site.name,
+          Date.parse('2019-11-01'),
+          Date.parse('2019-11-11'),
+          'params.url',
+          'http://www.url.gov',
+          { field: 'params.query.raw', size: 10000 }
+        ]
+      end
+      let(:query) { instance_double(DateRangeTopNFieldQuery, body: '') }
 
       before do
+        travel_to(Time.gm(2019, 11, 11))
+        expect(DateRangeTopNFieldQuery).
+          to receive(:new).with(*query_args).and_return(query)
         allow(RtuTopClicks).to receive(:new).and_return rtu_top_clicks
         get :show,
             params: {
               site_id: site.id,
-              start_date: Date.current,
-              end_date: Date.current,
               url: 'http://www.url.gov'
             }
       end
 
+      after { travel_back }
+
       it { is_expected.to assign_to(:top_queries).with(top_n) }
     end
   end
-
 end

--- a/spec/controllers/sites/query_clicks_controller_spec.rb
+++ b/spec/controllers/sites/query_clicks_controller_spec.rb
@@ -11,17 +11,31 @@ describe Sites::QueryClicksController do
       include_context 'approved user logged in to a site'
       let(:top_n) { [['url1', 10], ['url2', 5]] }
       let(:rtu_top_clicks) { double(RtuTopClicks, top_n: top_n) }
+      let(:query_args) do
+        [
+          site.name,
+          Date.parse('2019-11-01'),
+          Date.parse('2019-11-11'),
+          'params.query.raw',
+          'foo',
+          { field: 'params.url', size: 10000 }
+        ]
+      end
+      let(:query) { instance_double(DateRangeTopNFieldQuery, body: '') }
 
       before do
+        travel_to(Time.gm(2019, 11, 11))
+        expect(DateRangeTopNFieldQuery).
+          to receive(:new).with(*query_args).and_return(query)
         allow(RtuTopClicks).to receive(:new).and_return rtu_top_clicks
         get :show,
             params: {
               site_id: site.id,
-              start_date: Date.current,
-              end_date: Date.current,
               query: 'foo'
             }
       end
+
+      after { travel_back }
 
       it { is_expected.to assign_to(:top_urls).with(top_n) }
     end

--- a/spec/controllers/sites/query_referrers_controller_spec.rb
+++ b/spec/controllers/sites/query_referrers_controller_spec.rb
@@ -11,20 +11,33 @@ describe Sites::QueryReferrersController do
       include_context 'approved user logged in to a site'
       let(:top_n) { [['url1', 10], ['url2', 5]] }
       let(:rtu_top_queries) { double(RtuTopQueries, top_n: top_n) }
+      let(:query_args) do
+        [
+          site.name,
+          Date.parse('2019-11-01'),
+          Date.parse('2019-11-11'),
+          'params.query.raw',
+          'foo',
+          { field: 'referrer', size: 10000 }
+        ]
+      end
+      let(:query) { instance_double(DateRangeTopNFieldQuery, body: "") }
 
       before do
+        travel_to(Time.gm(2019, 11, 11))
+        expect(DateRangeTopNFieldQuery).
+          to receive(:new).with(*query_args).and_return(query)
         allow(RtuTopQueries).to receive(:new).and_return rtu_top_queries
         get :show,
             params: {
               site_id: site.id,
-              start_date: Date.current,
-              end_date: Date.current,
               query: 'foo'
             }
       end
 
+      after { travel_back }
+
       it { is_expected.to assign_to(:top_urls).with(top_n) }
     end
   end
-
 end

--- a/spec/controllers/sites/referrer_queries_controller_spec.rb
+++ b/spec/controllers/sites/referrer_queries_controller_spec.rb
@@ -11,8 +11,22 @@ describe Sites::ReferrerQueriesController do
       include_context 'approved user logged in to a site'
       let(:top_n) { [['query1', 10], ['query2', 5]] }
       let(:rtu_top_queries) { double(RtuTopQueries, top_n: top_n) }
+      let(:query_args) do
+        [
+          site.name,
+          Date.parse('2019-11-01'),
+          Date.parse('2019-11-11'),
+          'referrer',
+          'http://www.url.gov',
+          { field: 'params.query.raw', size: 10000 }
+        ]
+      end
+      let(:query) { instance_double(DateRangeTopNFieldQuery, body: '') }
 
       before do
+        travel_to(Time.gm(2019, 11, 11))
+        expect(DateRangeTopNFieldQuery).
+          to receive(:new).with(*query_args).and_return(query)
         allow(RtuTopQueries).to receive(:new).and_return rtu_top_queries
         get :show,
             params: {
@@ -22,6 +36,8 @@ describe Sites::ReferrerQueriesController do
               url: 'http://www.url.gov'
             }
       end
+
+      after { travel_back }
 
       it { is_expected.to assign_to(:top_queries).with(top_n) }
     end

--- a/spec/jobs/searchgov_domain_indexer_job_spec.rb
+++ b/spec/jobs/searchgov_domain_indexer_job_spec.rb
@@ -27,8 +27,10 @@ describe SearchgovDomainIndexerJob do
 
     context 'when the domain has multiple unfetched urls' do
       let!(:another_searchgov_url) { SearchgovUrl.create(url: 'https://agency.gov/another') }
-      before { Timecop.freeze }
-      after { Timecop.return }
+
+      before { travel_to(Time.now) }
+
+      after { travel_back }
 
       it 'enqueues the next job after the specified delay' do
         expect{ perform }.to have_enqueued_job(SearchgovDomainIndexerJob).

--- a/spec/models/click_counter_spec.rb
+++ b/spec/models/click_counter_spec.rb
@@ -56,9 +56,9 @@ describe ClickCounter do
   describe '#statistically_significant_clicks' do
     subject(:clicks) { counter.send(:statistically_significant_clicks) }
 
-    before { Timecop.freeze }
+    before { travel_to(Time.now) }
 
-    after { Timecop.return }
+    after { travel_back }
 
     it "generates a query for the last month's significant clicks" do
       expect(DateRangeTopNFieldQuery).to receive(:new).
@@ -67,7 +67,7 @@ describe ClickCounter do
              Time.now,
              'click_domain',
              'agency.gov',
-             { field: 'params.url', size: 0 }).
+             { field: 'params.url', size: 100000 }).
         and_call_original
       clicks
     end

--- a/spec/models/document_fetch_logger_spec.rb
+++ b/spec/models/document_fetch_logger_spec.rb
@@ -16,8 +16,8 @@ describe DocumentFetchLogger do
 
   describe '#log' do
     before { allow(Rails.logger).to receive(:info) }
-    before { Timecop.freeze(Time.gm(1997, 8, 4, 5, 14)) }
-    after { Timecop.return }
+    before { travel_to(Time.gm(1997, 8, 4, 5, 14)) }
+    after { travel_back }
 
     context 'when no additional attributes are provided' do
       it 'logs just the domain, time, type, and url' do

--- a/spec/models/logstash_queries/date_range_top_n_field_query_spec.rb
+++ b/spec/models/logstash_queries/date_range_top_n_field_query_spec.rb
@@ -7,27 +7,88 @@ describe DateRangeTopNFieldQuery do
                                 Date.parse('2014-06-29'),
                                 'params.url',
                                 'some_url',
-                                { field: 'params.query.raw', size: 0 })
+                                { field: 'params.query.raw', size: 100 })
+  end
+  let(:expected_body) do
+    {
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "term": {
+                "params.affiliate": "affiliate_name"
+              }
+            },
+            {
+              "term": {
+                "params.url": "some_url"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "gte": "2014-06-28",
+                  "lte": "2014-06-29"
+                }
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "agg": {
+          "terms": {
+            "field": "params.query.raw",
+            "size": 100
+          }
+        }
+      }
+    }.to_json
   end
 
-  # SRCH-1039
-  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"foo"}},{"term":{"params.url":"some_url"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":0}}}}))}
+  it_behaves_like 'a logstash query'
 
   context 'when the affiliate is nil' do
     let(:query) do
       DateRangeTopNFieldQuery.new(nil,
                                   Date.parse("2014-06-28"),
                                   Date.parse("2014-06-29"),
-                                  'some_field',
-                                  'some_value',
-                                  { field: 'raw', size: 0 })
+                                  'params.url',
+                                  'some_url',
+                                  { field: 'params.query.raw', size: 100 })
+    end
+    let(:expected_body) do
+      {
+        "query": {
+          "bool": {
+            "filter": [
+              {
+                "term": {
+                  "params.url": "some_url"
+                }
+              },
+              {
+                "range": {
+                  "@timestamp": {
+                    "gte": "2014-06-28",
+                    "lte": "2014-06-29"
+                  }
+                }
+              }
+            ]
+          }
+        },
+        "aggs": {
+          "agg": {
+            "terms": {
+              "field": "params.query.raw",
+              "size": 100
+            }
+          }
+        }
+      }.to_json
     end
 
-    # SRCH-1039
-    xit 'filters by the field' do
-      expect(body).to eq(
-        %q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"some_field":"some_value"}},{"range":{"@timestamp":{"gte":"2014-06-28","lte":"2014-06-29"}}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":0}}}})
-      )
-    end
+    it_behaves_like 'a logstash query'
   end
 end

--- a/spec/models/logstash_queries/date_range_top_n_missing_query_spec.rb
+++ b/spec/models/logstash_queries/date_range_top_n_missing_query_spec.rb
@@ -1,10 +1,60 @@
 require 'spec_helper'
 
-describe DateRangeTopNMissingQuery, '#body' do
-  let(:query) { DateRangeTopNMissingQuery.new('aff_name', Date.new(2015, 6, 1), Date.new(2015, 6, 30), { field: 'raw', size: 1000 }) }
+describe DateRangeTopNMissingQuery do
+  let(:query) do
+    DateRangeTopNMissingQuery.new('affiliate_name',
+                                  Date.new(2015, 6, 1),
+                                  Date.new(2015, 6, 30),
+                                  { field: 'params.query.raw', size: 1000 })
+  end
+  let(:expected_body) do
+    {
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "term": {
+                "params.affiliate": "affiliate_name"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "gte": "2015-06-01",
+                  "lte": "2015-06-30"
+                }
+              }
+            }
+          ],
+          "must_not": [
+            {
+              "term": {
+                "useragent.device": "Spider"
+              }
+            },
+            {
+              "term": {
+                "params.query.raw": ""
+              }
+            },
+            {
+              "exists": {
+                "field": "modules"
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "agg": {
+          "terms": {
+            "field": "params.query.raw",
+            "size": 1000
+          }
+        }
+      }
+    }.to_json
+  end
 
-  subject(:body) { query.body }
-
-  # SRCH-1040
-  xit { is_expected.to eq(%q({"query":{"filtered":{"filter":{"bool":{"must":[{"term":{"affiliate":"aff_name"}},{"missing":{"field":"modules"}},{"range":{"@timestamp":{"gte":"2015-06-01","lte":"2015-06-30"}}}],"must_not":[{"term":{"useragent.device":"Spider"}},{"term":{"raw":""}}]}}}},"aggs":{"agg":{"terms":{"field":"raw","size":1000}}}}))}
+  it_behaves_like 'a logstash query'
 end

--- a/spec/models/rtu_monthly_report_spec.rb
+++ b/spec/models/rtu_monthly_report_spec.rb
@@ -51,8 +51,19 @@ describe RtuMonthlyReport do
     context 'when top no results queries are available' do
       let(:json_response) { JSON.parse(File.read("#{Rails.root}/spec/fixtures/json/rtu_monthly_report/no_result_queries.json")) }
       let(:no_result_queries) { [['tsunade', 24], ['jiraiya', 22], ['orochimaru', 32]] }
+      let(:query_args) do
+        [
+          site.name,
+          Date.new(2014,5,1),
+          Date.new(2014,5,31),
+          { field: 'params.query.raw', min_doc_count: 20 }
+        ]
+      end
+      let(:query) { instance_double(DateRangeTopNMissingQuery, body: '') }
 
       before do
+        expect(DateRangeTopNMissingQuery).
+          to receive(:new).with(*query_args).and_return(query)
         allow(ES::ELK.client_reader).to receive(:search).
           and_return(available_dates_response, json_response)
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -58,6 +58,7 @@ RSpec.configure do |config|
   config.fixture_path = "#{::Rails.root}/spec/fixtures"
   config.use_transactional_fixtures = true
   config.include Paperclip::Shoulda::Matchers
+  config.include ActiveSupport::Testing::TimeHelpers
   config.infer_spec_type_from_file_location!
   config.expect_with(:rspec) do |c|
     c.syntax = [:expect]


### PR DESCRIPTION
- update DateRangeTopNMissingQuery
- update DateRangeTopNFieldQuery
- replace Timecop with ActiveSupport::Testing::TimeHelpers