### PR TITLE
tweak raw fields

### DIFF
--- a/app/models/logstash_queries/trending_terms_query.rb
+++ b/app/models/logstash_queries/trending_terms_query.rb
@@ -33,7 +33,7 @@ class TrendingTermsQuery
         json.aggs do
           json.clientip_count do
             json.cardinality do
-              json.field 'clientip.raw'
+              json.field 'clientip'
             end
           end
         end

--- a/spec/models/logstash_queries/top_n_query_spec.rb
+++ b/spec/models/logstash_queries/top_n_query_spec.rb
@@ -1,7 +1,9 @@
 require 'spec_helper'
 
 describe TopNQuery, "#body" do
-  let(:query) { TopNQuery.new('affiliate_name', { field: 'raw', size: 1000 }) }
+  let(:query) do
+    TopNQuery.new('affiliate_name', { field: 'params.query.raw', size: 1000 })
+  end
   let(:expected_body) do
     {
       "query": {
@@ -21,7 +23,7 @@ describe TopNQuery, "#body" do
       "aggs": {
         "agg": {
           "terms": {
-            "field": "raw",
+            "field": "params.query.raw",
             "size": 1000
           }
         }

--- a/spec/models/logstash_queries/trending_terms_query_spec.rb
+++ b/spec/models/logstash_queries/trending_terms_query_spec.rb
@@ -86,7 +86,7 @@ describe TrendingTermsQuery do
           "aggs": {
             "clientip_count": {
               "cardinality": {
-                "field": "clientip.raw"
+                "field": "clientip"
               }
             }
           }


### PR DESCRIPTION
This PR tweaks a couple of field names. I realized when testing some queries on production that the logstash template hadn't been applied to the production 5.6 cluster. The field names have been corrected to work with the template mappings.