### PR TITLE
Knollfear/containerization

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,6 +109,7 @@ gem 'jquery-rails', git: 'https://github.com/GSA/jquery-rails', ref: 'c0c56208f5
 gem 'therubyracer', '~> 0.12.3'
 gem 'yui-compressor', '~> 0.12.0'
 gem 'twitter-typeahead-rails', '~> 0.11.1'
+gem 'paper_trail'
 # Why do we have two versions of Font Awesome?
 # One is for general use around the app, in places where
 # web fonts are expected to work...

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -462,6 +462,9 @@ GEM
     oj (3.3.10)
     open_uri_redirections (0.2.1)
     os (0.9.6)
+    paper_trail (10.3.1)
+      activerecord (>= 4.2)
+      request_store (~> 1.1)
     paperclip (5.2.1)
       activemodel (>= 4.2.0)
       activesupport (>= 4.2.0)
@@ -828,6 +831,7 @@ DEPENDENCIES
   newrelic_rpm (~> 5.0.0)
   nokogiri (~> 1.10.4)
   oj (~> 3.3.10)
+  paper_trail
   paperclip (~> 5.2.0)
   poltergeist (~> 1.18.1)
   pry-byebug (~> 3.5)

--- a/README.markdown
+++ b/README.markdown
@@ -52,7 +52,26 @@ If you find that you need to run specs that interact with a remote service, you'
 
 Anything listed in the `secret_keys` entry of that file will automatically be masked by VCR in newly-recorded cassettes.
 
-## Database
+## Dependencies
+To run the test suite successfully ElasticSearch and MYSQL must be running.  
+You can bring up these dependencies manually or with docker.
+
+### Docker
+In lieu of installing and running MYSQL and ElasticSearch locally you can run 
+
+    ```docker-compose -f docker-compose.dependencies.yml```
+
+
+which will start both versions of ElasticSearch and a MYSQL instance.  
+Once the containers are running you will need to seed the database with the following commands
+    
+    $ rake db:setup
+    $ rake db:test:prepare
+    
+The database is not persisted outside of the container so these commands will need to be run every time the containers start.
+The containers do not need to be restarted on any specific cadence, they can stay up basically all the time.
+ [Next Section](#redis)
+### Database
 
 Install MySQL 5.6.x using Homebrew:
 ```
@@ -90,7 +109,7 @@ Create and setup your development and test databases. The database.yml file assu
     $ rake db:setup
     $ rake db:test:prepare
 
-### Troubleshooting your database setup
+#### Troubleshooting your database setup
 
 Problems may arise if you have multiple versions of MySQL installed, or if you have installed MySQL via the OSX installer instead of or in addition to Homebrew. Below are some troubleshooting steps:
 
@@ -116,7 +135,7 @@ $ gem uninstall mysql2
 $ gem install mysql2 -v '0.3.11' --   --with-mysql-lib=$(brew --prefix mysql56)/lib   --with-mysql-dir=$(brew --prefix mysql56)   --with-mysql-config=$(brew --prefix mysql56)/bin/mysql_config   --with-mysql-include=$(brew --prefix mysql56)/include
 ```
 
-## Asset pipeline
+### Asset pipeline
 
 A few tips when working with asset pipeline:
 
@@ -128,7 +147,7 @@ A few tips when working with asset pipeline:
 
         Rails.application.assets['relative_path/to_asset.ext']
 
-## JAVA
+### JAVA
 
 Install Java 8.
 
@@ -136,7 +155,7 @@ Install Java 8.
 
     $ brew cask install java8
     
-## Elasticsearch
+### Elasticsearch
 
 We're using [Elastic](http://www.elasticsearch.org/) v1.7.3 for fulltext search and query analytics.
 
@@ -198,7 +217,7 @@ To facilitate use of this container a makefile has been provided with the follow
      
      
      
-### Indexes
+#### Indexes
 
 You can create the USASearch-related indexes like this:
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
+  has_paper_trail
   APPROVAL_STATUSES = %w[pending_email_verification
                          pending_approval approved
                          not_approved].freeze

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,6 +11,7 @@ development:
   username: root
   encoding: utf8mb4
   collation: utf8mb4_unicode_ci
+  host: <%= ENV['DB_HOST'] || '127.0.0.1' %>
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".

--- a/db/migrate/20191114215421_create_versions.rb
+++ b/db/migrate/20191114215421_create_versions.rb
@@ -1,0 +1,36 @@
+# This migration creates the `versions` table, the only schema PT requires.
+# All other migrations PT provides are optional.
+class CreateVersions < ActiveRecord::Migration[5.0]
+
+  # The largest text column available in all supported RDBMS is
+  # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
+  # so that MySQL will use `longtext` instead of `text`.  Otherwise,
+  # when serializing very large objects, `text` might not be big enough.
+  TEXT_BYTES = 1_073_741_823
+
+  def change
+    create_table :versions, { options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci" } do |t|
+      t.string   :item_type, {:null=>false, :limit=>191}
+      t.integer  :item_id,   null: false, limit: 8
+      t.string   :event,     null: false
+      t.string   :whodunnit
+      t.text     :object, limit: TEXT_BYTES
+
+      # Known issue in MySQL: fractional second precision
+      # -------------------------------------------------
+      #
+      # MySQL timestamp columns do not support fractional seconds unless
+      # defined with "fractional seconds precision". MySQL users should manually
+      # add fractional seconds precision to this migration, specifically, to
+      # the `created_at` column.
+      # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
+      #
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
+      # version of ActiveRecord with support for fractional seconds in MySQL.
+      # (https://github.com/rails/rails/pull/14359)
+      #
+      t.datetime :created_at
+    end
+    add_index :versions, %i(item_type item_id)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1,6 +1,6 @@
--- MySQL dump 10.13  Distrib 5.6.43, for osx10.13 (x86_64)
+-- MySQL dump 10.13  Distrib 5.6.43, for osx10.15 (x86_64)
 --
--- Host: localhost    Database: usasearch_development
+-- Host: 127.0.0.1    Database: usasearch_test
 -- ------------------------------------------------------
 -- Server version	5.6.43
 
@@ -1490,6 +1490,26 @@ CREATE TABLE `users` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
+-- Table structure for table `versions`
+--
+
+DROP TABLE IF EXISTS `versions`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `versions` (
+  `id` int(11) NOT NULL AUTO_INCREMENT,
+  `item_type` varchar(191) NOT NULL,
+  `item_id` bigint(20) NOT NULL,
+  `event` varchar(255) NOT NULL,
+  `whodunnit` varchar(255) DEFAULT NULL,
+  `object` longtext,
+  `created_at` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `index_versions_on_item_type_and_item_id` (`item_type`,`item_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
 -- Table structure for table `watchers`
 --
 
@@ -1571,7 +1591,7 @@ CREATE TABLE `youtube_profiles` (
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
--- Dumping routines for database 'usasearch_development'
+-- Dumping routines for database 'usasearch_test'
 --
 /*!40103 SET TIME_ZONE=@OLD_TIME_ZONE */;
 
@@ -1583,7 +1603,7 @@ CREATE TABLE `youtube_profiles` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2019-09-24 15:49:59
+-- Dump completed on 2019-11-15 11:31:18
 INSERT INTO `schema_migrations` (version) VALUES
 ('20090818003200'),
 ('20090827135344'),
@@ -2309,6 +2329,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20181109212904'),
 ('20181213153332'),
 ('20190205200912'),
-('20190920181828');
+('20190920181828'),
+('20191114215421');
 
 

--- a/docker-compose.dependencies.yml
+++ b/docker-compose.dependencies.yml
@@ -1,0 +1,29 @@
+version: '3.7'
+
+services:
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:5.6.16
+    environment:
+      discovery.type: single-node
+      cluster.name: elasticsearch_56
+      node.name: "es56"
+    ports:
+      - '9256:9200'
+      - '9356:9300'
+  elasticsearch-classic:
+    image: elasticsearch:1.7.3
+    environment:
+      discovery.type: single-node
+      cluster.name: elasticsearch_56
+      node.name: "es56"
+    ports:
+      - '9200:9200'
+      - '9300:9300'
+  mysql-dev:
+    image: mysql:5.6
+    command: mysqld --character-set-server=utf8mb4 --collation-server=utf8mb4_unicode_ci --innodb_large_prefix=on --innodb_file_format=barracuda --innodb_file_per_table=true
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    ports:
+      - "3306:3306"

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -688,4 +688,28 @@ describe User do
       it { is_expected.to eq false }
     end
   end
+  describe 'paper-trail tests' do
+    context 'enabled', versioning: true do
+      let(:user) { User.create!(@valid_affiliate_attributes) }
+      before do
+        user.update!(contact_name: 'Tom Two', password: 'TomTwo222!')
+        user.update!(contact_name: 'Bob Three', password: 'BobThree333!')
+      end
+      it 'is possible to do assertions on previous versions' do
+        expect(user).to have_a_version_with contact_name: 'Tom Two'
+        expect(user.contact_name).to_not eq 'Tom Two'
+      end
+      it 'the current state is not stored in a version' do
+        expect(user).to_not have_a_version_with contact_name: 'Bob Three'
+        expect(user.contact_name).to eq 'Bob Three'
+      end
+      it 'check version count' do
+        expect(user.versions.size).to eq(3)
+      end
+      it 'check updating increases version count' do
+        user.update!(contact_name: 'Jim Four', password: 'JimFour44!')
+        expect(user.versions.size).to eq(4)
+      end
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,7 @@ require 'email_spec'
 require 'authlogic/test_case'
 require 'paperclip/matchers'
 require 'webmock/rspec'
+require 'paper_trail/frameworks/rspec'
 
 include Authlogic::TestCase
 WebMock.disable_net_connect!(allow_localhost: true)


### PR DESCRIPTION
This adds a docker-compose file for the test dependencies.  With this change there will be no need to install ElasticSearch or run a MYSQL db locally.  Instead users can simply bring up the necessary containers with docker-compose.  This should speed up the time it takes for new people to successfully run the tests and have a functional workspace.