### PR TITLE
SRCH-1071 update ElasticLinkPopularityQuery spec

### DIFF
--- a/spec/models/logstash_queries/elastic_link_popularity_query_spec.rb
+++ b/spec/models/logstash_queries/elastic_link_popularity_query_spec.rb
@@ -2,40 +2,35 @@ require 'spec_helper'
 
 describe ElasticLinkPopularityQuery do
   let(:query) { ElasticLinkPopularityQuery.new('https://search.gov', 10) }
-
-  describe '#body' do
-    subject(:body) { query.body }
-
-    let(:expected_body) do
-      {
-        query: {
-          constant_score: {
-            filter: {
-              bool: {
-                must: [
-                  {
-                    terms: {
-                      'params.url': [
-                        'https://search.gov',
-                        'https://search.gov/'
-                      ]
-                    }
-                  },
-                  {
-                    range: {
-                      '@timestamp': {
-                        gt: 'now-10d/d'
-                      }
+  let(:expected_body) do
+    {
+      query: {
+        constant_score: {
+          filter: {
+            bool: {
+              must: [
+                {
+                  terms: {
+                    'params.url': [
+                      'https://search.gov',
+                      'https://search.gov/'
+                    ]
+                  }
+                },
+                {
+                  range: {
+                    '@timestamp': {
+                      gt: 'now-10d/d'
                     }
                   }
-                ]
-              }
+                }
+              ]
             }
           }
         }
-      }.to_json
-    end
-
-    it { is_expected.to eq(expected_body) }
+      }
+    }.to_json
   end
+
+  it_behaves_like 'a logstash query'
 end


### PR DESCRIPTION
This PR updates the ElasticLinkPopularityQuery spec to ensure it does not raise errors in Elasticsearch. No code changes were necessary.