### PR TITLE
KNOLLFEAR/SRCH-988-3 Symbolizing config keys

### DIFF
--- a/lib/es.rb
+++ b/lib/es.rb
@@ -4,7 +4,9 @@ require 'typhoeus/adapters/faraday'
 
 module ES
   INDEX_PREFIX = "#{Rails.env}-usasearch"
-  CLIENT_CONFIG = Rails.application.config_for(:elasticsearch_client).freeze
+  CLIENT_CONFIG = Rails.application.config_for(
+    :elasticsearch_client
+  ).deep_symbolize_keys.freeze
 
   def client_reader
     @client_reader ||= initialize_client(reader_config)

--- a/spec/support/elasticsearch_client_behavior.rb
+++ b/spec/support/elasticsearch_client_behavior.rb
@@ -5,8 +5,7 @@ shared_examples 'an Elasticsearch client' do
       expect(handler).to eq(Faraday::Adapter::Typhoeus)
     end
 
-    # Resolve 5.1 upgrade failures - SRCH-988
-    xit 'uses the specified options' do
+    it 'uses the specified options' do
       options = {
         log: false,
         randomize_hosts: true,


### PR DESCRIPTION
symbolizing config keys so that the tests run correctly.