### PR TITLE
SRCH-1048 update LowQueryCtrWatcher for Elasticsearch 5.6

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -260,13 +260,12 @@ workflows:
             - setup_elasticsearch
             - bundle_install
 
-# Temporarily commenting out until logstash queries are updated
-#      - cucumber:
-#          requires:
-#            - setup_elasticsearch
-#            - bundle_install
-#
-#      - report_coverage:
-#          requires:
-#            - rspec
-#            - cucumber
+      - cucumber:
+          requires:
+            - setup_elasticsearch
+            - bundle_install
+
+      - report_coverage:
+          requires:
+            - rspec
+            - cucumber

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3340,6 +3340,7 @@ Style/LambdaCall:
     - 'app/models/elastic_data/*'
     - 'app/models/custom_index_queries/*'
     - 'app/models/logstash_queries/*'
+    - 'app/models/watcher.rb'
     - 'lib/watcher_dsl.rb'
 
 Style/LineEndConcatenation:
@@ -3365,6 +3366,7 @@ Style/MethodCallWithArgsParentheses:
     - 'app/models/elastic_data/*'
     - 'app/models/custom_index_queries/*'
     - 'app/models/logstash_queries/*'
+    - 'app/models/watcher.rb'
     - 'lib/analytics_dsl.rb'
 
 Style/MethodCallWithoutArgsParentheses:

--- a/app/models/low_query_ctr_watcher.rb
+++ b/app/models/low_query_ctr_watcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LowQueryCtrWatcher < Watcher
   WATCHER_DEFAULTS = { search_click_total: 100, low_ctr_threshold: 15 }
   define_hash_columns_accessors column_name_method: :conditions,
@@ -10,24 +12,31 @@ class LowQueryCtrWatcher < Watcher
     "#{low_ctr_threshold}% CTR on #{number_with_delimiter search_click_total} Queries & Clicks"
   end
 
+  def label
+    'Low Query Click-Through Rate (CTR)'
+  end
+
+  private
+
   def input(json)
-    options = { affiliate_name: affiliate.name, time_window: time_window, min_doc_count: search_click_total.to_i,
+    options = { affiliate_name: affiliate.name,
+                time_window: time_window,
+                min_doc_count: search_click_total.to_i,
                 query_blocklist: query_blocklist }
     low_query_ctr_query_body = WatcherLowCtrQuery.new(options).body
-    input_search_request(json, search_type: :count, types: %w(search click),
-                         indices: watcher_indexes_from_window_size(time_window), body: JSON.parse(low_query_ctr_query_body))
+    input_search_request(json,
+                         types: %w[search click],
+                         indices: watcher_indexes_from_window_size(time_window),
+                         body: JSON.parse(low_query_ctr_query_body).merge(size: 0))
   end
 
   def condition_script
-    "ctx.payload.aggregations && ctx.payload.aggregations.agg.buckets.any({ it.ctr.value < #{low_ctr_threshold}})"
+    "ctx.payload.aggregations.agg.buckets.any(it -> it.ctr.value < #{low_ctr_threshold})"
   end
 
   def transform_script
-    "ctx.payload.aggregations.agg.buckets.findAll({ it.ctr.value < #{low_ctr_threshold}}).collect({ it.key }).join('\",\"')"
+    # rubocop:disable LineLength
+    "ctx.payload.aggregations.agg.buckets.findAll(it -> it.ctr.value < #{low_ctr_threshold}).collect(it -> it.key).join('\",\"')"
+    # rubocop:enable LineLength
   end
-
-  def label
-    "Low Query Click-Through Rate (CTR)"
-  end
-
 end

--- a/app/models/watcher.rb
+++ b/app/models/watcher.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Watcher < ApplicationRecord
   extend HashColumnsAccessible
   include ActionView::Helpers::NumberHelper
@@ -28,6 +30,8 @@ class Watcher < ApplicationRecord
       metadata(json)
     end
   end
+
+  private
 
   def metadata(json)
     json.metadata do

--- a/features/admin_center_watchers.feature
+++ b/features/admin_center_watchers.feature
@@ -3,8 +3,6 @@ Feature: Watchers (aka Analytics Alerts)
   As a site customer
   I want to set up and manage various alerts
 
-  # SRCH-1038
-  @wip
   Scenario: View watchers
     Given the following Affiliates exist:
       | display_name | name       | contact_email   | contact_name |

--- a/spec/fixtures/json/watcher/low_query_ctr_watcher_body.json
+++ b/spec/fixtures/json/watcher/low_query_ctr_watcher_body.json
@@ -7,75 +7,70 @@
   "input": {
     "search": {
       "request": {
-        "search_type": "count",
         "types": [
           "search",
           "click"
         ],
         "indices": [
-          "<human-logstash-{now/d}>",
-          "<human-logstash-{now/d-1d}>",
-          "<human-logstash-{now/d-2d}>",
-          "<human-logstash-{now/d-3d}>",
-          "<human-logstash-{now/d-4d}>",
-          "<human-logstash-{now/d-5d}>",
-          "<human-logstash-{now/d-6d}>",
-          "<human-logstash-{now/d-7d}>",
-          "<human-logstash-{now/d-8d}>"
+          "<human-logstash-{now/d{YYYY.MM.dd}}>",
+          "<human-logstash-{now/d-1d{YYYY.MM.dd}}>",
+          "<human-logstash-{now/d-2d{YYYY.MM.dd}}>",
+          "<human-logstash-{now/d-3d{YYYY.MM.dd}}>",
+          "<human-logstash-{now/d-4d{YYYY.MM.dd}}>",
+          "<human-logstash-{now/d-5d{YYYY.MM.dd}}>",
+          "<human-logstash-{now/d-6d{YYYY.MM.dd}}>",
+          "<human-logstash-{now/d-7d{YYYY.MM.dd}}>",
+          "<human-logstash-{now/d-8d{YYYY.MM.dd}}>"
         ],
         "body": {
           "query": {
-            "filtered": {
-              "filter": {
-                "bool": {
-                  "must": [
-                    {
-                      "term": {
-                        "affiliate": "nps.gov"
-                      }
-                    },
-                    {
-                      "exists": {
-                        "field": "modules"
-                      }
-                    },
-                    {
-                      "range": {
-                        "@timestamp": {
-                          "gte": "{{ctx.trigger.scheduled_time}}||-1w",
-                          "lte": "{{ctx.trigger.scheduled_time}}"
-                        }
-                      }
+            "bool": {
+              "filter": [
+                {
+                  "term": {
+                    "params.affiliate": "nps.gov"
+                  }
+                },
+                {
+                  "exists": {
+                    "field": "modules"
+                  }
+                },
+                {
+                  "range": {
+                    "@timestamp": {
+                      "gte": "{{ctx.trigger.scheduled_time}}||-1w",
+                      "lte": "{{ctx.trigger.scheduled_time}}"
                     }
-                  ],
-                  "must_not": [
-                    {
-                      "term": {
-                        "useragent.device": "Spider"
-                      }
-                    },
-                    {
-                      "term": {
-                        "raw": ""
-                      }
-                    },
-                    {
-                      "term": {
-                        "modules": "QRTD"
-                      }
-                    },
-                    {
-                      "terms": {
-                        "raw": [
-                          "foo",
-                          "bar",
-                          "another one"
-                        ]
-                      }
-                    }
-                  ]
+                  }
                 }
-              }
+              ],
+              "must_not": [
+                {
+                  "term": {
+                    "useragent.device": "Spider"
+                  }
+                },
+                {
+                  "term": {
+                    "params.query.raw": ""
+                  }
+                },
+                {
+                  "term": {
+                    "modules": "QRTD"
+                  }
+                },
+                {
+                  "terms": {
+                    "params.query.raw": [
+                      "foo",
+                      "bar",
+                      "another one"
+                    ]
+                  }
+                }
+              ]
             }
           },
           "aggs": {
@@ -83,29 +78,42 @@
               "terms": {
                 "min_doc_count": 101,
                 "size": 100000,
-                "field": "raw"
+                "field": "params.query.raw"
               },
               "aggs": {
                 "ctr": {
                   "scripted_metric": {
-                    "init_script": "_agg['click'] = _agg['search'] = 0",
-                    "map_script": "_agg[doc['type'].value] += 1",
-                    "reduce_script": "clicks = searches = 0; for (agg in _aggs) {  clicks += agg.click ; searches += agg.search ;}; float ctr = searches == 0 ? 0 : 100 * clicks / searches; ctr"
+                    "init_script": {
+                      "source": "params._agg['click'] = params._agg['search'] = 0"
+                    },
+                    "map_script": {
+                      "source": "params._agg[doc['type'].value] += 1"
+                    },
+                    "reduce_script": {
+                      "source": "int clicks = 0;\nint searches = 0;\nfor (agg in params._aggs){\n  clicks += agg.click ;\n  searches += agg.search\n}\ndouble ctr = searches == 0 ? 0 : 100.0 * clicks / searches; ctr"
+                    }
                   }
                 }
               }
             }
-          }
+          },
+          "size": 0
         }
       }
     }
   },
   "condition": {
-    "script": "ctx.payload.aggregations && ctx.payload.aggregations.agg.buckets.any({ it.ctr.value < 15.5})"
+    "script": {
+      "source": "ctx.payload.aggregations.agg.buckets.any(it -> it.ctr.value < 15.5)",
+      "lang": "painless"
+    }
   },
   "throttle_period": "24h",
   "transform": {
-    "script": "ctx.payload.aggregations.agg.buckets.findAll({ it.ctr.value < 15.5}).collect({ it.key }).join('\",\"')"
+    "script": {
+      "source": "ctx.payload.aggregations.agg.buckets.findAll(it -> it.ctr.value < 15.5).collect(it -> it.key).join('\",\"')",
+      "lang": "painless"
+    }
   },
   "actions": {
     "analytics_alert": {

--- a/spec/models/elastic_sayt_suggestion_spec.rb
+++ b/spec/models/elastic_sayt_suggestion_spec.rb
@@ -115,8 +115,6 @@ describe ElasticSaytSuggestion do
         ElasticSaytSuggestion.commit
       end
 
-      # Temporarily disabling these specs during ES56 upgrade
-      # https://cm-jira.usa.gov/browse/SRCH-838
       it 'ignores exact matches regardless of case' do
         ['the exact match', 'THE EXACT MATCH'].each do |query|
           expect(ElasticSaytSuggestion.search_for(q: query, affiliate_id: affiliate.id, language: affiliate.indexing_locale).total).to be_zero

--- a/spec/models/logstash_queries/watcher_low_ctr_query_spec.rb
+++ b/spec/models/logstash_queries/watcher_low_ctr_query_spec.rb
@@ -1,0 +1,105 @@
+require 'spec_helper'
+
+describe WatcherLowCtrQuery do
+  let(:query_args) do
+    {
+      affiliate_name: 'affiliate_name',
+      time_window: '1w',
+      min_doc_count: 50,
+      query_blocklist: 'foo, bar, baz biz'
+    }
+  end
+  let(:query) { WatcherLowCtrQuery.new(query_args) }
+  let(:reduce_script) do
+    <<~SCRIPT.strip
+      int clicks = 0;
+      int searches = 0;
+      for (agg in params._aggs){
+        clicks += agg.click ;
+        searches += agg.search
+      }
+      double ctr = searches == 0 ? 0 : 100.0 * clicks / searches; ctr
+    SCRIPT
+  end
+  let(:expected_body) do
+    {
+      "query": {
+        "bool": {
+          "filter": [
+            {
+              "term": {
+                "params.affiliate": "affiliate_name"
+              }
+            },
+            {
+              "exists": {
+                "field": "modules"
+              }
+            },
+            {
+              "range": {
+                "@timestamp": {
+                  "gte": "{{ctx.trigger.scheduled_time}}||-1w",
+                  "lte": "{{ctx.trigger.scheduled_time}}"
+                }
+              }
+            }
+          ],
+          "must_not": [
+            {
+              "term": {
+                "useragent.device": "Spider"
+              }
+            },
+            {
+              "term": {
+                "params.query.raw": ""
+              }
+            },
+            {
+              "term": {
+                "modules": "QRTD"
+              }
+            },
+            {
+              "terms": {
+                "params.query.raw": [
+                  "foo",
+                  "bar",
+                  "baz biz"
+                ]
+              }
+            }
+          ]
+        }
+      },
+      "aggs": {
+        "agg": {
+          "terms": {
+            "min_doc_count": 50,
+            "size": 100000,
+            "field": "params.query.raw"
+          },
+          "aggs": {
+            "ctr": {
+              "scripted_metric": {
+                "init_script": {
+                  "source": "params._agg['click'] = params._agg['search'] = 0"
+                },
+                "map_script": {
+                  "source": "params._agg[doc['type'].value] += 1"
+                },
+                "reduce_script": {
+                  "source": reduce_script
+                }
+              }
+            }
+          }
+        }
+      }
+    }.to_json
+  end
+
+  it_behaves_like 'a watcher query'
+end
+

--- a/spec/models/no_results_watcher_spec.rb
+++ b/spec/models/no_results_watcher_spec.rb
@@ -30,5 +30,11 @@ describe NoResultsWatcher do
     end
   end
 
+  describe '#label' do
+    subject(:label) { watcher.label }
+
+    it { is_expected.to eq('No Results') }
+  end
+
   it_behaves_like 'a watcher'
 end

--- a/spec/support/watcher_behavior.rb
+++ b/spec/support/watcher_behavior.rb
@@ -4,6 +4,7 @@ shared_examples_for 'a watcher' do
   end
   let(:delete_watcher) do
     ES::ELK.client_reader.xpack.watcher.delete_watch(id: watcher.id)
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
   end
 
   before do
@@ -13,7 +14,9 @@ shared_examples_for 'a watcher' do
   describe '#body' do
     subject(:body) { watcher.body }
 
-    it { is_expected.to eq(expected_body) }
+    it 'returns a JSON structure representing an Elasticsearch Watcher body' do
+      expect(body).to eq(expected_body)
+    end
   end
 
   describe 'creating a watcher' do


### PR DESCRIPTION
This PR updates the LowQueryCtrWatcher for Elasticsearch 5.6.