### PR TITLE
Knollfear/srch 1092&1093

### DIFF
--- a/app/models/alert.rb
+++ b/app/models/alert.rb
@@ -1,8 +1,8 @@
 class Alert < ApplicationRecord
   belongs_to :affiliate
-  validates :text, presence: true, :unless => "title.blank?"
+  validates :text, presence: true, unless: -> { title.blank? }
   validates :status, presence: true
-  validates :title, presence: true, :unless => "text.blank?"
+  validates :title, presence: true, unless: -> { text.blank? }
   validates_length_of :text, within: (0..255)
   validates_length_of :title, within: (0..75)
 

--- a/app/models/flickr_profile.rb
+++ b/app/models/flickr_profile.rb
@@ -27,7 +27,7 @@ class FlickrProfile < ApplicationRecord
                           if: Proc.new { |fp| fp.affiliate_id? && fp.profile_type? && fp.profile_id? }
 
   after_create :notify_oasis,
-               unless: 'skip_notify_oasis'
+               unless: -> { skip_notify_oasis }
   scope :users, -> { where(profile_type: 'user') }
   scope :groups, -> { where(profile_type: 'group') }
 

--- a/app/models/routed_query_keyword_observer.rb
+++ b/app/models/routed_query_keyword_observer.rb
@@ -8,7 +8,7 @@ class RoutedQueryKeywordObserver < ActiveRecord::Observer
 
   def after_update(routed_query_keyword)
     sayt_suggestion = SaytSuggestion.find_by_affiliate_id_and_phrase_and_is_protected(routed_query_keyword.routed_query.affiliate.id,
-                                                                                      routed_query_keyword.keyword_was,
+                                                                                      routed_query_keyword.attribute_before_last_save('keyword'),
                                                                                       true)
     sayt_suggestion.update_attribute(:phrase, routed_query_keyword.keyword) if sayt_suggestion.present?
   end


### PR DESCRIPTION
Fixing both deprecations for the rails 5.2 upgrade
1092 - DEPRECATION WARNING: Passing string to be evaluated in :if and :unless conditional options is deprecated and will be removed in Rails 5.2 without replacement.

1093 - DEPRECATION WARNING: The behavior of `attribute_was` inside of after callbacks will be changing in the next version of Rails. The new return value will reflect the behavior of calling the method after `save` returned (e.g. the opposite of what it returns now). To maintain the current behavior, use `attribute_before_last_save` instead. 