### PR TITLE
SRCH-1102 validate SiteFeedUrl#rss_url

### DIFF
--- a/app/models/site_feed_url.rb
+++ b/app/models/site_feed_url.rb
@@ -5,6 +5,7 @@ class SiteFeedUrl < ApplicationRecord
   belongs_to :affiliate
   before_validation NormalizeUrl.new(:rss_url)
   validates_presence_of :rss_url
+  validates_url :rss_url
   after_destroy :fast_destroy_indexed_rss_docs
 
   def self.refresh_all

--- a/config/initializers/http_connection.rb
+++ b/config/initializers/http_connection.rb
@@ -1,6 +1,6 @@
 module HttpConnection
   def self.get(url)
-    f = Kernel.open(url, 'Accept-Encoding' => 'None')
+    f = URI.parse(url).open
     begin
       f.read
     ensure

--- a/spec/models/site_feed_url_spec.rb
+++ b/spec/models/site_feed_url_spec.rb
@@ -4,9 +4,14 @@ describe SiteFeedUrl do
   fixtures :affiliates
   let(:site_feed_url) { SiteFeedUrl.create!(affiliate_id: affiliates(:basic_affiliate).id, rss_url: "http://nps.gov/urls.rss", quota: 3) }
 
-  describe "Creating new instance" do
+  describe 'associations' do
     it { is_expected.to belong_to :affiliate }
+  end
+
+  describe 'validations' do
     it { is_expected.to validate_presence_of :rss_url }
+    it { is_expected.to allow_value('http://some.site.gov/url').for(:rss_url) }
+    it { is_expected.not_to allow_value('not a URL').for(:rss_url) }
   end
 
   describe ".delete" do

--- a/spec/models/site_feed_url_spec.rb
+++ b/spec/models/site_feed_url_spec.rb
@@ -12,6 +12,8 @@ describe SiteFeedUrl do
     it { is_expected.to validate_presence_of :rss_url }
     it { is_expected.to allow_value('http://some.site.gov/url').for(:rss_url) }
     it { is_expected.not_to allow_value('not a URL').for(:rss_url) }
+    it { is_expected.not_to allow_value("javascript:alert('test')").for(:rss_url) }
+    it { is_expected.not_to allow_value("| touch test.txt").for(:rss_url) }
   end
 
   describe ".delete" do


### PR DESCRIPTION
- validate that SiteFeedUrl#rss_url is a valid URL
- use `URI.parse(url).open` instead of `Kernel.open`