### PR TITLE
SRCH-1134 display top queries on site dashboard

### DIFF
--- a/app/models/rtu_query_raw_human_array.rb
+++ b/app/models/rtu_query_raw_human_array.rb
@@ -1,10 +1,12 @@
+# frozen_string_literal: true
+
 class RtuQueryRawHumanArray < RtuPopularRawHumanArray
   def query_class
     RtuTopQueries
   end
 
   def aggs_field
-    'raw'
+    'params.query.raw'
   end
 
   def top_queries

--- a/spec/models/rtu_query_raw_human_array_spec.rb
+++ b/spec/models/rtu_query_raw_human_array_spec.rb
@@ -1,14 +1,31 @@
 require 'spec_helper'
 
 describe RtuQueryRawHumanArray do
+  let(:query_raw_human_array) do
+    RtuQueryRawHumanArray.new('usagov', Date.current, Date.current, 5)
+  end
 
   describe ".top_queries" do
+    subject(:top_queries) { query_raw_human_array.top_queries }
+
     context 'when data is available' do
-      let(:query_raw_human_array) { RtuQueryRawHumanArray.new('usagov', Date.current, Date.current, 5) }
+      let(:query_args) do
+        [
+          'usagov',
+          Date.current,
+          Date.current,
+          { field: 'params.query.raw', size: 1_000_000 }
+        ]
+      end
 
       before do
         allow(RtuTopQueries).to receive(:new).with(anything, false).and_return double(RtuTopQueries, top_n: [['query6', 55], ['query5', 54], ['query4', 14]])
         allow(RtuTopQueries).to receive(:new).with(anything, true).and_return double(RtuTopQueries, top_n: [['query6', 53], ['query5', 50]])
+      end
+
+      it 'generates a DateRangeTopNQuery with the expected options' do
+        expect(DateRangeTopNQuery).to receive(:new).with(*query_args).and_call_original
+        top_queries
       end
 
       it 'should return an array of [query, total, human] sorted by desc human' do

--- a/spec/models/rtu_top_n_spec.rb
+++ b/spec/models/rtu_top_n_spec.rb
@@ -1,0 +1,42 @@
+require 'spec_helper'
+
+describe RtuTopN do
+  let(:rtu_top_n) do
+    RtuTopN.new('an ES query body', 'event_type', false, Date.new(2019, 1, 1))
+  end
+
+  describe '#top_n' do
+    subject(:top_n) { rtu_top_n.top_n }
+    let(:query_args) do
+      {
+        index: 'logstash-2019.01.01',
+        type: 'event_type',
+        body: 'an ES query body',
+        size: 10_000
+      }
+    end
+
+    it 'queries Elasticsearch with the expected args' do
+      expect(ES::ELK.client_reader).to receive(:search).
+        with(query_args).and_return({})
+      top_n
+    end
+
+    context 'when the search fails' do
+      before do
+        allow(ES::ELK.client_reader).to receive(:search).
+          and_raise(StandardError, 'search failure')
+      end
+
+      it 'returns an empty array' do
+        expect(top_n).to eq([])
+      end
+
+      it 'logs the error' do
+        expect(Rails.logger).to receive(:error).
+          with(/Error querying top_n event_type data: search failure/)
+        top_n
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR:
- fixes an issue preventing top queries from appearing on the site dashboard
- adds specs for the fix
- adds logging for failed ES searches