### PR TITLE
SRCH-1141 display search module CTRs in super admin

### DIFF
--- a/lib/ctrs.rb
+++ b/lib/ctrs.rb
@@ -1,9 +1,16 @@
+# frozen_string_literal: true
+
 module Ctrs
 
   private
   def ctrs(query_body, historical_days_back = 0)
-    params = { index: indexes_to_date(historical_days_back, true), type: %w(search click), body: query_body,
-               search_type: 'count', ignore_unavailable: true }
+    params = {
+      index: indexes_to_date(historical_days_back, true),
+      type: %w[search click],
+      body: query_body,
+      size: 0,
+      ignore_unavailable: true
+    }
     ES::ELK.client_reader.search(params)["aggregations"]["agg"]["buckets"] rescue nil
   end
 

--- a/spec/models/search_module_ctr_spec.rb
+++ b/spec/models/search_module_ctr_spec.rb
@@ -11,7 +11,9 @@ describe SearchModuleCtr do
       let(:mb_json_response) { JSON.parse(File.read("#{Rails.root}/spec/fixtures/json/rtu_dashboard/module_breakdown.json")) }
 
       before do
-        expect(ES::ELK.client_reader).to receive(:search).with(hash_including(type: %w(search click))).and_return(historical_mb_json_response, mb_json_response)
+        expect(ES::ELK.client_reader).to receive(:search).
+          with(hash_including(type: %w[search click], size: 0)).
+          and_return(historical_mb_json_response, mb_json_response)
       end
 
       it "should return collection of SearchModuleCtrStat instances ordered by decr search+click count" do


### PR DESCRIPTION
This PR fixes a bug that prevented "Search Module CTRs" data from appearing in super admin.