### PR TITLE
SRCH-1143 update LogstashDeduper for Elasticsearch 5.6

### DIFF
--- a/app/models/logstash_deduper.rb
+++ b/app/models/logstash_deduper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class LogstashDeduper
   extend Resque::Plugins::Priority
   extend ResqueJobStats
@@ -8,7 +10,13 @@ class LogstashDeduper
     index_name = "logstash-#{day_str}"
     seen, dupe_ids = Set.new, []
     client = ES::ELK.client_reader
-    result = client.search index: index_name, type: "search", scroll: '5m', size: SCROLL_SIZE, search_type: :scan
+    result = client.search(
+      index: index_name,
+      type: 'search',
+      scroll: '5m',
+      size: SCROLL_SIZE,
+      sort: '_doc'
+    )
     while result = client.scroll(scroll_id: result['_scroll_id'], scroll: '5m') and not result['hits']['hits'].empty?
       result['hits']['hits'].each do |d|
         idx = d['_source'].hash.to_s

--- a/spec/models/logstash_deduper_spec.rb
+++ b/spec/models/logstash_deduper_spec.rb
@@ -1,28 +1,56 @@
 require 'spec_helper'
 
-describe LogstashDeduper, ".perform" do
+describe LogstashDeduper do
 
   it_behaves_like 'a ResqueJobStats job'
 
   describe '.perform' do
-    before do
-      cursor = JSON.parse(File.read("#{Rails.root}/spec/fixtures/json/logstash/scroll_cursor.json"))
-      scroll_1 = JSON.parse(File.read("#{Rails.root}/spec/fixtures/json/logstash/scroll_1.json"))
-      scroll_2 = JSON.parse(File.read("#{Rails.root}/spec/fixtures/json/logstash/scroll_2.json"))
-      scroll_3 = JSON.parse(File.read("#{Rails.root}/spec/fixtures/json/logstash/scroll_3.json"))
-      expect(ES::ELK.client_reader).to receive(:search).with(index: 'logstash-2015.08.26', type: "search", scroll: '5m',
-                                                     size: LogstashDeduper::SCROLL_SIZE, search_type: :scan).and_return cursor
-      expect(ES::ELK.client_reader).to receive(:scroll).with(scroll_id: 'c2NhbjsxOzE3NDcwMjc0OmVRMFNETWNtUnltN0xjd3dWNEFpVUE7MTt0b3RhbF9oaXRzOjE1MzIzMjc7', scroll: '5m').and_return scroll_1, scroll_2, scroll_3
+    context 'when duplicates exist' do
+      let(:search_args) do
+        {
+          index: 'logstash-2015.08.26',
+          type: 'search',
+          scroll: '5m',
+          size: LogstashDeduper::SCROLL_SIZE,
+          sort: '_doc'
+        }
+      end
+      let(:cursor) { JSON.parse(read_fixture_file('/json/logstash/scroll_cursor.json')) }
+      let(:scroll_1) { JSON.parse(read_fixture_file('/json/logstash/scroll_1.json')) }
+      let(:scroll_2) { JSON.parse(read_fixture_file('/json/logstash/scroll_2.json')) }
+      let(:scroll_3) { JSON.parse(read_fixture_file('/json/logstash/scroll_3.json')) }
+      let(:scroll_id) do
+        'c2NhbjsxOzE3NDcwMjc0OmVRMFNETWNtUnltN0xjd3dWNEFpVUE7MTt0b3RhbF9oaXRzOjE1MzIzMjc7'
+      end
+
+      before do
+        allow(ES::ELK.client_reader).to receive(:search).
+          with(search_args).and_return cursor
+        allow(ES::ELK.client_reader).to receive(:scroll).
+          with(scroll_id: scroll_id, scroll: '5m').
+          and_return(scroll_1, scroll_2, scroll_3)
+      end
+
+      it 'deletes the dupes' do
+        expect(ES::ELK.client_reader).to receive(:bulk).
+          with(
+            body: [
+              { delete: { _index: 'logstash-2015.08.26', _type: 'search', _id: 'abcde' } },
+              { delete: { _index: 'logstash-2015.08.26', _type: 'search', _id: 'copy1' } },
+              { delete: { _index: 'logstash-2015.08.26', _type: 'search', _id: 'copy2' } },
+              { delete: { _index: 'logstash-2015.08.26', _type: 'search', _id: 'copy3' } },
+              { delete: { _index: 'logstash-2015.08.26', _type: 'search', _id: 'copy4' } },
+              { delete: { _index: 'logstash-2015.08.26', _type: 'search', _id: 'copy5' } }
+          ]
+        )
+        LogstashDeduper.perform('2015.08.26')
+      end
     end
 
-    it 'deletes the dupes' do
-      expect(ES::ELK.client_reader).to receive(:bulk).with(body: [{ :delete => { :_index => "logstash-2015.08.26", :_type => "search", :_id => "abcde" } },
-                                                          { :delete => { :_index => "logstash-2015.08.26", :_type => "search", :_id => "copy1" } },
-                                                          { :delete => { :_index => "logstash-2015.08.26", :_type => "search", :_id => "copy2" } },
-                                                          { :delete => { :_index => "logstash-2015.08.26", :_type => "search", :_id => "copy3" } },
-                                                          { :delete => { :_index => "logstash-2015.08.26", :_type => "search", :_id => "copy4" } },
-                                                          { :delete => { :_index => "logstash-2015.08.26", :_type => "search", :_id => "copy5" } }])
-      LogstashDeduper.perform('2015.08.26')
+    it 'does not raise an error' do
+      expect {
+        LogstashDeduper.perform(Date.today.strftime('%Y.%m.%d'))
+      }.not_to raise_error
     end
   end
 end


### PR DESCRIPTION
This PR:
- updates the LogstashDeduper to work on ES 5.6
- adds a spec to ensure the deduper does not raise an error