### PR TITLE
SRCH-1165 - Youtube rake tasks should run successfully

### DIFF
--- a/app/models/youtube_profile.rb
+++ b/app/models/youtube_profile.rb
@@ -10,7 +10,7 @@ class YoutubeProfile < ApplicationRecord
 
   after_create :create_video_rss_feed
 
-  scope :active, -> { joins(:affiliates).uniq }
+  scope :active, -> { joins(:affiliates).distinct }
   scope :stale, -> { where('imported_at IS NULL or imported_at <= ?', Time.current - 1.hour).order(:imported_at) }
 
   def url

--- a/spec/fixtures/affiliates.yml
+++ b/spec/fixtures/affiliates.yml
@@ -45,6 +45,7 @@ another_affiliate:
   display_name: Another Gov Site
   name: another.gov
   api_access_key: another_key
+  youtube_profiles: nps
 
 admin_affiliate:
   <<: *DEFAULTS

--- a/spec/fixtures/youtube_profiles.yml
+++ b/spec/fixtures/youtube_profiles.yml
@@ -5,3 +5,7 @@ whitehouse:
 nps:
   channel_id: natlparkservice_channel_id
   title: natlparkservice
+
+no_affiliate:
+  channel_id: noaffiliate_channel_id
+  title: noaffiliate_title

--- a/spec/models/youtube_profile_spec.rb
+++ b/spec/models/youtube_profile_spec.rb
@@ -7,8 +7,28 @@ describe YoutubeProfile do
   it { is_expected.to validate_presence_of :channel_id }
   it { is_expected.to have_one(:rss_feed).dependent :destroy }
   it { is_expected.to have_and_belong_to_many :affiliates }
-  it { is_expected.to validate_uniqueness_of(:channel_id).
-                with_message(/has already been added/) }
+  it do
+    is_expected.to validate_uniqueness_of(:channel_id).
+      with_message(/has already been added/)
+  end
+
+  it do
+    is_expected.to have_many(:youtube_playlists).
+                   dependent(:destroy).
+                   inverse_of(:youtube_profile)
+  end
+
+  describe 'Gets the active YoutubeProfiles' do
+    let (:profiles) { YoutubeProfile.active }
+
+    it 'gets the active youtube profiles' do
+      expect(YoutubeProfile.active.count).to equal(2)
+    end
+
+    it 'is expected to have uniq values' do
+      expect(YoutubeProfile.active.count).to equal(YoutubeProfile.active.distinct.count)
+    end
+  end
 
   describe '#after_create' do
     it 'creates RssFeed and RssFeedUrl' do

--- a/spec/models/youtube_profile_spec.rb
+++ b/spec/models/youtube_profile_spec.rb
@@ -7,15 +7,10 @@ describe YoutubeProfile do
   it { is_expected.to validate_presence_of :channel_id }
   it { is_expected.to have_one(:rss_feed).dependent :destroy }
   it { is_expected.to have_and_belong_to_many :affiliates }
+  
   it do
     is_expected.to validate_uniqueness_of(:channel_id).
       with_message(/has already been added/)
-  end
-
-  it do
-    is_expected.to have_many(:youtube_playlists).
-                   dependent(:destroy).
-                   inverse_of(:youtube_profile)
   end
 
   describe 'Gets the active YoutubeProfiles' do


### PR DESCRIPTION
This pull request removes uniq and places it with distinct as uniq is deprecated in rails 5.0 and was removed in rails 5.1. 

