### PR TITLE
SRCH-1191 - create not_active_for scope that passes time parameter

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,16 @@ class User < ApplicationRecord
                 90.days.ago)
         }
 
+  scope :not_active_for,
+        lambda { |days|
+          where('current_login_at >= ? AND current_login_at <= ? OR
+                (current_login_at IS NULL AND created_at >= ? AND created_at <=? )',
+                days.beginning_of_day,
+                days.end_of_day,
+                days.beginning_of_day,
+                days.end_of_day)
+        }
+
   acts_as_authentic do |c|
     c.login_field = :email
     c.validate_email_field = true

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,7 +39,7 @@ class User < ApplicationRecord
                 90.days.ago)
         }
 
-  scope :not_active_for,
+  scope :not_active_since,
         lambda { |date|
           where('DATE(current_login_at) = ? OR
                 (current_login_at IS NULL AND DATE(created_at) = ?)', date, date)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,13 +40,9 @@ class User < ApplicationRecord
         }
 
   scope :not_active_for,
-        lambda { |days|
-          where('current_login_at >= ? AND current_login_at <= ? OR
-                (current_login_at IS NULL AND created_at >= ? AND created_at <=? )',
-                days.beginning_of_day,
-                days.end_of_day,
-                days.beginning_of_day,
-                days.end_of_day)
+        lambda { |date|
+          where('DATE(current_login_at) = ? OR
+                (current_login_at IS NULL AND DATE(created_at) = ?)', date, date)
         }
 
   acts_as_authentic do |c|

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -114,6 +114,16 @@ new_non_active_user:
   email: new_non_active_user@fixtures.org
   created_at: <%= 3.days.ago.to_s(:db) %>
 
+not_active_76_days:
+  <<: *DEFAULTS
+  email: not_active_for_76_days@fixtures.org
+  current_login_at: <%= 76.days.ago.to_s(:db) %>
+
+never_active_76_days:
+  <<: *DEFAULTS
+  email: never_active_for_76_days@fixtures.org
+  created_at: <%= 76.days.ago.to_s(:db) %>
+
 affiliate_manager_with_pending_contact_information_status:
   <<: *DEFAULTS
   email: affiliate_manager_with_pending_contact_information_status@fixtures.org

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -141,8 +141,8 @@ describe User do
       it { is_expected.not_to include(new_non_active_user) }
     end
 
-    describe '.not_active_for' do
-      subject(:not_active_for) { User.not_active_for(76.days.ago.to_date) }
+    describe '.not_active_since' do
+      subject(:not_active_since) { User.not_active_since(76.days.ago.to_date) }
 
       let(:not_active_76_days_user) { users(:not_active_76_days) }
       let(:never_active_76_days_user) { users(:never_active_76_days) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -142,7 +142,7 @@ describe User do
     end
 
     describe '.not_active_for' do
-      subject(:not_active_for) { User.not_active_for(76.days.ago) }
+      subject(:not_active_for) { User.not_active_for(76.days.ago.to_date) }
 
       let(:not_active_76_days_user) { users(:not_active_76_days) }
       let(:never_active_76_days_user) { users(:never_active_76_days) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -140,6 +140,16 @@ describe User do
       it { is_expected.to include(never_active_user) }
       it { is_expected.not_to include(new_non_active_user) }
     end
+
+    describe '.not_active_for' do
+      subject(:not_active_for) { User.not_active_for(76.days.ago) }
+
+      let(:not_active_76_days_user) { users(:not_active_76_days) }
+      let(:never_active_76_days_user) { users(:never_active_76_days) }
+
+      it { is_expected.to include(not_active_76_days_user) }
+      it { is_expected.to include(never_active_76_days_user) }
+    end
   end
 
   describe '#deliver_password_reset_instructions!' do


### PR DESCRIPTION
This pull request is to create a scope in the User model to collect all users that have been not active for a given number of days. 

For example if you pass the number 76 you can get back all the users that were not active for exactly 76 days. 