### PR TITLE
Release 1.16.9

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,12 @@ class User < ApplicationRecord
                 90.days.ago)
         }
 
+  scope :not_active_since,
+        lambda { |date|
+          where('DATE(current_login_at) = ? OR
+                (current_login_at IS NULL AND DATE(created_at) = ?)', date, date)
+        }
+
   acts_as_authentic do |c|
     c.login_field = :email
     c.validate_email_field = true

--- a/features/step_definitions/web_ext_steps.rb
+++ b/features/step_definitions/web_ext_steps.rb
@@ -126,7 +126,7 @@ end
 Then /^I should see an s3 image "(.*?)"$/ do |image_file_name|
   image_url = page.find(:xpath, '//img')[:src]
   image_url.should =~ /s3\.amazonaws\.com.+#{Regexp.escape(image_file_name)}/
-  lambda { Kernel.open(image_url) }.should_not raise_error
+  lambda { URI.parse(image_url).open }.should_not raise_error
 end
 
 Then /^I should find "(.+)" in (.+)$/ do |text, locator|

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -114,6 +114,16 @@ new_non_active_user:
   email: new_non_active_user@fixtures.org
   created_at: <%= 3.days.ago.to_s(:db) %>
 
+not_active_76_days:
+  <<: *DEFAULTS
+  email: not_active_for_76_days@fixtures.org
+  current_login_at: <%= 76.days.ago.to_s(:db) %>
+
+never_active_76_days:
+  <<: *DEFAULTS
+  email: never_active_for_76_days@fixtures.org
+  created_at: <%= 76.days.ago.to_s(:db) %>
+
 affiliate_manager_with_pending_contact_information_status:
   <<: *DEFAULTS
   email: affiliate_manager_with_pending_contact_information_status@fixtures.org

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -140,6 +140,16 @@ describe User do
       it { is_expected.to include(never_active_user) }
       it { is_expected.not_to include(new_non_active_user) }
     end
+
+    describe '.not_active_since' do
+      subject(:not_active_since) { User.not_active_since(76.days.ago.to_date) }
+
+      let(:not_active_76_days_user) { users(:not_active_76_days) }
+      let(:never_active_76_days_user) { users(:never_active_76_days) }
+
+      it { is_expected.to include(not_active_76_days_user) }
+      it { is_expected.to include(never_active_76_days_user) }
+    end
   end
 
   describe '#deliver_password_reset_instructions!' do


### PR DESCRIPTION
[SRCH-1191] - create not_active_for scope that passes time parameter (#516 …
[external contributor, checked by Martha] - replace Kernel.open which lets data spawn shells with URI.parse to protect against RCE