### PR TITLE
SRCH-1266 - Create first_name last_name column in users table

### DIFF
--- a/db/migrate/20200212183209_add_firstname_lastname_to_users.rb
+++ b/db/migrate/20200212183209_add_firstname_lastname_to_users.rb
@@ -1,0 +1,8 @@
+class AddFirstnameLastnameToUsers < ActiveRecord::Migration[5.2]
+  def change
+    change_table :users, bulk: true do |t|
+      t.string :first_name
+      t.string :last_name
+    end
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1119,6 +1119,8 @@ CREATE TABLE `users` (
   `default_affiliate_id` int(11) DEFAULT NULL,
   `sees_filtered_totals` tinyint(1) NOT NULL DEFAULT '1',
   `uid` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `first_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `last_name` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `index_users_on_email` (`email`),
   UNIQUE KEY `index_users_on_api_key` (`api_key`),
@@ -1923,6 +1925,7 @@ INSERT INTO `schema_migrations` (version) VALUES
 ('20190205200912'),
 ('20190920181828'),
 ('20191113214448'),
-('20200121220041');
+('20200121220041'),
+('20200212183209');
 
 


### PR DESCRIPTION
This pull request is to just add 2 columns to the users table named first_name and last_name
These two columns will eventually replace contact_name column. 

DEPLOYMENT NOTES:
Migration needed on production