### PR TITLE
change it so that the rake task only passes the number of days not the date

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -20,8 +20,8 @@ namespace :usasearch do
     end
 
     desc 'Warns not active users account will be deactivated'
-    task :warn_set_to_not_approved, [:number_of] => [:environment] do |_t, args|
-      date = args.number_of.days.ago
+    task :warn_set_to_not_approved, [:number_of_days] => [:environment] do |_t, args|
+      date = args.number_of_days.to_i.days.ago
       UserApproval.warn_set_to_not_approved(User.
         not_active_since(date.to_date), date.to_date)
     end

--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -20,9 +20,10 @@ namespace :usasearch do
     end
 
     desc 'Warns not active users account will be deactivated'
-    task :warn_set_to_not_approved, [:date] => [:environment] do |_t, args|
+    task :warn_set_to_not_approved, [:number_of] => [:environment] do |_t, args|
+      date = args.number_of.days.ago
       UserApproval.warn_set_to_not_approved(User.
-        not_active_since(args.date.to_date), args.date.to_date)
+        not_active_since(date.to_date), date.to_date)
     end
   end
 end

--- a/spec/lib/tasks/user_spec.rb
+++ b/spec/lib/tasks/user_spec.rb
@@ -104,13 +104,13 @@ describe 'User rake tasks' do
     it 'calls warn_set_to_not_approved' do
       expect(UserApproval).to receive(:warn_set_to_not_approved).
         with(users, 76.days.ago.to_date)
-      @rake[task_name].invoke(76.days.ago.to_date)
+      @rake[task_name].invoke(76)
     end
 
     it 'will not call warn_set_to_not_approved prematurely' do
       expect(UserApproval).not_to receive(:warn_set_to_not_approved).
         with(users, 75.days.ago.to_date)
-      @rake[task_name].invoke(76.days.ago.to_date)
+      @rake[task_name].invoke(76)
     end
   end
 end


### PR DESCRIPTION
This pull request is so that our chef cookbooks would only pass a number rather than figuring out the date 76 days ago or 86 days ago. Instead it will pays the number 76 and the code will interpret that part. 