### PR TITLE
SRCH-1304 - warn only approved users

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -22,7 +22,7 @@ namespace :usasearch do
     desc 'Warns not active users account will be deactivated'
     task :warn_set_to_not_approved, [:number_of_days] => [:environment] do |_t, args|
       date = args.number_of_days.to_i.days.ago
-      UserApproval.warn_set_to_not_approved(User.
+      UserApproval.warn_set_to_not_approved(User.approved.
         not_active_since(date.to_date), date.to_date)
     end
   end

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -125,6 +125,12 @@ not_active_76_days:
   email: not_active_for_76_days@fixtures.org
   current_login_at: <%= 76.days.ago.to_s(:db) %>
 
+not_active_unapproved_76_days:
+  <<: *DEFAULTS
+  email: not_active_unapproved_for_76_days@fixtures.org
+  current_login_at: <%= 76.days.ago.to_s(:db) %>
+  approval_status: not_approved
+
 never_active_76_days:
   <<: *DEFAULTS
   email: never_active_for_76_days@fixtures.org

--- a/spec/lib/tasks/user_spec.rb
+++ b/spec/lib/tasks/user_spec.rb
@@ -90,7 +90,8 @@ describe 'User rake tasks' do
   end
 
   describe 'usasearch:user:warn_set_to_not_approved' do
-    let(:users) { User.not_active_since(76.days.ago.to_date) }
+    let(:users) { User.approved.not_active_since(76.days.ago.to_date) }
+    let(:not_approved_users) { User.not_approved.not_active_since(76.days.ago.to_date)}
     let(:task_name) { "usasearch:user:warn_set_to_not_approved" }
 
     before do
@@ -104,6 +105,12 @@ describe 'User rake tasks' do
     it 'calls warn_set_to_not_approved' do
       expect(UserApproval).to receive(:warn_set_to_not_approved).
         with(users, 76.days.ago.to_date)
+      @rake[task_name].invoke(76)
+    end
+
+    it 'will not call warn_set_to_not_approved on not approved users' do
+      expect(UserApproval).not_to receive(:warn_set_to_not_approved).
+        with(not_approved_users, 76.days.ago.to_date)
       @rake[task_name].invoke(76)
     end
 


### PR DESCRIPTION
This pull request fixes a bug where inactive unapproved users were getting emails. The warning emails should only be sent to approved users that have been inactive. 