### PR TITLE
Release 1.16.20

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ gem 'curb', '~> 0.9.4'
 gem 'haml', '~> 5.0.4'
 gem 'json', '~> 1.8.6'
 gem 'will_paginate', '~> 3.1.6'
-gem 'nokogiri', '~> 1.10.4'
+gem 'nokogiri', '~> 1.10.8'
 gem 'bcrypt-ruby', '~> 3.1.5', :require => 'bcrypt'
 gem 'authlogic', '~> 3.8.0'
 gem 'omniauth_login_dot_gov', git: 'https://github.com/18f/omniauth_login_dot_gov.git',

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -508,7 +508,7 @@ GEM
     pry-rails (0.3.9)
       pry (>= 0.10.4)
     public_suffix (3.1.1)
-    puma (3.12.3)
+    puma (3.12.4)
     raabro (1.1.6)
     rack (2.0.8)
     rack-accept (0.4.5)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -471,7 +471,7 @@ GEM
     net-http-persistent (2.9.4)
     newrelic_rpm (5.0.0.342)
     nio4r (2.5.2)
-    nokogiri (1.10.7)
+    nokogiri (1.10.8)
       mini_portile2 (~> 2.4.0)
     nokogumbo (1.5.0)
       nokogiri
@@ -847,7 +847,7 @@ DEPENDENCIES
   mysql2 (~> 0.4.4)
   net-http-persistent (~> 2.9.3)
   newrelic_rpm (~> 5.0.0)
-  nokogiri (~> 1.10.4)
+  nokogiri (~> 1.10.8)
   oj (~> 3.3.10)
   omniauth-rails_csrf_protection (~> 0.1.2)
   omniauth_login_dot_gov!


### PR DESCRIPTION
[SRCH-1311] - Update Nokogiri security vulnerability for search.gov
[SRCH-1325] - Update puma 3.12.4 security vulnerability for search.gov