### PR TITLE
90 deactivation email clarity 

### DIFF
--- a/app/mailers/emailer.rb
+++ b/app/mailers/emailer.rb
@@ -32,7 +32,8 @@ class Emailer < ApplicationMailer
 
   def account_deactivation_warning(user, date)
     @user = user
-    @deactivation_date = (date - 90.days.ago.to_date).to_i.days.from_now.strftime("%m/%d/%Y")
+    days_remaining = (date - 90.days.ago.to_date).to_i
+    @deactivation_date = days_remaining.days.from_now.strftime("%m/%d/%Y")
     @user_contact_name = get_contact_name(user)
     generic_user_html_email(user, __method__)
   end

--- a/app/mailers/emailer.rb
+++ b/app/mailers/emailer.rb
@@ -33,7 +33,7 @@ class Emailer < ApplicationMailer
   def account_deactivation_warning(user, date)
     @user = user
     days_remaining = (date - 90.days.ago.to_date).to_i
-    @deactivation_date = days_remaining.days.from_now.strftime("%m/%d/%Y")
+    @deactivation_date = days_remaining.days.from_now.strftime('%m/%d/%Y')
     @user_contact_name = get_contact_name(user)
     generic_user_html_email(user, __method__)
   end

--- a/app/mailers/emailer.rb
+++ b/app/mailers/emailer.rb
@@ -32,7 +32,7 @@ class Emailer < ApplicationMailer
 
   def account_deactivation_warning(user, date)
     @user = user
-    @remaining_days = (date - 90.days.ago.to_date).to_i
+    @deactivation_date = (date - 90.days.ago.to_date).to_i.days.from_now.strftime("%m/%d/%Y")
     @user_contact_name = get_contact_name(user)
     generic_user_html_email(user, __method__)
   end

--- a/db/email_templates/account_deactivation_warning.html.erb
+++ b/db/email_templates/account_deactivation_warning.html.erb
@@ -614,9 +614,10 @@
                                           <div style="text-align: left;"><br>
                                             <span style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">
                                               <p>Hello <%= @user_contact_name %>,</p>
-                                              <p> This is a notification to let you know that our system will automatically deactivate your account in the next <%= @remaining_days %> days due to inactivity.</p>
-                                              <p>Please log in today to maintain access to your search.gov account.</p>
-                                              <p>Thank you!</p>
+                                              <p>Search.gov user accounts must be accessed at least once every 90 days to remain active. Please log in before <%= @deactivation_date %>, or your account will automatically be deactivated due to inactivity.
+                                              <p>Your search sites will continue to function normally.</p>
+                                              <p>Please log in today to maintain access to your Search.gov account.</p>
+                                              <p>Thank you</p>
                                             </span>
                                           </div>
                                         </td>

--- a/db/email_templates/account_deactivation_warning.html.erb
+++ b/db/email_templates/account_deactivation_warning.html.erb
@@ -617,7 +617,7 @@
                                               <p>Search.gov user accounts must be accessed at least once every 90 days to remain active. Please log in before <%= @deactivation_date %>, or your account will automatically be deactivated due to inactivity.
                                               <p>Your search sites will continue to function normally.</p>
                                               <p>Please log in today to maintain access to your Search.gov account.</p>
-                                              <p>Thank you</p>
+                                              <p>Thank you!</p>
                                             </span>
                                           </div>
                                         </td>
@@ -742,7 +742,7 @@
                                             <div style="line-height: 20.8px; text-align: center;">
                                               <span style="font-size:12px">
                                                 <span style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">
-                                                  <span style="line-height:20.8px">You received this message because you have an account&nbsp;on&nbsp;
+                                                  <span style="line-height:20.8px">You received this message because you have an account on
                                                     <a href="https://search.gov" target="_blank">Search.gov</a> that is set to expire soon.&nbsp;
                                                   </span><br>
                                                   <br>

--- a/spec/mailers/emailer_spec.rb
+++ b/spec/mailers/emailer_spec.rb
@@ -8,8 +8,9 @@ context do
 
   describe '.account_deactivation_warning' do
     let(:user) { users(:not_active_76_days) }
+    let(:expected_date) { 14.days.from_now.strftime("%m/%d/%Y") }
     let(:message) do
-      'automatically deactivate your account in the next 14 days due to inactivity.'
+      "at least once every 90 days to remain active. Please log in before #{expected_date}"
     end
 
     subject(:account_deactivation_warning) do


### PR DESCRIPTION
In this pull request, the email warning wording is tweaked so costumers understand that even if their account is de-activated their sites will work just fine. 

Deployment notes
Templates need to be reloaded in the rails console on production to reflect the wording change:
EmailTemplate.load_default_templates

