### PR TITLE
Changes made to find user by UID

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,6 +125,9 @@ class User < ApplicationRecord
   end
 
   def self.from_omniauth(auth)
+    user = find_by(uid: auth.uid)
+    return user if user.present?
+
     find_or_create_by(email: auth.info.email).tap do |user|
       user.update(uid: auth.uid)
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -125,8 +125,8 @@ class User < ApplicationRecord
   end
 
   def self.from_omniauth(auth)
-    user = find_by(uid: auth.uid)
-    return user if user.present?
+    users = where(uid: auth.uid)
+    return users.first if users&.count == 1
 
     find_or_create_by(email: auth.info.email).tap do |user|
       user.update(uid: auth.uid)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -126,7 +126,9 @@ class User < ApplicationRecord
 
   def self.from_omniauth(auth)
     users = where(uid: auth.uid)
-    return users.first if users&.count == 1
+
+    return users.first if users&.count == 1 &&
+                          users.first.has_government_affiliated_email?
 
     find_or_create_by(email: auth.info.email).tap do |user|
       user.update(uid: auth.uid)

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -111,6 +111,11 @@ user_with_uid:
   email: user_with_uid@fixtures.org
   uid: 11111
 
+user_with_same_uid:
+  <<: *DEFAULTS
+  email: user_with_same_uid@fixtures.org
+  uid: 11111
+
 user_without_uid:
   <<: *DEFAULTS
   email: user_without_uid@fixtures.org

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -508,5 +508,17 @@ describe User do
         expect(from_omniauth.email).to_not eq 'user_with_same_uid@fixtures.org@fixtures.org'
       end
     end
+
+    context 'when user logs in with non gov email not in search.gov' do
+      let(:auth) { mock_user_auth('my_email@gmail.com', '11111') }
+
+      it "creates the new user with 'my_email@gmail.com'" do
+        expect(from_omniauth.email).to eq 'my_email@gmail.com'
+      end
+
+      it 'sets the user as pending_approval' do
+        expect(from_omniauth.approval_status).to eq 'pending_approval'
+      end
+    end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -481,12 +481,20 @@ describe User do
       end
     end
 
-    context 'when existing user no uid' do
+    context 'when existing user has no uid' do
       let(:auth) { mock_user_auth('user_without_uid@fixtures.org', '22222') }
       let(:user) { users(:user_without_uid) }
 
       it 'sets the uid' do
         expect(from_omniauth.uid).to eq '22222'
+      end
+    end
+
+    context 'when user has uid but logged in with different email' do
+      let(:auth) { mock_user_auth('different_email@gsa.gov', '12345') }
+
+      it 'finds the user by uid which has different email' do
+        expect(from_omniauth.email).to eq 'test@gsa.gov'
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -489,11 +489,23 @@ describe User do
       end
     end
 
-    context 'when user has uid but logged in with different email' do
+    context 'when user has uid, logged in with email that is not in search.gov' do
       let(:auth) { mock_user_auth('different_email@gsa.gov', '12345') }
 
       it 'finds the user by uid which has different email' do
         expect(from_omniauth.email).to eq 'test@gsa.gov'
+      end
+    end
+
+    context 'when user has a uid but 2 different emails in search.gov' do
+      let(:auth) { mock_user_auth('user_with_uid@fixtures.org', '11111') }
+
+      it 'finds the user by email' do
+        expect(from_omniauth.email).to eq 'user_with_uid@fixtures.org'
+      end
+
+      it 'does not pick up the other email with same uid' do
+        expect(from_omniauth.email).to_not eq 'user_with_same_uid@fixtures.org@fixtures.org'
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -483,7 +483,6 @@ describe User do
 
     context 'when existing user has no uid' do
       let(:auth) { mock_user_auth('user_without_uid@fixtures.org', '22222') }
-      let(:user) { users(:user_without_uid) }
 
       it 'sets the uid' do
         expect(from_omniauth.uid).to eq '22222'


### PR DESCRIPTION
This pull request allows a user to be looked up by the unique identifier passed from login.gov. 
Sometimes users are logging in with their other email account from login.gov. Sometimes they changed their email address on login.gov.  Currently the app looks up a user by email. If the user does not exist it creates them.  Additional code is added for the following scenarios:
1) user logs in with different .gov email that does not exist in our system. 
   (uid has 1 user associated in search.gov)
    User account is looked up by uid and that account is pulled up. Email has to be manualy changed by admin for now
2) user logs in with different email that is non gov and does not exists in the system. 
    (uid has 1 user associated in search.gov)
  User account is not looked up by uid because this user is non gov it is looked up by email. If email is not there the new user is created pending approval
3) user logs has multiple gov emails in search.gov and in their login.gov account.
    (uid has 2+ user associated in search.gov)
  User account is looked up by email. If it exists user logs in. If not new account created. 


This will be one of many steps towards updating the app to allow users to be able to change their email address or confirm that they wanted to login with the unsaved email address. 