### PR TITLE
SRCH-1371 update drilldowns to query by `type` field

### DIFF
--- a/app/controllers/sites/click_drilldowns_controller.rb
+++ b/app/controllers/sites/click_drilldowns_controller.rb
@@ -13,8 +13,10 @@ class Sites::ClickDrilldownsController < Sites::SetupSiteController
                                          start_date,
                                          end_date,
                                          'params.url',
-                                         url)
-    request_drilldown = RequestDrilldown.new(@current_user.sees_filtered_totals?, 'click', drilldown_query.body)
+                                         url,
+                                         'click')
+    request_drilldown = RequestDrilldown.new(@current_user.sees_filtered_totals?,
+                                             drilldown_query.body)
     requests = request_drilldown.docs.map { |doc| document_mapping(doc) }
     csv_response(filename, HEADER_FIELDS, requests)
   end

--- a/app/controllers/sites/query_drilldowns_controller.rb
+++ b/app/controllers/sites/query_drilldowns_controller.rb
@@ -12,8 +12,10 @@ class Sites::QueryDrilldownsController < Sites::SetupSiteController
                                          start_date,
                                          end_date,
                                          'params.query.raw',
-                                         query)
-    request_drilldown = RequestDrilldown.new(@current_user.sees_filtered_totals?, 'search', drilldown_query.body)
+                                         query,
+                                         'search')
+    request_drilldown = RequestDrilldown.new(@current_user.sees_filtered_totals?,
+                                             drilldown_query.body)
     requests = request_drilldown.docs.map { |doc| document_mapping(doc) }
     csv_response(filename, HEADER_FIELDS, requests)
   end

--- a/app/models/logstash_queries/drilldown_query.rb
+++ b/app/models/logstash_queries/drilldown_query.rb
@@ -3,8 +3,13 @@
 class DrilldownQuery
   include AnalyticsDSL
 
-  def initialize(affiliate_name, start_date, end_date, field, value)
-    @affiliate_name, @start_date, @end_date, @field, @value = affiliate_name, start_date, end_date, field, value
+  def initialize(affiliate_name, start_date, end_date, field, value, type)
+    @affiliate_name = affiliate_name
+    @start_date = start_date
+    @end_date = end_date
+    @field = field
+    @value = value
+    @type = type
   end
 
   def body
@@ -19,6 +24,7 @@ class DrilldownQuery
       json.child! { json.term { json.set! @field, @value } }
     end
     must_affiliate(json, @affiliate_name)
+    must_type(json, @type)
     must_not_spider(json)
   end
 end

--- a/app/models/request_drilldown.rb
+++ b/app/models/request_drilldown.rb
@@ -4,9 +4,8 @@ class RequestDrilldown
   include LogstashPrefix
   MAX_RESULTS = 10_000
 
-  def initialize(filtered_totals, type, drilldown_query_body)
+  def initialize(filtered_totals, drilldown_query_body)
     @filtered_totals = filtered_totals
-    @type = type
     @drilldown_query_body = drilldown_query_body
   end
 
@@ -14,7 +13,7 @@ class RequestDrilldown
     response = ES::ELK.client_reader.search(query_opts)
     response['hits']['hits']&.map { |hit| hit['_source'] }
   rescue StandardError => error
-    Rails.logger.error("Error extracting #{@type} drilldown hits: #{error}")
+    Rails.logger.error("Error extracting drilldown hits: #{error}")
     []
   end
 
@@ -23,7 +22,6 @@ class RequestDrilldown
   def query_opts
     {
       index: "#{logstash_prefix(@filtered_totals)}*",
-      type: @type,
       body: @drilldown_query_body,
       size: MAX_RESULTS,
       sort: '@timestamp:asc'

--- a/lib/analytics_dsl.rb
+++ b/lib/analytics_dsl.rb
@@ -82,4 +82,10 @@ module AnalyticsDSL
     must_date_range(json, start_date, end_date)
     must_not_spider(json)
   end
+
+  def must_type(json, type)
+    json.filter do
+      json.child! { json.term { json.type type } }
+    end
+  end
 end

--- a/spec/controllers/sites/click_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/click_drilldowns_controller_spec.rb
@@ -17,7 +17,8 @@ describe Sites::ClickDrilldownsController do
           Date.new(2015,02,01),
           Date.new(2015,02,05),
           'params.url',
-          'http://some.gov.url/super_long_so_truncate_at_50/blah.cfm'
+          'http://some.gov.url/super_long_so_truncate_at_50/blah.cfm',
+          'click'
         ]
       end
       let(:query) { instance_double(DrilldownQuery, body: '') }

--- a/spec/controllers/sites/query_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/query_drilldowns_controller_spec.rb
@@ -17,7 +17,8 @@ describe Sites::QueryDrilldownsController do
           Date.new(2015,02,1),
           Date.new(2015,02,5),
           'params.query.raw',
-          'foo bar'
+          'foo bar',
+          'search'
         ]
       end
       let(:query) { instance_double(DrilldownQuery, body: '') }

--- a/spec/models/logstash_queries/drilldown_query_spec.rb
+++ b/spec/models/logstash_queries/drilldown_query_spec.rb
@@ -6,7 +6,8 @@ describe DrilldownQuery do
                        Date.new(2019,11,01),
                        Date.new(2019,11,15),
                        'params.query.raw',
-                       'foo')
+                       'foo',
+                       'click')
   end
   let(:expected_body) do
     {
@@ -29,6 +30,11 @@ describe DrilldownQuery do
             {
               "term": {
                 "params.affiliate": "affiliate_name"
+              }
+            },
+            {
+              "term": {
+                "type": "click"
               }
             }
           ],

--- a/spec/models/request_drilldown_spec.rb
+++ b/spec/models/request_drilldown_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RequestDrilldown do
-  subject(:drilldown) { RequestDrilldown.new(true, 'search', '') }
+  subject(:drilldown) { RequestDrilldown.new(true, '') }
 
   describe '#docs' do
     subject(:docs) { drilldown.docs }
@@ -9,7 +9,6 @@ describe RequestDrilldown do
     it 'queries Elasticsearch with the expected options' do
       expect(ES::ELK.client_reader).to receive(:search).with(
         index: 'human-logstash-*',
-        type: 'search',
         body: '',
         size: 10_000,
         sort: '@timestamp:asc'
@@ -45,7 +44,7 @@ describe RequestDrilldown do
 
       it 'logs the error' do
         expect(Rails.logger).to receive(:error).
-          with('Error extracting search drilldown hits: failure')
+          with('Error extracting drilldown hits: failure')
         docs
       end
     end


### PR DESCRIPTION
This PR updates the analytics queries to search by the `type` field, rather than by document type, which has been deprecated.