### PR TITLE
SRCH-1384 update LinkPopularity query search by `type` field

### DIFF
--- a/app/models/link_popularity.rb
+++ b/app/models/link_popularity.rb
@@ -1,11 +1,16 @@
+# frozen_string_literal: true
+
 class LinkPopularity
   extend LogstashPrefix
+
   def self.popularity_for(url, days_back)
     link_popularity_query = ElasticLinkPopularityQuery.new(url, days_back)
-    total = ES::ELK.client_reader.count(index: indexes_to_date(days_back, true), type: 'click', body: link_popularity_query.body)["count"]
+    total = ES::ELK.client_reader.count(
+      index: indexes_to_date(days_back, true),
+      body: link_popularity_query.body
+    )['count']
     [Math.log10(total), 1.0].max
-  rescue Elasticsearch::Transport::Transport::Errors::NotFound => e
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
     1.0
   end
-
 end

--- a/app/models/logstash_queries/elastic_link_popularity_query.rb
+++ b/app/models/logstash_queries/elastic_link_popularity_query.rb
@@ -15,6 +15,7 @@ class ElasticLinkPopularityQuery
           json.filter do
             json.bool do
               json.must do
+                json.child! { json.term { json.type 'click' } }
                 json.child! do
                   json.terms do
                     json.set! 'params.url', links

--- a/spec/models/link_popularity_spec.rb
+++ b/spec/models/link_popularity_spec.rb
@@ -1,13 +1,39 @@
 require 'spec_helper'
 
-describe LinkPopularity, ".popularity_for(url, days_back)" do
-  context 'when days_back logstash indexes does not exist' do
-    before do
-      allow(ES::ELK.client_reader).to receive(:count).and_raise(Elasticsearch::Transport::Transport::Errors::NotFound)
+describe LinkPopularity do
+  describe '.popularity_for' do
+    subject(:popularity_for) do
+      LinkPopularity.popularity_for('http://www.gov.gov/someurl.html', 7)
     end
 
-    it 'should return a default popularity of 1.0' do
-      expect(LinkPopularity.popularity_for("http://www.gov.gov/someurl.html", 7)).to eq(1.0)
+    context 'when clicks have occurred' do
+      let(:click_count) { 50 }
+
+      before do
+        allow(ES::ELK.client_reader).to receive(:count).
+          and_return( 'count' => click_count )
+      end
+
+      it 'returns the base 10 log of the click count' do
+        expect(popularity_for).to eq(1.6989700043360187)
+      end
+
+      context 'when the base 10 log of the click count is < 1' do
+        let(:click_count) { 5 }
+
+        it { is_expected.to eq(1.0) }
+      end
+    end
+
+    context 'when days_back logstash indexes does not exist' do
+      before do
+        allow(ES::ELK.client_reader).to receive(:count).
+          and_raise(Elasticsearch::Transport::Transport::Errors::NotFound)
+      end
+
+      it 'returns a default popularity of 1.0' do
+        expect(popularity_for).to eq(1.0)
+      end
     end
   end
 end

--- a/spec/models/logstash_queries/elastic_link_popularity_query_spec.rb
+++ b/spec/models/logstash_queries/elastic_link_popularity_query_spec.rb
@@ -4,23 +4,28 @@ describe ElasticLinkPopularityQuery do
   let(:query) { ElasticLinkPopularityQuery.new('https://search.gov', 10) }
   let(:expected_body) do
     {
-      query: {
-        constant_score: {
-          filter: {
-            bool: {
-              must: [
+      "query": {
+        "constant_score": {
+          "filter": {
+            "bool": {
+              "must": [
                 {
-                  terms: {
-                    'params.url': [
-                      'https://search.gov',
-                      'https://search.gov/'
+                  "term": {
+                    "type": "click"
+                  }
+                },
+                {
+                  "terms": {
+                    "params.url": [
+                      "https://search.gov",
+                      "https://search.gov/"
                     ]
                   }
                 },
                 {
-                  range: {
-                    '@timestamp': {
-                      gt: 'now-10d/d'
+                  "range": {
+                    "@timestamp": {
+                      "gt": "now-10d/d"
                     }
                   }
                 }


### PR DESCRIPTION
This PR updates the `ElasticLinkPopularityQuery` to filter by `"type": "click"`, which is necessary after passing the type to the client was deprecated in ES 6.