### PR TITLE
SRCH-1387 - disable email address field for admin center

### DIFF
--- a/app/views/users/_form.haml
+++ b/app/views/users/_form.haml
@@ -10,4 +10,5 @@
 = form.label :organization_name, 'Government agency'
 = form.text_field :organization_name
 = form.label :email, 'Email', class: 'required'
-= form.email_field :email, class: 'required'
+= form.email_field :email, disabled: true, class: 'required'
+%p To update your email address, please contact the Search.gov team at #{ mail_to "search@support.digitalgov.gov",  "search@support.digitalgov.gov"}

--- a/app/views/users/_form.haml
+++ b/app/views/users/_form.haml
@@ -11,4 +11,4 @@
 = form.text_field :organization_name
 = form.label :email, 'Email', class: 'required'
 = form.email_field :email, disabled: true, class: 'required'
-%p To update your email address, please contact the Search.gov team at #{ mail_to "search@support.digitalgov.gov",  "search@support.digitalgov.gov"}
+%p To update your email address, please contact the Search.gov team at #{ mail_to "search@support.digitalgov.gov",  "search@support.digitalgov.gov"}.

--- a/features/users.feature
+++ b/features/users.feature
@@ -71,7 +71,6 @@ Feature: Users
       | First name        |               |
       | Last name         |               |
       | Government agency |               |
-      | Email             | elvis@cia.gov |
     And I press "Save"
     And I should see "Organization name can't be blank"
     And I should see "First name can't be blank"
@@ -80,10 +79,9 @@ Feature: Users
       | First name        | Elvis          |
       | Last name         | Presley        |
       | Government agency | CIA            |
-      | Email             | elvis@cia.gov  |
     And I press "Save"
     Then I should see "Account updated!"
-    And I should see "elvis@cia.gov"
+    And I should see "affiliate_admin@fixtures.org"
 
   # to be updated in SRCH-952 for login.gov
   @wip


### PR DESCRIPTION
This pull request disables the email field email field in  /account/edit.  Adds the following message "To update your email address, please contact the Search.gov team at search@support.digitalgov.gov"
