### PR TITLE
SRCH-1364 update RtuDateRangeQuery for compatibility with ES 6

### DIFF
--- a/app/models/logstash_queries/rtu_date_range_query.rb
+++ b/app/models/logstash_queries/rtu_date_range_query.rb
@@ -3,19 +3,21 @@
 class RtuDateRangeQuery
   include AnalyticsDSL
 
-  def initialize(affiliate_name)
+  def initialize(affiliate_name, type)
     @affiliate_name = affiliate_name
+    @type = type
   end
 
   def body
     Jbuilder.encode do |json|
       filter_booleans(json)
-      stats(json, "@timestamp")
+      stats(json, '@timestamp')
     end
   end
 
   def booleans(json)
-    must_affiliate(json, @affiliate_name)
+    must_affiliate(json, affiliate_name)
+    must_type(json, type)
     must_not_spider(json)
   end
 end

--- a/app/models/rtu_date_range.rb
+++ b/app/models/rtu_date_range.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
 class RtuDateRange
+  attr_reader :affiliate_name, :type
+
   def initialize(affiliate_name, type)
     @affiliate_name = affiliate_name
     @type = type
   end
 
   def available_dates_range
-    rtu_date_range_query = RtuDateRangeQuery.new(@affiliate_name)
+    rtu_date_range_query = RtuDateRangeQuery.new(affiliate_name, type)
     result = search(rtu_date_range_query.body)
     result.present? ? extract_date_range(result) : Date.current..Date.current
   end
@@ -23,7 +25,12 @@ class RtuDateRange
   private
 
   def search(query_body)
-    ES::ELK.client_reader.search(index: "logstash-*", type: @type, body: query_body, size: 0) rescue nil
+    ES::ELK.client_reader.search(
+      index: 'logstash-*',
+      body: query_body,
+      size: 0)
+  rescue
+    nil
   end
 
   def extract_date_range(result)

--- a/spec/models/logstash_queries/rtu_date_range_query_spec.rb
+++ b/spec/models/logstash_queries/rtu_date_range_query_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe RtuDateRangeQuery do
-  let(:query) { RtuDateRangeQuery.new('affiliate_name') }
+  let(:query) { RtuDateRangeQuery.new('affiliate_name', 'search') }
   let(:expected_body) do
     {
       "query": {
@@ -10,6 +10,11 @@ describe RtuDateRangeQuery do
             {
               "term": {
                 "params.affiliate": "affiliate_name"
+              }
+            },
+            {
+              "terms": {
+                "type": ["search"]
               }
             }
           ],

--- a/spec/models/rtu_date_range_spec.rb
+++ b/spec/models/rtu_date_range_spec.rb
@@ -5,10 +5,25 @@ describe RtuDateRange do
 
   shared_context 'when dates are available' do
     let(:json_response) do
-      JSON.parse(File.read("#{Rails.root}/spec/fixtures/json/rtu_dashboard/rtu_date_range.json"))
+      JSON.parse(
+        read_fixture_file('/json/rtu_dashboard/rtu_date_range.json')
+      )
+    end
+    let(:search_opts) do
+      {
+        index: 'logstash-*',
+        body: 'query_body',
+        size: 0
+      }
     end
 
-    before { allow(ES::ELK.client_reader).to receive(:search).and_return json_response }
+    before do
+      allow(RtuDateRangeQuery).to receive(:new).
+        with('some affiliate', 'search or click type here').
+        and_return(instance_double(RtuDateRangeQuery, body: 'query_body'))
+      allow(ES::ELK.client_reader).to receive(:search).
+        with(search_opts).and_return json_response
+    end
   end
 
 


### PR DESCRIPTION
This PR updates the `RtuDateRangeQuery` to filter by `"type"`, which is necessary after passing the type to the client was deprecated in ES 6.