### PR TITLE
SRCH-1401 change sayt_suggestions default limit to 1000

### DIFF
--- a/lib/tasks/sayt_suggestions.rake
+++ b/lib/tasks/sayt_suggestions.rake
@@ -1,15 +1,16 @@
 namespace :usasearch do
   namespace :sayt_suggestions do
 
-    desc "generate top X SAYT suggestions from human Logstash searches for given YYYYMMDD date (defaults to an unlimited number for yesterday)"
+    desc 'generate top X SAYT suggestions from human Logstash searches
+      for given YYYYMMDD date (defaults to 1000 for yesterday)'.squish
     task :compute, [:day, :limit] => [:environment] do |t, args|
       args.with_defaults(:day => Date.yesterday.to_s(:number))
       yyyymmdd = args.day.to_i
-      limit = args.limit.nil? ? 0 : args.limit.to_i
+      limit = args.limit.nil? ? 1000 : args.limit.to_i
       SaytSuggestion.populate_for(yyyymmdd, limit)
     end
 
-    desc "expire SAYT suggestions that have not been updated in X days (defaults to 30)"
+    desc 'expire SAYT suggestions that have not been updated in X days (defaults to 30)'
     task :expire, [:days_back] => [:environment] do |t, args|
       args.with_defaults(:days_back => 30)
       SaytSuggestion.expire(args.days_back.to_i)

--- a/spec/lib/tasks/sayt_suggestions_spec.rb
+++ b/spec/lib/tasks/sayt_suggestions_spec.rb
@@ -21,7 +21,7 @@ describe "SAYT suggestions rake tasks" do
       context "when target day is specified" do
         it "should populate sayt_suggestions for that given day" do
           day = Date.current.to_s(:number).to_i
-          expect(SaytSuggestion).to receive(:populate_for).with(day, 0)
+          expect(SaytSuggestion).to receive(:populate_for).with(day, 1000)
           @rake[task_name].invoke(day)
         end
       end
@@ -29,7 +29,7 @@ describe "SAYT suggestions rake tasks" do
       context "when target day is not specified" do
         it "should default to yesterday" do
           day = Date.yesterday.to_s(:number).to_i
-          expect(SaytSuggestion).to receive(:populate_for).with(day, 0)
+          expect(SaytSuggestion).to receive(:populate_for).with(day, 1000)
           @rake[task_name].invoke
         end
       end
@@ -44,9 +44,9 @@ describe "SAYT suggestions rake tasks" do
       end
 
       context "when limit is not specified" do
-        it "should pass 0 to #populate_for" do
+        it "should pass 1000 to #populate_for" do
           day = Date.current.to_s(:number).to_i
-          expect(SaytSuggestion).to receive(:populate_for).with(day, 0)
+          expect(SaytSuggestion).to receive(:populate_for).with(day, 1000)
           @rake[task_name].invoke(day)
         end
       end


### PR DESCRIPTION
The usage of `size: 0` to request unlimited aggregation buckets was [deprecated in Elasticsearch 5](https://github.com/elastic/elasticsearch/issues/18838). This PR changes the default limit in the sayt_suggestion rake task from 0 (unlimited) to 1000 (which is what we use in production).