### PR TITLE
SRCH-1263 do not pass types to low query CTR watcher

### DIFF
--- a/app/models/low_query_ctr_watcher.rb
+++ b/app/models/low_query_ctr_watcher.rb
@@ -25,7 +25,6 @@ class LowQueryCtrWatcher < Watcher
                 query_blocklist: query_blocklist }
     low_query_ctr_query_body = WatcherLowCtrQuery.new(options).body
     input_search_request(json,
-                         types: %w[search click],
                          indices: watcher_indexes_from_window_size(time_window),
                          body: JSON.parse(low_query_ctr_query_body).merge(size: 0))
   end

--- a/spec/fixtures/json/watcher/low_query_ctr_watcher_body.json
+++ b/spec/fixtures/json/watcher/low_query_ctr_watcher_body.json
@@ -7,10 +7,6 @@
   "input": {
     "search": {
       "request": {
-        "types": [
-          "search",
-          "click"
-        ],
         "indices": [
           "<human-logstash-{now/d{YYYY.MM.dd}}>",
           "<human-logstash-{now/d-1d{YYYY.MM.dd}}>",


### PR DESCRIPTION
This fixes an oversight from the analytics changes; types are now passed in the query body, and should not be passed as a separate parameter to the ES search.