### PR TITLE
API documentation for existing routed queries

### DIFF
--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -85,7 +85,7 @@ module Api
           .joins(:routed_query_keywords)
           .where(routed_query_keywords:{keyword: search_params[:query]})
           .first
-        respond_with({ redirect: routed_query[:url] }, { status: 200 }) unless routed_query.nil?
+        respond_with({ route_to: routed_query[:url] }, { status: 200 }) unless routed_query.nil?
       end
 
       def query_routing_is_enabled?

--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -79,17 +79,13 @@ module Api
       end
 
       def handle_query_routing
-        return unless search_params[:query].present? and query_routing_is_enabled?
+        return unless search_params[:query].present?
         affiliate = @search_options.site
         routed_query = affiliate.routed_queries
           .joins(:routed_query_keywords)
           .where(routed_query_keywords:{keyword: search_params[:query]})
           .first
         respond_with({ route_to: routed_query[:url] }, { status: 200 }) unless routed_query.nil?
-      end
-
-      def query_routing_is_enabled?
-        search_params[:routed] == 'true'
       end
 
       def search_params

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -73,7 +73,7 @@
 
 
 
-  All other parameters are optional: `enable_highlighting`, `limit`, `offset`, `sort_by`.
+  All other parameters are optional: `enable_highlighting`, `limit`, `offset`, `sort_by`, and `routed`.
 
 
 
@@ -136,6 +136,25 @@
       `#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query={YOUR_SEARCH_TERM}&sort_by=date`
 
 
+
+
+
+  * ### routed
+
+
+
+
+      If set to true, then any queries for terms that you have set to be [routed queries](https://search.gov/manual/routed-queries.html) will return a url for your site to redirect to.
+
+      For example, if we set queries for `example` to route to `https://search.gov` then the following API call:
+
+      `#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query=example&routed=true`
+
+      Should return this example response:
+
+      `{"redirect":"https://search.gov"}`
+
+      By default, routed is set to `false`, so you must set up the routed queries in the admin section, and include this parameter in your API calls. Including `routed=true` in all of your queries is okay.
 
 
   ## Response Fields

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -139,24 +139,6 @@
 
 
 
-  * ### routed
-
-
-
-
-      If set to true, then any queries for terms that you have set to be [routed queries](https://search.gov/manual/routed-queries.html) will return a url for your site to redirect to.
-
-      For example, if we set queries for `example` to route to `https://search.gov` then the following API call:
-
-      `#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query=example&routed=true`
-
-      Should return this example response:
-
-      `{"route_to":"https://search.gov"}`
-
-      By default, routed is set to `false`, so you must set up the routed queries in the admin section, and include this parameter in your API calls. Including `routed=true` in all of your queries is okay.
-
-
   ## Response Fields
 
 
@@ -386,6 +368,20 @@
 
       An array of related search terms, which are based on recent, common searches on the your site.
 
+
+
+  ## Routed Queries
+
+
+    If you have [routed queries](https://search.gov/manual/routed-queries.html) set in your Admin page, then any matching query terms will change the API response.
+
+    For example, if you set queries for `example` to route to `https://search.gov` then the following API call:
+
+    `#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query=example`
+
+    Will then return this response:
+
+    `{"route_to":"https://search.gov"}`
 
 
 

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -152,7 +152,7 @@
 
       Should return this example response:
 
-      `{"redirect":"https://search.gov"}`
+      `{"route_to":"https://search.gov"}`
 
       By default, routed is set to `false`, so you must set up the routed queries in the admin section, and include this parameter in your API calls. Including `routed=true` in all of your queries is okay.
 

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -100,7 +100,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -155,7 +155,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -210,7 +210,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -267,7 +267,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -327,7 +327,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -402,7 +402,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -464,7 +464,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -570,7 +570,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'spec_helper'
 
 describe Api::V2::SearchesController do
-  fixtures :affiliates, :document_collections
-  let(:affiliate) { mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en) }
+  fixtures :affiliates, :document_collections, :routed_queries
+  let(:affiliate) { affiliates(:usagov_affiliate) }
   let(:search_params) do
     { affiliate: 'usagov',
       access_key: 'usagov_key',
@@ -63,7 +63,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiAzureSearch, as_json: { foo: 'bar'}, modules: %w(AWEB)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiAzureSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
@@ -85,16 +84,14 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are valid and routed query term is matched' do
       before do
         routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
         get :azure,
-            params: search_params.merge(query: 'foo bar', routed: 'true')
+            params: search_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -120,7 +117,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiAzureCompositeWebSearch, as_json: { foo: 'bar'}, modules: %w(AZCW)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiAzureCompositeWebSearch).to receive(:new).
@@ -141,15 +137,13 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are valid and and routed query term is matched' do
       before do
         routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :azure_web, params: search_params.merge(query: 'foo bar', routed: 'true')
+        get :azure_web, params: search_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -175,7 +169,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiAzureCompositeImageSearch, as_json: { foo: 'bar'}, modules: %w(AZCI)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiAzureCompositeImageSearch).to receive(:new).
@@ -196,15 +189,13 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are valid and and routed query term is matched' do
       before do
         routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :azure_image, params: search_params.merge(query: 'foo bar', routed: 'true')
+        get :azure_image, params: search_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -232,7 +223,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiBingSearch, as_json: { foo: 'bar'}, modules: %w(BWEB)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiBingSearch).to receive(:new).
@@ -253,15 +243,13 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are valid and and routed query term is matched' do
       before do
         routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :bing, params: bing_params.merge(query: 'foo bar', routed: 'true')
+        get :bing, params: bing_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -293,7 +281,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiGssSearch, as_json: { foo: 'bar'}, modules: %w(GWEB)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiGssSearch).to receive(:new).with(hash_including(:query => 'api')).and_return(search)
@@ -313,15 +300,13 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are not valid and and routed query term is matched' do
       before do
         routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :gss, params: gss_params.merge(query: 'foo bar', routed: 'true')
+        get :gss, params: gss_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -388,15 +373,13 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are not valid and and routed query term is matched' do
       before do
         routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :i14y, params: search_params.merge(query: 'foo bar', routed: 'true')
+        get :i14y, params: search_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -430,7 +413,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiVideoSearch, as_json: { foo: 'bar'}, modules: %w(VIDS)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiVideoSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
@@ -450,15 +432,13 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are not valid and and routed query term is matched' do
       before do
         routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :video, params: search_params.merge(query: 'foo bar', routed: 'true')
+        get :video, params: search_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -487,6 +467,7 @@ describe Api::V2::SearchesController do
       before do
         affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en, search_engine: 'BingV6')
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(affiliate).to receive_message_chain(:routed_queries, :joins, :where, :first)
 
         expect(ApiBingDocsSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
         expect(search).to receive(:run)
@@ -512,6 +493,7 @@ describe Api::V2::SearchesController do
       before do
         affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en, search_engine: 'BingV6')
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(affiliate).to receive_message_chain(:routed_queries, :joins, :where, :first)
 
         expect(DocumentCollection).to receive(:find).and_return(document_collection)
 
@@ -538,6 +520,7 @@ describe Api::V2::SearchesController do
       before do
         affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en, search_engine: 'Google')
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(affiliate).to receive_message_chain(:routed_queries, :joins, :where, :first)
 
         expect(ApiGoogleDocsSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
         expect(search).to receive(:run)
@@ -556,15 +539,13 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are valid and and routed query term is matched' do
       before do
         routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
         routed_query.routed_query_keywords.build(keyword: 'foo bar')
         routed_query.save!
 
-        get :docs, params: docs_params.merge(query: 'foo bar', routed: 'true')
+        get :docs, params: docs_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }


### PR DESCRIPTION
This PR adds separate commits for each feature:
- instructions for how to use the routed queries feature in the API
- returns `route_to` instead of `redirect` for the routed query url attribute
- Removes the need for a param for checking for routed queries

This is a Draft PR as I expect we will want to make changes to how this feature works and the instructions, before releasing.