### PR TITLE
SRCH-1406 - Update routed query feature in the API

### DIFF
--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -79,14 +79,18 @@ module Api
       end
 
       def handle_query_routing
-        return if search_params[:query].blank?
-
         affiliate = @search_options.site
         routed_query = affiliate.routed_queries
           .joins(:routed_query_keywords)
           .where(routed_query_keywords:{keyword: search_params[:query]})
           .first
-        respond_with({ route_to: routed_query[:url] }, { status: 200 }) unless routed_query.nil?
+
+        if routed_query
+          RoutedQueryImpressionLogger.log(affiliate,
+                                      @search_options.query, request)
+
+          respond_with({ route_to: routed_query[:url] }, { status: 200 })
+        end
       end
 
       def search_params

--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -85,12 +85,12 @@ module Api
           .where(routed_query_keywords:{keyword: search_params[:query]})
           .first
 
-        if routed_query
-          RoutedQueryImpressionLogger.log(affiliate,
-                                      @search_options.query, request)
+        return unless routed_query
 
-          respond_with({ route_to: routed_query[:url] }, { status: 200 })
-        end
+        RoutedQueryImpressionLogger.log(affiliate,
+                                        @search_options.query, request)
+
+        respond_with({ route_to: routed_query[:url] }, { status: 200 })
       end
 
       def search_params

--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -85,7 +85,7 @@ module Api
           .joins(:routed_query_keywords)
           .where(routed_query_keywords:{keyword: search_params[:query]})
           .first
-        respond_with({ redirect: routed_query[:url] }, { status: 200 }) unless routed_query.nil?
+        respond_with({ route_to: routed_query[:url] }, { status: 200 }) unless routed_query.nil?
       end
 
       def query_routing_is_enabled?

--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -79,17 +79,14 @@ module Api
       end
 
       def handle_query_routing
-        return unless search_params[:query].present? and query_routing_is_enabled?
+        return if search_params[:query].blank?
+
         affiliate = @search_options.site
         routed_query = affiliate.routed_queries
           .joins(:routed_query_keywords)
           .where(routed_query_keywords:{keyword: search_params[:query]})
           .first
         respond_with({ route_to: routed_query[:url] }, { status: 200 }) unless routed_query.nil?
-      end
-
-      def query_routing_is_enabled?
-        search_params[:routed] == 'true'
       end
 
       def search_params

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -73,7 +73,7 @@
 
 
 
-  All other parameters are optional: `enable_highlighting`, `limit`, `offset`, `sort_by`.
+  All other parameters are optional: `enable_highlighting`, `limit`, `offset`, `sort_by`, and `routed`.
 
 
 
@@ -136,6 +136,25 @@
       `#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query={YOUR_SEARCH_TERM}&sort_by=date`
 
 
+
+
+
+  * ### routed
+
+
+
+
+      If set to true, then any queries for terms that you have set to be [routed queries](https://search.gov/manual/routed-queries.html) will return a url for your site to redirect to.
+
+      For example, if we set queries for `example` to route to `https://search.gov` then the following API call:
+
+      `#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query=example&routed=true`
+
+      Should return this example response:
+
+      `{"redirect":"https://search.gov"}`
+
+      By default, routed is set to `false`, so you must set up the routed queries in the admin section, and include this parameter in your API calls. Including `routed=true` in all of your queries is okay.
 
 
   ## Response Fields

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -382,6 +382,31 @@
 
     `{"route_to":"https://search.gov"}`
 
+    With this response you can redirect your users to the url. Here is an example with javascript:
+
+    ```javascript
+    var request = new XMLHttpRequest();
+    var apiUrl = '#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query=example'
+
+    request.open('GET', apiUrl, true);
+
+    request.onload = function() {
+        if (this.status >= 200 && this.status < 400) {
+            // Success!
+            var data = JSON.parse( this.response );
+            window.location.replace( data.route_to );
+        } else {
+             // We reached our target server, but it returned an error
+        }
+    };
+
+    request.onerror = function() {
+        // There was a connection error of some sort
+    };
+
+    request.send();
+    ```
+
 
   ## I14y API
 

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -396,7 +396,7 @@
             var data = JSON.parse( this.response );
             window.location.replace( data.route_to );
         } else {
-             // We reached our target server, but it returned an error
+            // We reached our target server, but it returned an error
         }
     };
 

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -1,4 +1,6 @@
 :markdown
+  <!-- Reminder to update https://open.gsa.gov/api/searchgov-results/ with any changes here. -->
+
   This API exposes all relevant results “modules” in a single JSON call, including:
 
 

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -73,7 +73,7 @@
 
 
 
-  All other parameters are optional: `enable_highlighting`, `limit`, `offset`, `sort_by`, and `routed`.
+  All other parameters are optional: `enable_highlighting`, `limit`, `offset`, `sort_by`.
 
 
 
@@ -136,25 +136,6 @@
       `#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query={YOUR_SEARCH_TERM}&sort_by=date`
 
 
-
-
-
-  * ### routed
-
-
-
-
-      If set to true, then any queries for terms that you have set to be [routed queries](https://search.gov/manual/routed-queries.html) will return a url for your site to redirect to.
-
-      For example, if we set queries for `example` to route to `https://search.gov` then the following API call:
-
-      `#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query=example&routed=true`
-
-      Should return this example response:
-
-      `{"route_to":"https://search.gov"}`
-
-      By default, routed is set to `false`, so you must set up the routed queries in the admin section, and include this parameter in your API calls. Including `routed=true` in all of your queries is okay.
 
 
   ## Response Fields
@@ -387,6 +368,19 @@
       An array of related search terms, which are based on recent, common searches on the your site.
 
 
+
+  ## Routed Queries
+
+
+    If you have [routed queries](https://search.gov/manual/routed-queries.html) set in your Admin page, then any matching query terms will change the API response.
+
+    For example, if you set queries for `example` to route to `https://search.gov` then the following API call:
+
+    `#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query=example`
+
+    Will then return this response:
+
+    `{"route_to":"https://search.gov"}`
 
 
   ## I14y API

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -152,7 +152,7 @@
 
       Should return this example response:
 
-      `{"redirect":"https://search.gov"}`
+      `{"route_to":"https://search.gov"}`
 
       By default, routed is set to `false`, so you must set up the routed queries in the admin section, and include this parameter in your API calls. Including `routed=true` in all of your queries is okay.
 

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -100,7 +100,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -155,7 +155,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -210,7 +210,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -267,7 +267,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -327,7 +327,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -402,7 +402,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -464,7 +464,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end
@@ -570,7 +570,7 @@ describe Api::V2::SearchesController do
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['redirect']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
       end
     end
   end

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -27,9 +27,18 @@ describe Api::V2::SearchesController do
     }
   end
   let(:routed_query_setup) do
-    routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
+    routed_query = affiliate.routed_queries.build(url: 'http://www.gov.gov/foo.html',
+                                                  description: 'testing')
     routed_query.routed_query_keywords.build(keyword: 'foo bar')
     routed_query.save!
+
+    # Routed queries pass a mocked search object
+    # with the QRTD module
+    # to the Search Impression logger.
+    long_class_name = RoutedQueryImpressionLogger::QueryRoutedSearch
+    mock_search = instance_double(long_class_name, modules: ['QRTD'])
+    allow(long_class_name).to receive(:new).with(['QRTD'], {}).and_return(mock_search)
+    expect(SearchImpression).to receive(:log).with(mock_search, any_args)
   end
 
   describe '#blended' do
@@ -140,7 +149,7 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and and routed query term is matched' do
+    context 'when the search options are valid and routed query term is matched' do
       before do
         routed_query_setup
 
@@ -190,7 +199,7 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and and routed query term is matched' do
+    context 'when the search options are valid and routed query term is matched' do
       before do
         routed_query_setup
 
@@ -242,7 +251,7 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and and routed query term is matched' do
+    context 'when the search options are valid and routed query term is matched' do
       before do
         routed_query_setup
 
@@ -297,7 +306,7 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and and routed query term is matched' do
+    context 'when the search options are not valid and routed query term is matched' do
       before do
         routed_query_setup
 
@@ -368,7 +377,7 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and and routed query term is matched' do
+    context 'when the search options are not valid and routed query term is matched' do
       before do
         routed_query_setup
 
@@ -425,7 +434,7 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and and routed query term is matched' do
+    context 'when the search options are not valid and routed query term is matched' do
       before do
         routed_query_setup
 
@@ -525,7 +534,7 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and and routed query term is matched' do
+    context 'when the search options are valid and routed query term is matched' do
       before do
         routed_query_setup
 

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -25,20 +25,6 @@ describe Api::V2::SearchesController do
       filter: '2'
     }
   end
-  let(:routed_query_setup) do
-    routed_query = affiliate.routed_queries.build(url: 'http://www.gov.gov/foo.html',
-                                                  description: 'testing')
-    routed_query.routed_query_keywords.build(keyword: 'foo bar')
-    routed_query.save!
-
-    # Routed queries pass a mocked search object
-    # with the QRTD module
-    # to the Search Impression logger.
-    long_class_name = RoutedQueryImpressionLogger::QueryRoutedSearch
-    mock_search = instance_double(long_class_name, modules: ['QRTD'])
-    allow(long_class_name).to receive(:new).with(['QRTD'], {}).and_return(mock_search)
-    expect(SearchImpression).to receive(:log).with(mock_search, any_args)
-  end
 
   describe '#blended' do
     before do
@@ -97,7 +83,8 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        routed_query_setup
+        expect(RoutedQueryImpressionLogger).to receive(:log).
+          with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :azure, params: search_params.merge(query: 'moar unclaimed money')
       end
@@ -147,7 +134,9 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        routed_query_setup
+        expect(RoutedQueryImpressionLogger).to receive(:log).
+          with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
+
 
         get :azure_web, params: search_params.merge(query: 'moar unclaimed money')
       end
@@ -197,7 +186,8 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        routed_query_setup
+        expect(RoutedQueryImpressionLogger).to receive(:log).
+          with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :azure_image, params: search_params.merge(query: 'moar unclaimed money')
       end
@@ -249,7 +239,8 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        routed_query_setup
+        expect(RoutedQueryImpressionLogger).to receive(:log).
+          with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :bing, params: bing_params.merge(query: 'moar unclaimed money')
       end
@@ -304,7 +295,8 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        routed_query_setup
+        expect(RoutedQueryImpressionLogger).to receive(:log).
+          with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :gss, params: gss_params.merge(query: 'moar unclaimed money')
       end
@@ -375,7 +367,8 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        routed_query_setup
+        expect(RoutedQueryImpressionLogger).to receive(:log).
+          with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :i14y, params: search_params.merge(query: 'moar unclaimed money')
       end
@@ -432,7 +425,8 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        routed_query_setup
+        expect(RoutedQueryImpressionLogger).to receive(:log).
+          with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :video, params: search_params.merge(query: 'moar unclaimed money')
       end
@@ -534,7 +528,8 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        routed_query_setup
+        expect(RoutedQueryImpressionLogger).to receive(:log).
+          with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :docs, params: docs_params.merge(query: 'moar unclaimed money')
       end

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 
 describe Api::V2::SearchesController do
   fixtures :affiliates, :document_collections
-  let(:affiliate) { mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en) }
+  let(:affiliate) { affiliates(:usagov_affiliate) }
   let(:search_params) do
     { affiliate: 'usagov',
       access_key: 'usagov_key',
@@ -25,6 +25,11 @@ describe Api::V2::SearchesController do
       file_type: 'pdf',
       filter: '2'
     }
+  end
+  let(:routed_query_setup) do
+    routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
+    routed_query.routed_query_keywords.build(keyword: 'foo bar')
+    routed_query.save!
   end
 
   describe '#blended' do
@@ -63,7 +68,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiAzureSearch, as_json: { foo: 'bar'}, modules: %w(AWEB)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiAzureSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
@@ -85,16 +89,12 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are valid and routed query term is matched' do
       before do
-        routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
-        routed_query.routed_query_keywords.build(keyword: 'foo bar')
-        routed_query.save!
+        routed_query_setup
 
         get :azure,
-            params: search_params.merge(query: 'foo bar', routed: 'true')
+            params: search_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -120,7 +120,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiAzureCompositeWebSearch, as_json: { foo: 'bar'}, modules: %w(AZCW)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiAzureCompositeWebSearch).to receive(:new).
@@ -141,15 +140,11 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are valid and and routed query term is matched' do
       before do
-        routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
-        routed_query.routed_query_keywords.build(keyword: 'foo bar')
-        routed_query.save!
+        routed_query_setup
 
-        get :azure_web, params: search_params.merge(query: 'foo bar', routed: 'true')
+        get :azure_web, params: search_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -175,7 +170,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiAzureCompositeImageSearch, as_json: { foo: 'bar'}, modules: %w(AZCI)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiAzureCompositeImageSearch).to receive(:new).
@@ -196,15 +190,11 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are valid and and routed query term is matched' do
       before do
-        routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
-        routed_query.routed_query_keywords.build(keyword: 'foo bar')
-        routed_query.save!
+        routed_query_setup
 
-        get :azure_image, params: search_params.merge(query: 'foo bar', routed: 'true')
+        get :azure_image, params: search_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -232,7 +222,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiBingSearch, as_json: { foo: 'bar'}, modules: %w(BWEB)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiBingSearch).to receive(:new).
@@ -253,15 +242,11 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are valid and and routed query term is matched' do
       before do
-        routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
-        routed_query.routed_query_keywords.build(keyword: 'foo bar')
-        routed_query.save!
+        routed_query_setup
 
-        get :bing, params: bing_params.merge(query: 'foo bar', routed: 'true')
+        get :bing, params: bing_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -293,7 +278,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiGssSearch, as_json: { foo: 'bar'}, modules: %w(GWEB)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiGssSearch).to receive(:new).with(hash_including(:query => 'api')).and_return(search)
@@ -313,15 +297,11 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are not valid and and routed query term is matched' do
       before do
-        routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
-        routed_query.routed_query_keywords.build(keyword: 'foo bar')
-        routed_query.save!
+        routed_query_setup
 
-        get :gss, params: gss_params.merge(query: 'foo bar', routed: 'true')
+        get :gss, params: gss_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -388,15 +368,11 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are not valid and and routed query term is matched' do
       before do
-        routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
-        routed_query.routed_query_keywords.build(keyword: 'foo bar')
-        routed_query.save!
+        routed_query_setup
 
-        get :i14y, params: search_params.merge(query: 'foo bar', routed: 'true')
+        get :i14y, params: search_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -430,7 +406,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiVideoSearch, as_json: { foo: 'bar'}, modules: %w(VIDS)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en)
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiVideoSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
@@ -450,15 +425,11 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are not valid and and routed query term is matched' do
       before do
-        routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
-        routed_query.routed_query_keywords.build(keyword: 'foo bar')
-        routed_query.save!
+        routed_query_setup
 
-        get :video, params: search_params.merge(query: 'foo bar', routed: 'true')
+        get :video, params: search_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }
@@ -485,7 +456,6 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiBingDocsSearch, as_json: { foo: 'bar'}, modules: %w(BWEB)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en, search_engine: 'BingV6')
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(ApiBingDocsSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
@@ -510,7 +480,6 @@ describe Api::V2::SearchesController do
       let!(:document_collection) { double(DocumentCollection, too_deep_for_bing?: true) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en, search_engine: 'BingV6')
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
 
         expect(DocumentCollection).to receive(:find).and_return(document_collection)
@@ -536,8 +505,8 @@ describe Api::V2::SearchesController do
       let!(:search) { double(ApiGoogleDocsSearch, as_json: { foo: 'bar'}, modules: %w(GWEB)) }
 
       before do
-        affiliate = mock_model(Affiliate, api_access_key: 'usagov_key', locale: :en, search_engine: 'Google')
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(affiliate).to receive(:search_engine).and_return("Google")
 
         expect(ApiGoogleDocsSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
         expect(search).to receive(:run)
@@ -556,15 +525,11 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and the routed flag is enabled' do
-      let(:affiliate) { affiliates(:usagov_affiliate) }
-
+    context 'when the search options are valid and and routed query term is matched' do
       before do
-        routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
-        routed_query.routed_query_keywords.build(keyword: 'foo bar')
-        routed_query.save!
+        routed_query_setup
 
-        get :docs, params: docs_params.merge(query: 'foo bar', routed: 'true')
+        get :docs, params: docs_params.merge(query: 'foo bar')
       end
 
       it { is_expected.to respond_with :success }

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -1,11 +1,10 @@
 require 'spec_helper'
 
 describe Api::V2::SearchesController do
-  fixtures :affiliates, :document_collections
-  let(:affiliate) { affiliates(:usagov_affiliate) }
+  let(:affiliate) { affiliates(:basic_affiliate) }
   let(:search_params) do
-    { affiliate: 'usagov',
-      access_key: 'usagov_key',
+    { affiliate: 'nps.gov',
+      access_key: 'basic_key',
       format: 'json',
       api_key: 'myawesomekey',
       query: 'api',
@@ -86,9 +85,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :azure,
-            params: search_params.
-              merge(access_key: 'usagov_key')
+        get :azure, params: search_params
       end
 
       it { is_expected.to respond_with :success }
@@ -98,18 +95,17 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and routed query term is matched' do
+    context 'when a routed query term is matched' do
       before do
         routed_query_setup
 
-        get :azure,
-            params: search_params.merge(query: 'foo bar')
+        get :azure, params: search_params.merge(query: 'moar unclaimed money')
       end
 
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('https://www.usa.gov/unclaimed_money')
       end
     end
   end
@@ -139,7 +135,7 @@ describe Api::V2::SearchesController do
                                                    hash_including('query'),
                                                    be_a_kind_of(ActionDispatch::Request))
 
-        get :azure_web, params: search_params.merge(access_key: 'usagov_key')
+        get :azure_web, params: search_params
       end
 
       it { is_expected.to respond_with :success }
@@ -149,17 +145,17 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and routed query term is matched' do
+    context 'when a routed query term is matched' do
       before do
         routed_query_setup
 
-        get :azure_web, params: search_params.merge(query: 'foo bar')
+        get :azure_web, params: search_params.merge(query: 'moar unclaimed money')
       end
 
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('https://www.usa.gov/unclaimed_money')
       end
     end
   end
@@ -199,17 +195,17 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and routed query term is matched' do
+    context 'when a routed query term is matched' do
       before do
         routed_query_setup
 
-        get :azure_image, params: search_params.merge(query: 'foo bar')
+        get :azure_image, params: search_params.merge(query: 'moar unclaimed money')
       end
 
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('https://www.usa.gov/unclaimed_money')
       end
     end
   end
@@ -251,17 +247,17 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and routed query term is matched' do
+    context 'when a routed query term is matched' do
       before do
         routed_query_setup
 
-        get :bing, params: bing_params.merge(query: 'foo bar')
+        get :bing, params: bing_params.merge(query: 'moar unclaimed money')
       end
 
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('https://www.usa.gov/unclaimed_money')
       end
     end
   end
@@ -306,17 +302,17 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and routed query term is matched' do
+    context 'when a routed query term is matched' do
       before do
         routed_query_setup
 
-        get :gss, params: gss_params.merge(query: 'foo bar')
+        get :gss, params: gss_params.merge(query: 'moar unclaimed money')
       end
 
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('https://www.usa.gov/unclaimed_money')
       end
     end
   end
@@ -326,7 +322,7 @@ describe Api::V2::SearchesController do
       before do
         get :i14y,
             params: {
-              affiliate: 'usagov',
+              affiliate: 'nps.gov',
               format: 'json',
               query: 'api'
             }
@@ -360,7 +356,7 @@ describe Api::V2::SearchesController do
 
       it 'passes the correct options to its ApiI4ySearch object' do
         expect(assigns(:search_options).attributes).to include({
-          access_key: 'usagov_key',
+          access_key: 'basic_key',
           affiliate: affiliate,
           enable_highlighting: true,
           file_type: 'pdf',
@@ -377,17 +373,17 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and routed query term is matched' do
+    context 'when a routed query term is matched' do
       before do
         routed_query_setup
 
-        get :i14y, params: search_params.merge(query: 'foo bar')
+        get :i14y, params: search_params.merge(query: 'moar unclaimed money')
       end
 
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('https://www.usa.gov/unclaimed_money')
       end
     end
   end
@@ -397,7 +393,7 @@ describe Api::V2::SearchesController do
       before do
         get :video,
             params: {
-              affiliate: 'usagov',
+              affiliate: 'nps.gov',
               format: 'json',
               query: 'api'
             }
@@ -434,17 +430,17 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are not valid and routed query term is matched' do
+    context 'when a routed query term is matched' do
       before do
         routed_query_setup
 
-        get :video, params: search_params.merge(query: 'foo bar')
+        get :video, params: search_params.merge(query: 'moar unclaimed money')
       end
 
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('https://www.usa.gov/unclaimed_money')
       end
     end
   end
@@ -466,6 +462,7 @@ describe Api::V2::SearchesController do
 
       before do
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(affiliate).to receive(:search_engine).and_return("BingV6")
 
         expect(ApiBingDocsSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
         expect(search).to receive(:run)
@@ -490,6 +487,7 @@ describe Api::V2::SearchesController do
 
       before do
         expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(affiliate).to receive(:search_engine).and_return("BingV6")
 
         expect(DocumentCollection).to receive(:find).and_return(document_collection)
 
@@ -534,17 +532,17 @@ describe Api::V2::SearchesController do
       end
     end
 
-    context 'when the search options are valid and routed query term is matched' do
+    context 'when a routed query term is matched' do
       before do
         routed_query_setup
 
-        get :docs, params: docs_params.merge(query: 'foo bar')
+        get :docs, params: docs_params.merge(query: 'moar unclaimed money')
       end
 
       it { is_expected.to respond_with :success }
 
       it 'returns search JSON' do
-        expect(JSON.parse(response.body)['route_to']).to eq('http://www.gov.gov/foo.html')
+        expect(JSON.parse(response.body)['route_to']).to eq('https://www.usa.gov/unclaimed_money')
       end
     end
   end

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 
 describe SearchesController do
-  fixtures :affiliates, :image_search_labels, :document_collections, :rss_feeds, :rss_feed_urls,
-           :navigations, :features, :news_items, :languages
-
   let(:affiliate) { affiliates(:usagov_affiliate) }
 
   context 'when showing a new search' do
@@ -103,22 +100,16 @@ describe SearchesController do
   context 'searching on a routed keyword' do
     let(:affiliate) { affiliates(:basic_affiliate) }
     context 'referrer does not match redirect url' do
-      before do
-        routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
-        routed_query.routed_query_keywords.build(keyword: 'foo bar')
-        routed_query.save!
-      end
-
       it 'redirects to the proper url' do
-        get :index, params: { query: "foo bar", affiliate: affiliate.name }
-        expect(response).to redirect_to 'http://www.gov.gov/foo.html'
+        get :index, params: { query: "moar unclaimed money", affiliate: affiliate.name }
+        expect(response).to redirect_to 'https://www.usa.gov/unclaimed_money'
       end
 
       it 'logs the impression' do
-        expect(SearchImpression).to receive(:log)
+        expect(RoutedQueryImpressionLogger).to receive(:log)
         get :index,
             params: {
-              query: 'foo bar',
+              query: 'moar unclaimed money',
               affiliate: affiliate.name
             }
       end

--- a/spec/models/routed_query_impression_logger_spec.rb
+++ b/spec/models/routed_query_impression_logger_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RoutedQueryImpressionLogger do
+  let!(:mock_search) do
+    instance_double(RoutedQueryImpressionLogger::QueryRoutedSearch,
+                    modules: ['QRTD'],
+                    diagnostics: {})
+  end
+  let(:affiliate) { affiliates(:basic_affiliate) }
+  let(:mock_request) do
+    double('request',
+           remote_ip: '1.2.3.4',
+           url: 'http://www.gov.gov/',
+           referer: 'http://www.gov.gov/ref',
+           user_agent: 'whatevs',
+           headers: {})
+  end
+
+  before do
+    allow(RoutedQueryImpressionLogger::QueryRoutedSearch).to receive(:new).with(
+      ['QRTD'],
+      {}
+    ).and_return(mock_search)
+  end
+
+  describe '.log' do
+    it 'sets up the right params to log a search impression' do
+      allow(SearchImpression).to receive(:log)
+
+      RoutedQueryImpressionLogger.log(affiliates(:basic_affiliate),
+                                      'example of a routed query',
+                                      mock_request)
+
+      expect(SearchImpression).to have_received(:log).with(
+        mock_search,
+        :web,
+        { affiliate: 'nps.gov', query: 'example of a routed query' },
+        mock_request
+      )
+    end
+
+    it 'has the expected log line' do
+      allow(Rails.logger).to receive(:info)
+
+      RoutedQueryImpressionLogger.log(affiliates(:basic_affiliate),
+                                      'example of a routed query',
+                                      mock_request)
+
+      expect(Rails.logger).to have_received(:info).with(
+        include('[Search Impression]',
+                '"modules":"QRTD"',
+                '"query":"example of a routed query"')
+      )
+    end
+  end
+end

--- a/spec/models/routed_query_impression_logger_spec.rb
+++ b/spec/models/routed_query_impression_logger_spec.rb
@@ -40,19 +40,5 @@ describe RoutedQueryImpressionLogger do
         mock_request
       )
     end
-
-    it 'has the expected log line' do
-      allow(Rails.logger).to receive(:info)
-
-      RoutedQueryImpressionLogger.log(affiliates(:basic_affiliate),
-                                      'example of a routed query',
-                                      mock_request)
-
-      expect(Rails.logger).to have_received(:info).with(
-        include('[Search Impression]',
-                '"modules":"QRTD"',
-                '"query":"example of a routed query"')
-      )
-    end
   end
 end

--- a/spec/models/search_impression_spec.rb
+++ b/spec/models/search_impression_spec.rb
@@ -2,11 +2,22 @@
 
 require 'spec_helper'
 
-describe 'SearchImpression' do
+describe SearchImpression do
   describe '.log' do
-    let!(:request) { double('request', remote_ip: '1.2.3.4', url: 'http://www.gov.gov/', referer: 'http://www.gov.gov/ref', user_agent: 'whatevs', headers: {}) }
-    let!(:search) { double(Search, modules: ['BWEB'], diagnostics: { AWEB: { snap: 'judgement' } }) }
-    let!(:params) { { 'foo' => 'yep' } }
+    let(:request) do
+      double('request',
+             remote_ip: '1.2.3.4',
+             url: 'http://www.gov.gov/',
+             referer: 'http://www.gov.gov/ref',
+             user_agent: 'whatevs',
+             headers: {})
+    end
+    let(:search) do
+      double(Search,
+             modules: ['BWEB'],
+             diagnostics: { AWEB: { snap: 'judgement' } })
+    end
+    let(:params) { { 'foo' => 'yep' } }
     let(:time) { Time.now }
 
     before do
@@ -17,18 +28,28 @@ describe 'SearchImpression' do
     end
 
     context 'with regular params' do
-      it 'has the expected log line' do
-        expect(Rails.logger).to have_received(:info).with("[Search Impression] {\"clientip\":\"1.2.3.4\",\"request\":\"http://www.gov.gov/\",\"referrer\":\"http://www.gov.gov/ref\",\"user_agent\":\"whatevs\",\"diagnostics\":[{\"snap\":\"judgement\",\"module\":\"AWEB\"}],\"time\":\"#{time.to_formatted_s(:db)}\",\"vertical\":\"web\",\"modules\":\"BWEB\",\"params\":{\"foo\":\"yep\"}}")
+      it 'has the single expected log line' do
+        expect(Rails.logger).to have_received(:info).once
+        expect(Rails.logger).to have_received(:info).with(
+          '[Search Impression] {"clientip":"1.2.3.4",'\
+          '"request":"http://www.gov.gov/",'\
+          '"referrer":"http://www.gov.gov/ref",'\
+          '"user_agent":"whatevs","diagnostics":'\
+          '[{"snap":"judgement","module":"AWEB"}],'\
+          "\"time\":\"#{time.to_formatted_s(:db)}\","\
+          '"vertical":"web","modules":"BWEB",'\
+          '"params":{"foo":"yep"}}'
+        )
       end
     end
 
-    context "with routed query module and empty diagnostics" do
-      let!(:search) { double(Search, modules: ['QRTD'], diagnostics: {}) }
+    context 'with routed query module and empty diagnostics' do
+      let(:search) { double(Search, modules: ['QRTD'], diagnostics: {}) }
 
       it 'has the expected log line parts' do
-        expect(Rails.logger).to have_received(:info).with(include('[Search Impression]'))
-        expect(Rails.logger).to have_received(:info).with(include('"modules":"QRTD"'))
-        expect(Rails.logger).to have_received(:info).with(include('"diagnostics":[]'))
+        expect(Rails.logger).to have_received(:info).with(
+          include('"modules":"QRTD"', '"diagnostics":[]')
+        )
       end
     end
 
@@ -36,16 +57,30 @@ describe 'SearchImpression' do
       let(:params) { { 'foo' => 'yep', 'bar.blat' => 'nope' } }
 
       it 'omits that parameter' do
-        expect(Rails.logger).to have_received(:info).with("[Search Impression] {\"clientip\":\"1.2.3.4\",\"request\":\"http://www.gov.gov/\",\"referrer\":\"http://www.gov.gov/ref\",\"user_agent\":\"whatevs\",\"diagnostics\":[{\"snap\":\"judgement\",\"module\":\"AWEB\"}],\"time\":\"#{time.to_formatted_s(:db)}\",\"vertical\":\"web\",\"modules\":\"BWEB\",\"params\":{\"foo\":\"yep\"}}")
+        expect(Rails.logger).to have_received(:info).with(
+          include('"params":{"foo":"yep"}')
+        )
       end
     end
 
     context 'headers contains X-Original-Request header' do
-      let!(:request) { double('request', remote_ip: '1.2.3.4', url: 'http://www.gov.gov/', referer: 'http://www.gov.gov/ref', user_agent: 'whatevs', headers: { 'X-Original-Request' => 'http://test.gov' }) }
+      let(:request) do
+        double('request',
+               remote_ip: '1.2.3.4',
+               url: 'http://www.gov.gov/',
+               referer: 'http://www.gov.gov/ref',
+               user_agent: 'whatevs',
+               headers: { 'X-Original-Request' => 'http://test.gov' })
+      end
 
-      it 'should log a non-null value for original_request' do
-        expect(Rails.logger).to have_received(:info).with('[X-Original-Request] ("http://test.gov")')
-        expect(Rails.logger).to have_received(:info).with("[Search Impression] {\"clientip\":\"1.2.3.4\",\"request\":\"http://test.gov\",\"referrer\":\"http://www.gov.gov/ref\",\"user_agent\":\"whatevs\",\"diagnostics\":[{\"snap\":\"judgement\",\"module\":\"AWEB\"}],\"time\":\"#{time.to_formatted_s(:db)}\",\"vertical\":\"web\",\"modules\":\"BWEB\",\"params\":{\"foo\":\"yep\"}}")
+      it 'should log two lines, the original-request header and the search impression' do
+        expect(Rails.logger).to have_received(:info).twice
+        expect(Rails.logger).to have_received(:info).with(
+          '[X-Original-Request] ("http://test.gov")'
+        )
+        expect(Rails.logger).to have_received(:info).with(
+          include('[Search Impression]', '"request":"http://test.gov"')
+        )
       end
     end
   end

--- a/spec/models/search_impression_spec.rb
+++ b/spec/models/search_impression_spec.rb
@@ -5,7 +5,7 @@ require 'spec_helper'
 describe 'SearchImpression' do
   describe '.log' do
     let!(:request) { double('request', remote_ip: '1.2.3.4', url: 'http://www.gov.gov/', referer: 'http://www.gov.gov/ref', user_agent: 'whatevs', headers: {}) }
-    let!(:search) { double(Search, modules: %w[BWEB], diagnostics: { AWEB: { snap: 'judgement' } }) }
+    let!(:search) { double(Search, modules: ['BWEB'], diagnostics: { AWEB: { snap: 'judgement' } }) }
     let!(:params) { { 'foo' => 'yep' } }
     let(:time) { Time.now }
 
@@ -19,6 +19,16 @@ describe 'SearchImpression' do
     context 'with regular params' do
       it 'has the expected log line' do
         expect(Rails.logger).to have_received(:info).with("[Search Impression] {\"clientip\":\"1.2.3.4\",\"request\":\"http://www.gov.gov/\",\"referrer\":\"http://www.gov.gov/ref\",\"user_agent\":\"whatevs\",\"diagnostics\":[{\"snap\":\"judgement\",\"module\":\"AWEB\"}],\"time\":\"#{time.to_formatted_s(:db)}\",\"vertical\":\"web\",\"modules\":\"BWEB\",\"params\":{\"foo\":\"yep\"}}")
+      end
+    end
+
+    context "with routed query module and empty diagnostics" do
+      let!(:search) { double(Search, modules: ['QRTD'], diagnostics: {}) }
+
+      it 'has the expected log line parts' do
+        expect(Rails.logger).to have_received(:info).with(include('[Search Impression]'))
+        expect(Rails.logger).to have_received(:info).with(include('"modules":"QRTD"'))
+        expect(Rails.logger).to have_received(:info).with(include('"diagnostics":[]'))
       end
     end
 


### PR DESCRIPTION
This PR makes some changes to the routed queries feature in the API:
- Removes the need for a special parameter.
- Returns `route_to` instead of `redirect` as the key.
- Adds documentation of the feature and a vanilla javascript example.
- Refactors the routed query specs to use the fixtures
- Adds logging for api routed queries
- Adds a spec for the RoutedQueryImpressionLogger used by both the api and the app.