### PR TITLE
Document and specs for existing click tracking endpoint

### DIFF
--- a/app/controllers/sites/click_tracking_api_instructions_controller.rb
+++ b/app/controllers/sites/click_tracking_api_instructions_controller.rb
@@ -1,0 +1,4 @@
+class Sites::ClickTrackingApiInstructionsController < Sites::SetupSiteController
+  def show
+  end
+end

--- a/app/helpers/sites_helper.rb
+++ b/app/helpers/sites_helper.rb
@@ -105,7 +105,7 @@ module SitesHelper
   end
 
   def site_activate_search_controllers
-    %w(api_access_keys api_instructions embed_codes i14y_api_instructions type_ahead_api_instructions)
+    %w(api_access_keys api_instructions embed_codes i14y_api_instructions type_ahead_api_instructions, click_tracking_api_instructions)
   end
 
   def site_analytics_controllers

--- a/app/views/sites/click_tracking_api_instructions/_show_md.html.haml
+++ b/app/views/sites/click_tracking_api_instructions/_show_md.html.haml
@@ -1,0 +1,28 @@
+:markdown
+  This API is available for you send click events to. Then you'll be able to see them on your [Admin Click Analytics](/sites/#{@site.id}/clicks/new) page.
+  
+  Read more about click tracking [here](https://search.gov/manual/clicks.html).
+  
+  ## Resource URL
+  `#{api_scheme_and_host}/clicked?u={URL}&q={QUERY}&p={POSITION}&t={TIME}&a={AFFILIATE_NAME}&s={RESULT_SOURCE}&v={VERTICAL}&l={LOCALE}&i={MODEL_ID}`
+
+  ## Method
+  **GET**
+
+  ## Required Parameters
+  - `u`: url - The Url of the link that was clicked.
+  - `q`: query - The search term that let this result get shown and clicked on.
+  - `a`: affiliate name - You can find your site handle on the [Settings](#{edit_site_setting_path(@site)}) page.
+  - `p`: position - The position/rank on your search results page. Was it the first result or the second?
+  - `s`: module - The module code for the source of the clicked result. Must be a valid module code. See https://search.gov/manual/module-codes.html
+  - `l`: locale - Unused
+  - `t`: timestamp - Unused - Use the [Unix epoch](https://en.wikipedia.org/wiki/Unix_time)
+  - `i`: model_id: The model ID is the id of your api search result.
+  - `v`: vertical - Hmmmmm 
+  
+  ## Responses
+  - **Success** - A response status code of 200 and empty body.
+  - **Error** - A response status code of 200 and empty body.
+
+  ## Terms of Service
+  By using this API, you agree to our [Terms of Service](https://search.gov/tos).

--- a/app/views/sites/click_tracking_api_instructions/show.html.haml
+++ b/app/views/sites/click_tracking_api_instructions/show.html.haml
@@ -1,0 +1,11 @@
+= content_for_site_page_title @site, 'Click Tracking API Instructions'
+.sub-nav-heading
+  %h2 Click Tracking API Instructions
+  .action-bar
+    %ul
+      = list_item_with_link_to_current_help_page
+
+- api_scheme_and_host = "#{request.scheme}://#{request.host_with_port}"
+
+.api-instruction
+  = render partial: 'show_md', locals: { api_scheme_and_host: api_scheme_and_host }

--- a/app/views/sites/shared/_activate_search_sub_nav.html.haml
+++ b/app/views/sites/shared/_activate_search_sub_nav.html.haml
@@ -7,3 +7,4 @@
   %li{ site_nav_css_class_hash('type_ahead_api_instructions') }= link_to 'Type-ahead API Instructions', site_type_ahead_api_instructions_path(@site)
   - if @site.gets_i14y_results?
     %li{ site_nav_css_class_hash('i14y_api_instructions') }= link_to 'i14y Content Indexing API Instructions', site_i14y_api_instructions_path(@site)
+  %li{ site_nav_css_class_hash('click_tracking_api_instructions') }= link_to 'Click Tracking API Instructions', site_click_tracking_api_instructions_path(@site)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -67,6 +67,7 @@ Rails.application.routes.draw do
       end
       resource :i14y_api_instructions, only: [:show]
       resource :type_ahead_api_instructions, only: [:show]
+      resource :click_tracking_api_instructions, only: [:show]
       resource :clicks, only: [:new, :create]
       resource :query_clicks, only: [:show]
       resource :query_referrers, only: [:show]

--- a/features/admin_center_activate_search.feature
+++ b/features/admin_center_activate_search.feature
@@ -55,3 +55,12 @@ Feature: Activate Search
     And I follow "i14y Content Indexing API Instructions"
     Then I should see "i14y Content Indexing API Instructions" within the Admin Center content
     And I should see "manage your i14y drawers"
+
+  Scenario: Visiting the Click Tracking API Instructions
+    Given the following Affiliates exist:
+      | display_name | name    | contact_email | first_name   | last_name         |
+      | aff site     | aff.gov | aff@bar.gov   | John Bar     | Bar               |
+    And I am logged in with email "aff@bar.gov"
+    When I go to the aff.gov's Activate Search page
+    And I follow "Click Tracking API Instructions"
+    Then I should see "Click Tracking API Instructions" within the Admin Center content

--- a/spec/helpers/results_helper_spec.rb
+++ b/spec/helpers/results_helper_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+describe ResultsHelper do
+  describe '#search_data' do
+    let(:search) do
+      double('search',
+             affiliate: affiliates(:basic_affiliate),
+             query: 'rutabaga',
+             module_tag: 'BOOS',
+             queried_at_seconds: "1588714504")
+    end
+    let(:search_vertical) { 'BOOS' }
+
+    it 'adds data attributes to #search needed for click tracking' do
+      output = search_data(search, search_vertical)
+      expected_output = {
+        data: {
+          a: 'nps.gov',
+          l: 'en',
+          q: 'rutabaga',
+          s: 'BOOS',
+          t: "1588714504",
+          v: 'BOOS'
+        }
+      }
+      expect(output).to eq expected_output
+    end
+  end
+
+  describe '#link_to_result_title' do
+    it 'makes a link with the added data-click attribute' do
+      output = link_to_result_title('1', 'test title', 'https://test.gov', '2', 'BOOS')
+      expected_output = '<a data-click="{&quot;i&quot;:&quot;1&quot;'\
+                        ',&quot;p&quot;:&quot;2&quot;,&quot;s&quot;:&quot;BOOS&quot;}"'\
+                        ' href="https://test.gov">test title</a>'
+      expect(output).to eq expected_output
+    end
+  end
+end


### PR DESCRIPTION
- ResultsHelper spec tests the html output needed for click tracking.
- Cleaned up the requests/clicked_spec to test that the `/clicked` end point works.
- Added documentation and feature spec to give user instructions.

<img width="1367" alt="Screen Shot 2020-05-15 at 11 46 40 AM" src="https://user-images.githubusercontent.com/595778/82085375-c6f3f800-96a1-11ea-8d40-a8a718b0b396.png">
