### PR TITLE
Release 1.16.30

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,18 @@ executors:
           http.port: 9256
           cluster.name: es56
           xpack.security.enabled: false
-          ES_JAVA_OPTS: '-Xms750m -Xmx750m'
+          ES_JAVA_OPTS: '-Xms512m -Xmx512m'
+
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.6
+        environment:
+          bootstrap.memory_lock: true
+          cluster.name: es68
+          discovery.type: single-node
+          http.port: 9268
+          xpack.license.self_generated.type: trial
+          xpack.monitoring.enabled: false
+          xpack.security.enabled: false
+          ES_JAVA_OPTS: '-Xms512m -Xmx512m'
 
 commands:
   prepare_database:
@@ -45,8 +56,12 @@ jobs:
       - checkout
 
       - run:
-          name: Wait for Elasticsearch
+          name: Wait for Elasticsearch 5.6
           command: dockerize -wait tcp://localhost:9256 -timeout 1m
+
+      - run:
+          name: Wait for Elasticsearch 6.8
+          command: dockerize -wait tcp://localhost:9268 -timeout 1m
 
       - run:
           name: Use developer secrets
@@ -84,40 +99,6 @@ jobs:
           paths:
             - vendor/bundle
 
-  setup_elasticsearch:
-    executor: test_executor
-
-    environment:
-      COVERAGE: true
-
-    steps:
-      - restore_cache:
-          key: repo-{{ .Environment.CIRCLE_SHA1 }}
-
-      - run:
-          name: Install Elasticsearch
-          command: |
-            java -version
-            echo $JAVA_HOME
-            curl -L -O https://download.elastic.co/elasticsearch/elasticsearch/elasticsearch-1.7.3.tar.gz
-            tar -xvf elasticsearch-1.7.3.tar.gz
-            PLUGINS=(
-              "elasticsearch/license/latest"
-              "elasticsearch/marvel/latest"
-              "polyfractal/elasticsearch-inquisitor/latest"
-              "elasticsearch/elasticsearch-analysis-kuromoji/2.7.0"
-              "elasticsearch/elasticsearch-analysis-smartcn/2.7.0"
-              "elasticsearch/elasticsearch-analysis-icu/2.7.0"
-              "elasticsearch/watcher/latest"
-            )
-            for plugin in ${PLUGINS[*]}; do /home/circleci/search-gov/elasticsearch-1.7.3/bin/plugin install $plugin; done
-            echo "script.index: on" >> /home/circleci/search-gov/elasticsearch-1.7.3/config/elasticsearch.yml
-            echo "script.inline: on" >> /home/circleci/search-gov/elasticsearch-1.7.3/config/elasticsearch.yml
-
-      - save_cache:
-          key: elasticsearch
-          paths: /home/circleci/search-gov/elasticsearch-1.7.3
-
   rspec:
     executor: test_executor
 
@@ -132,16 +113,11 @@ jobs:
 
       - run: bundle --path vendor/bundle
 
-      - restore_cache:
-          key: elasticsearch
-
       - prepare_database
 
       - run:
           name: Run Tests
           command: |
-            /home/circleci/search-gov/elasticsearch-1.7.3/bin/elasticsearch -d
-            sleep 10
             bundle exec rake usasearch:elasticsearch:create_indexes
 
             mkdir /tmp/test-results
@@ -182,16 +158,11 @@ jobs:
 
       - run: bundle --path vendor/bundle
 
-      - restore_cache:
-          key: elasticsearch
-
       - prepare_database
 
       - run:
           name: Run Tests
           command: |
-            /home/circleci/search-gov/elasticsearch-1.7.3/bin/elasticsearch -d
-            sleep 10
             bundle exec rake usasearch:elasticsearch:create_indexes
 
             bundle exec rake tmp:create
@@ -249,20 +220,16 @@ workflows:
     jobs:
       - checkout_code
 
-      - setup_elasticsearch
-
       - bundle_install:
           requires:
           - checkout_code
 
       - rspec:
           requires:
-            - setup_elasticsearch
             - bundle_install
 
       - cucumber:
           requires:
-            - setup_elasticsearch
             - bundle_install
 
       - report_coverage:

--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -79,17 +79,18 @@ module Api
       end
 
       def handle_query_routing
-        return unless search_params[:query].present? and query_routing_is_enabled?
         affiliate = @search_options.site
         routed_query = affiliate.routed_queries
           .joins(:routed_query_keywords)
           .where(routed_query_keywords:{keyword: search_params[:query]})
           .first
-        respond_with({ redirect: routed_query[:url] }, { status: 200 }) unless routed_query.nil?
-      end
 
-      def query_routing_is_enabled?
-        search_params[:routed] == 'true'
+        return unless routed_query
+
+        RoutedQueryImpressionLogger.log(affiliate,
+                                        @search_options.query, request)
+
+        respond_with({ route_to: routed_query[:url] }, { status: 200 })
       end
 
       def search_params

--- a/app/views/sites/api_instructions/_show_web_md.html.haml
+++ b/app/views/sites/api_instructions/_show_web_md.html.haml
@@ -1,4 +1,6 @@
 :markdown
+  <!-- Reminder to update https://open.gsa.gov/api/searchgov-results/ with any changes here. -->
+
   This API exposes all relevant results “modules” in a single JSON call, including:
 
 
@@ -368,6 +370,44 @@
       An array of related search terms, which are based on recent, common searches on the your site.
 
 
+
+  ## Routed Queries
+
+
+    If you have [routed queries](https://search.gov/manual/routed-queries.html) set in your Admin page, then any matching query terms will change the API response.
+
+    For example, if you set queries for `example` to route to `https://search.gov` then the following API call:
+
+    `#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query=example`
+
+    Will then return this response:
+
+    `{"route_to":"https://search.gov"}`
+
+    With this response you can redirect your users to the url. Here is an example with javascript:
+
+    ```javascript
+    var request = new XMLHttpRequest();
+    var apiUrl = '#{api_scheme_and_host}/api/v2/search?affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&query=example'
+
+    request.open('GET', apiUrl, true);
+
+    request.onload = function() {
+        if (this.status >= 200 && this.status < 400) {
+            // Success!
+            var data = JSON.parse( this.response );
+            window.location.replace( data.route_to );
+        } else {
+            // We reached our target server, but it returned an error
+        }
+    };
+
+    request.onerror = function() {
+        // There was a connection error of some sort
+    };
+
+    request.send();
+    ```
 
 
   ## I14y API

--- a/config/secrets.yml.dev
+++ b/config/secrets.yml.dev
@@ -69,12 +69,12 @@ dev_settings: &DEV_SETTINGS
     elasticsearch:
       reader:
         hosts:
-          - http://localhost:9256
+          - http://localhost:9268
         user: elastic
         password: changeme
       writers:
         - hosts:
-            - http://localhost:9256
+            - http://localhost:9268
           user: elastic
           password: changeme
   asis:
@@ -83,12 +83,12 @@ dev_settings: &DEV_SETTINGS
     elasticsearch:
       reader:
         hosts:
-          - http://localhost:9256
+          - http://localhost:9268
         user: elastic
         password: changeme
       writers:
         - hosts:
-            - http://localhost:9256
+            - http://localhost:9268
           user: elastic
           password: changeme
   jobs:

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -1,9 +1,6 @@
 require 'spec_helper'
 
 describe SearchesController do
-  fixtures :affiliates, :image_search_labels, :document_collections, :rss_feeds, :rss_feed_urls,
-           :navigations, :features, :news_items, :languages
-
   let(:affiliate) { affiliates(:usagov_affiliate) }
 
   context 'when showing a new search' do
@@ -103,22 +100,16 @@ describe SearchesController do
   context 'searching on a routed keyword' do
     let(:affiliate) { affiliates(:basic_affiliate) }
     context 'referrer does not match redirect url' do
-      before do
-        routed_query = affiliate.routed_queries.build(url: "http://www.gov.gov/foo.html", description: "testing")
-        routed_query.routed_query_keywords.build(keyword: 'foo bar')
-        routed_query.save!
-      end
-
       it 'redirects to the proper url' do
-        get :index, params: { query: "foo bar", affiliate: affiliate.name }
-        expect(response).to redirect_to 'http://www.gov.gov/foo.html'
+        get :index, params: { query: "moar unclaimed money", affiliate: affiliate.name }
+        expect(response).to redirect_to 'https://www.usa.gov/unclaimed_money'
       end
 
       it 'logs the impression' do
-        expect(SearchImpression).to receive(:log)
+        expect(RoutedQueryImpressionLogger).to receive(:log)
         get :index,
             params: {
-              query: 'foo bar',
+              query: 'moar unclaimed money',
               affiliate: affiliate.name
             }
       end

--- a/spec/models/routed_query_impression_logger_spec.rb
+++ b/spec/models/routed_query_impression_logger_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe RoutedQueryImpressionLogger do
+  let!(:mock_search) do
+    instance_double(RoutedQueryImpressionLogger::QueryRoutedSearch,
+                    modules: ['QRTD'],
+                    diagnostics: {})
+  end
+  let(:affiliate) { affiliates(:basic_affiliate) }
+  let(:mock_request) do
+    double('request',
+           remote_ip: '1.2.3.4',
+           url: 'http://www.gov.gov/',
+           referer: 'http://www.gov.gov/ref',
+           user_agent: 'whatevs',
+           headers: {})
+  end
+
+  before do
+    allow(RoutedQueryImpressionLogger::QueryRoutedSearch).to receive(:new).with(
+      ['QRTD'],
+      {}
+    ).and_return(mock_search)
+  end
+
+  describe '.log' do
+    it 'sets up the right params to log a search impression' do
+      allow(SearchImpression).to receive(:log)
+
+      RoutedQueryImpressionLogger.log(affiliates(:basic_affiliate),
+                                      'example of a routed query',
+                                      mock_request)
+
+      expect(SearchImpression).to have_received(:log).with(
+        mock_search,
+        :web,
+        { affiliate: 'nps.gov', query: 'example of a routed query' },
+        mock_request
+      )
+    end
+  end
+end

--- a/spec/models/search_impression_spec.rb
+++ b/spec/models/search_impression_spec.rb
@@ -1,30 +1,87 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
-describe SearchImpression, ".log" do
-  context 'params contains key with period' do
-    let(:params) { { "foo" => "yep", "bar.blat" => "nope" } }
-    let(:search) { double(Search, modules: %w(BWEB), diagnostics: { AWEB: { snap: 'judgement' } }) }
-    let(:request) { double("request", remote_ip: '1.2.3.4', url: 'http://www.gov.gov/', referer: 'http://www.gov.gov/ref', user_agent: 'whatevs', headers: {}) }
-
-    it 'omits that parameter' do
-      time = Time.now
-      allow(Time).to receive(:now).and_return time
-      expect(Rails.logger).to receive(:info).with("[Search Impression] {\"clientip\":\"1.2.3.4\",\"request\":\"http://www.gov.gov/\",\"referrer\":\"http://www.gov.gov/ref\",\"user_agent\":\"whatevs\",\"diagnostics\":[{\"snap\":\"judgement\",\"module\":\"AWEB\"}],\"time\":\"#{time.to_formatted_s(:db)}\",\"vertical\":\"web\",\"modules\":\"BWEB\",\"params\":{\"foo\":\"yep\"}}")
-      SearchImpression.log(search, "web", params, request)
+describe SearchImpression do
+  describe '.log' do
+    let(:request) do
+      double('request',
+             remote_ip: '1.2.3.4',
+             url: 'http://www.gov.gov/',
+             referer: 'http://www.gov.gov/ref',
+             user_agent: 'whatevs',
+             headers: {})
     end
-  end
+    let(:search) do
+      double(Search,
+             modules: ['BWEB'],
+             diagnostics: { AWEB: { snap: 'judgement' } })
+    end
+    let(:params) { { 'foo' => 'yep' } }
+    let(:time) { Time.now }
 
-  context 'headers contains X-Original-Request header' do
-    let(:params) { { "foo" => "yep", "bar.blat" => "nope" } }
-    let(:search) { double(Search, modules: %w(BWEB), diagnostics: { AWEB: { snap: 'judgement' } }) }
-    let(:request) { double("request", remote_ip: '1.2.3.4', url: 'http://www.gov.gov/', referer: 'http://www.gov.gov/ref', user_agent: 'whatevs', headers: { 'X-Original-Request' => 'http://test.gov' }) }
+    before do
+      allow(Time).to receive(:now).and_return(time)
+      allow(Rails.logger).to receive(:info)
 
-    it 'should log a non-null value for original_request' do
-      time = Time.now
-      allow(Time).to receive(:now).and_return time
-      expect(Rails.logger).to receive(:info).with("[X-Original-Request] (\"http://test.gov\")")
-      expect(Rails.logger).to receive(:info).with("[Search Impression] {\"clientip\":\"1.2.3.4\",\"request\":\"http://test.gov\",\"referrer\":\"http://www.gov.gov/ref\",\"user_agent\":\"whatevs\",\"diagnostics\":[{\"snap\":\"judgement\",\"module\":\"AWEB\"}],\"time\":\"#{time.to_formatted_s(:db)}\",\"vertical\":\"web\",\"modules\":\"BWEB\",\"params\":{\"foo\":\"yep\"}}")
-      SearchImpression.log(search, "web", params, request)
+      SearchImpression.log(search, 'web', params, request)
+    end
+
+    context 'with regular params' do
+      it 'has the single expected log line' do
+        expect(Rails.logger).to have_received(:info).once
+        expect(Rails.logger).to have_received(:info).with(
+          '[Search Impression] {"clientip":"1.2.3.4",'\
+          '"request":"http://www.gov.gov/",'\
+          '"referrer":"http://www.gov.gov/ref",'\
+          '"user_agent":"whatevs","diagnostics":'\
+          '[{"snap":"judgement","module":"AWEB"}],'\
+          "\"time\":\"#{time.to_formatted_s(:db)}\","\
+          '"vertical":"web","modules":"BWEB",'\
+          '"params":{"foo":"yep"}}'
+        )
+      end
+    end
+
+    context 'with routed query module and empty diagnostics' do
+      let(:search) { double(Search, modules: ['QRTD'], diagnostics: {}) }
+
+      it 'has the expected log line parts' do
+        expect(Rails.logger).to have_received(:info).with(
+          include('"modules":"QRTD"', '"diagnostics":[]')
+        )
+      end
+    end
+
+    context 'params contains key with period' do
+      let(:params) { { 'foo' => 'yep', 'bar.blat' => 'nope' } }
+
+      it 'omits that parameter' do
+        expect(Rails.logger).to have_received(:info).with(
+          include('"params":{"foo":"yep"}')
+        )
+      end
+    end
+
+    context 'headers contains X-Original-Request header' do
+      let(:request) do
+        double('request',
+               remote_ip: '1.2.3.4',
+               url: 'http://www.gov.gov/',
+               referer: 'http://www.gov.gov/ref',
+               user_agent: 'whatevs',
+               headers: { 'X-Original-Request' => 'http://test.gov' })
+      end
+
+      it 'should log two lines, the original-request header and the search impression' do
+        expect(Rails.logger).to have_received(:info).twice
+        expect(Rails.logger).to have_received(:info).with(
+          '[X-Original-Request] ("http://test.gov")'
+        )
+        expect(Rails.logger).to have_received(:info).with(
+          include('[Search Impression]', '"request":"http://test.gov"')
+        )
+      end
     end
   end
 end

--- a/spec/support/indexable_behavior.rb
+++ b/spec/support/indexable_behavior.rb
@@ -10,7 +10,7 @@ shared_examples "an indexable" do
 
   context 'when there are multiple clusters' do
     let(:es1) { Elasticsearch::Client.new(host: 'localhost:9256') }
-    let(:es2) { Elasticsearch::Client.new(host: '127.0.0.1') }
+    let(:es2) { Elasticsearch::Client.new(host: 'localhost:9268') }
 
     before do
       allow(ES::CustomIndices).to receive(:client_writers).and_return [es1, es2]


### PR DESCRIPTION
[SRCH-1261] and [SRCH-958] - run specs against Elasticsearch 6.8
[SRCH-1406] - Update routed query feature in the API