### PR TITLE
fix url_status_code_fetcher_spec

### DIFF
--- a/spec/lib/url_status_code_fetcher_spec.rb
+++ b/spec/lib/url_status_code_fetcher_spec.rb
@@ -6,7 +6,7 @@ describe UrlStatusCodeFetcher do
   # has more dev support, is more easily stubbed, and is already used extensively
   # in our code.
 
-  let(:valid_url) { "https://www.usa.gov/" }
+  let(:valid_url) { "https://search.gov/" }
   let(:invalid_url) { "https://www.google.com/404" }
 
   describe '.fetch' do


### PR DESCRIPTION
This PR fixes a spec that started failing due to the usa.gov URL being unreachable:
```
$ curl -I https://www.usa.gov/
curl: (60) SSL certificate problem: certificate has expired
```
In a perfect world, we'd stub the request in the spec, but that class uses a gem for requests that are not easily stubbed. So for now I'm fixing this by switching to a working URL.