### PR TITLE
Added comments for finding old code in srch-1525

### DIFF
--- a/app/assets/javascripts/legacy/application.js
+++ b/app/assets/javascripts/legacy/application.js
@@ -1,4 +1,5 @@
 function clk(a, b, c, d, e, f, g, h, i) {
+  // TO REMOVE SRCH-1525
   if (document.images) {
     var img = new Image;
     img.src = ['/clicked?','u=',encodeURIComponent(b),'&q=',encodeURIComponent(a),'&p=',c,'&a=',d,'&s=',e,'&t=',f,'&v=',g,'&l=',h,'&i=',i].join('');

--- a/app/assets/javascripts/searches/clk.js
+++ b/app/assets/javascripts/searches/clk.js
@@ -1,3 +1,4 @@
+// TO REMOVE SRCH-1525
 function clk(a, b, c, d, e, f, g, h, i) {
   if (document.images) {
     var img = new Image;

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -125,6 +125,7 @@ module SearchHelper
   end
 
   def onmousedown_for_tweet_click_attribute(query, url, zero_based_index, affiliate_name, source, queried_at, vertical)
+    # TO REMOVE SRCH-1525
     tracked_url = url ? "'#{URI.escape(url)}'" : 'this.href'
     "return clk('#{h query}', #{tracked_url}, #{zero_based_index + 1}, '#{affiliate_name}', '#{source}', #{queried_at}, '#{vertical}', '#{I18n.locale.to_s}')"
   end
@@ -134,10 +135,12 @@ module SearchHelper
   end
 
   def onmousedown_for_click_attribute(query, zero_based_index, affiliate_name, source, queried_at, vertical, model_id)
+    # TO REMOVE SRCH-1525
     "return clk('#{h query}',this.href, #{zero_based_index + 1}, '#{affiliate_name}', '#{source}', #{queried_at}, '#{vertical}', '#{I18n.locale.to_s}', '#{model_id}')"
   end
 
   def onmousedown_attribute_for_image_click(query, media_url, zero_based_index, affiliate_name, source, queried_at, vertical)
+    # TO REMOVE SRCH-1525
     "return clk('#{h(escape_javascript(query))}', '#{media_url}', #{zero_based_index + 1}, '#{affiliate_name}', '#{source}', #{queried_at}, '#{vertical}', '#{I18n.locale.to_s}')"
   end
 

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -88,7 +88,7 @@ describe SearchHelper do
       end
     end
   end
-  
+
   describe "#display_image_result_link" do
     before do
       @result = {'Url' => 'http://aHost.gov/aPath',
@@ -169,6 +169,7 @@ describe SearchHelper do
   end
 
   describe "#onmousedown_attribute_for_image_click" do
+    # TO REMOVE SRCH-1525
     it "should return with escaped query parameter and (index + 1) value" do
       now = Time.now.to_i
       content = helper.onmousedown_attribute_for_image_click("NASA's Space Rock", "url", 99, "affiliate name", "SOURCE", now, :image)
@@ -364,6 +365,7 @@ Veterans of the Vietnam War, families, friends, distinguished guests. I know it 
   end
 
   describe '#display_web_result_title' do
+    # TO REMOVE SRCH-1525
     it 'should render search results module' do
       result = {'title' => 'USASearch', 'unescapedUrl' => 'http://search.gov'}
       search = double(Search, query: 'gov', module_tag: 'BOGUS_MODULE', spelling_suggestion: nil, queried_at_seconds: 1000)

--- a/spec/helpers/twitter_profiles_helper_spec.rb
+++ b/spec/helpers/twitter_profiles_helper_spec.rb
@@ -24,6 +24,7 @@ describe TwitterProfilesHelper do
     end
 
     it 'should render tweet link with click tracking' do
+      # TO REMOVE SRCH-1525
       result = helper.legacy_render_tweet_text(tweet, search, 1)
       expect(result).to eq(%q[Search Notes for the Week Ending September 21, 2012 - <a href="http://t.co/YQQSs9bb" onmousedown="return clk('notes', 'http://tmblr.co/Z8xAVxUEKvaK', 2, 'usagov', 'TWEET', 1350362825, 'web', 'en')">tmblr.co/Z8xAVxUEKvaK</a> <a href="http://t.co/YQQSs9bb" onmousedown="return clk('notes', 'http://tmblr.co/Z8xAVxUEKvaK', 2, 'usagov', 'TWEET', 1350362825, 'web', 'en')">tmblr.co/Z8xAVxUEKvaK</a>])
     end
@@ -39,6 +40,7 @@ describe TwitterProfilesHelper do
     end
 
     it 'should render link with click tracking' do
+    # TO REMOVE SRCH-1525
       result = helper.legacy_render_twitter_profile(profile, search, 1)
       expect(result).to eq(%Q[<a href="http://twitter.com/USASearch" onmousedown="return clk('notes', this.href, 2, 'usagov', 'TWEET', 1350362825, 'web', 'en')">\n<span class="screen-name"> @</span></a>])
     end


### PR DESCRIPTION
As part of removing the [legacy SERPs](https://cm-jira.usa.gov/browse/SRCH-368), these comments can help remove some of the code used for the old way click tracking used to work. I would also look at the methods in [results_helper.rb](https://github.com/GSA/search-gov/blob/master/app/helpers/results_helper.rb), besides the first two.
