### PR TITLE
SRCH-1356 - Separate sitemap and searchgov queues

### DIFF
--- a/app/jobs/sitemap_indexer_job.rb
+++ b/app/jobs/sitemap_indexer_job.rb
@@ -1,5 +1,5 @@
 class SitemapIndexerJob < ApplicationJob
-  queue_as :searchgov
+  queue_as :sitemap
 
   def perform(sitemap_url:)
     SitemapIndexer.new(sitemap_url: sitemap_url).index

--- a/app/jobs/sitemap_monitor_job.rb
+++ b/app/jobs/sitemap_monitor_job.rb
@@ -1,5 +1,5 @@
 class SitemapMonitorJob < ApplicationJob
-  queue_as :searchgov
+  queue_as :sitemap
 
   def perform
     SearchgovDomain.ok.each do |searchgov_domain|

--- a/spec/jobs/sitemap_indexer_job_spec.rb
+++ b/spec/jobs/sitemap_indexer_job_spec.rb
@@ -8,7 +8,7 @@ describe SitemapIndexerJob do
   let(:indexer) { instance_double(SitemapIndexer) }
   subject(:perform) { SitemapIndexerJob.perform_now(args) }
 
-  it_behaves_like 'a searchgov job'
+  it_behaves_like 'a sitemap job'
 
   it 'indexes the sitemap' do
     allow(SitemapIndexer).to receive(:new).with(args).and_return(indexer)

--- a/spec/jobs/sitemap_monitor_job_spec.rb
+++ b/spec/jobs/sitemap_monitor_job_spec.rb
@@ -4,7 +4,7 @@ describe SitemapMonitorJob do
   let(:searchgov_domain) { instance_double(SearchgovDomain) }
   subject(:perform) { SitemapMonitorJob.perform_now }
 
-  it_behaves_like 'a searchgov job'
+  it_behaves_like 'a sitemap job'
 
   context 'when domains can be indexed' do
     before do

--- a/spec/support/sitemap_job_behavior.rb
+++ b/spec/support/sitemap_job_behavior.rb
@@ -1,0 +1,9 @@
+shared_examples_for 'a sitemap job' do
+  let(:args) { nil }
+
+  it 'uses the "sitemap" queue' do
+    expect{
+      described_class.perform_later(args)
+    }.to have_enqueued_job.on_queue('sitemap')
+  end
+end


### PR DESCRIPTION
This PR separates the sitemap and searchgov queues. Now sitemap indexing can happen at the same time as domain indexing.  https://cm-jira.usa.gov/browse/SRCH-1356

Will need to be matched with some Chef changes that adds a worker to this new queue.
`QUEUE=sitemap rake resque:work`
`QUEUE=searchgov rake resque:work`