### PR TITLE
Use Elasticsearch 6.8.11 in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -28,7 +28,7 @@ executors:
           xpack.security.enabled: false
           ES_JAVA_OPTS: '-Xms512m -Xmx512m'
 
-      - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.6
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.8.11
         environment:
           bootstrap.memory_lock: true
           cluster.name: es68


### PR DESCRIPTION
The Elasticsearch 6.8.6 image has been pulled from Docker, so this PR bumps the version used in CircleCi to 6.8.11.