### PR TITLE
SRCH-1650 preserve tmp/pids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,8 @@ public/system/
 test
 tmp/
 webrat-*.html
+
+# Ignore pidfiles, but keep the directory.
+/tmp/pids/*
+!/tmp/pids/
+!/tmp/pids/.keep


### PR DESCRIPTION
This PR resolves the following issue that I encountered in CircleCi:
https://www.alanvardy.com/post/puma-server-not-loading

Failures: https://app.circleci.com/pipelines/github/ondrae/search-gov/111/workflows/7a57fee0-4a56-4ec5-984f-177253fb6fc4/jobs/581

We used to create the `tmp/pids` directory [when setting up Redis for tests](https://github.com/GSA/search-gov/pull/587/files#diff-9042eb635a014a2e0077a0bb9f81ffdbL11), but now CircleCi will fail when it tries to spin up a server for a js-driven system spec. So this PR commits `/tmp/pids/.keep` to ensure that `/tmp/pids` will exist for spec runs. (This is the default in Rails 6.)