### PR TITLE
SRCH-1678 format click module as a string in drilldown CSV

### DIFF
--- a/app/controllers/sites/click_drilldowns_controller.rb
+++ b/app/controllers/sites/click_drilldowns_controller.rb
@@ -33,7 +33,7 @@ class Sites::ClickDrilldownsController < Sites::SetupSiteController
     record << doc['request']
     record << doc['referrer']
     record << doc['vertical']
-    record << doc['modules']
+    record << Array(doc['modules']).first
     record << (doc['useragent']['device'] rescue '')
     record << (doc['useragent']['name'] rescue '')
     record << (doc['useragent']['os'] rescue '')

--- a/app/controllers/sites/click_drilldowns_controller.rb
+++ b/app/controllers/sites/click_drilldowns_controller.rb
@@ -5,9 +5,9 @@ class Sites::ClickDrilldownsController < Sites::SetupSiteController
   HEADER_FIELDS = ['Date', 'Time', 'Query', 'Position', 'Request', 'Referrer', 'Vertical', 'Modules', 'Device', 'Browser', 'OS', 'Country Code', 'Region', 'Client IP', 'User Agent']
 
   def show
-    url = request["url"]
-    end_date = request["end_date"].to_date
-    start_date = request["start_date"].to_date
+    url = request['url']
+    end_date = request['end_date'].to_date
+    start_date = request['start_date'].to_date
     filename = [@site.name, url.first(50), start_date, end_date].join('_')
     drilldown_query = DrilldownQuery.new(@site.name,
                                          start_date,
@@ -33,7 +33,7 @@ class Sites::ClickDrilldownsController < Sites::SetupSiteController
     record << doc['request']
     record << doc['referrer']
     record << doc['vertical']
-    record << Array(doc['modules']).first
+    record << format_modules(doc['modules'])
     record << (doc['useragent']['device'] rescue '')
     record << (doc['useragent']['name'] rescue '')
     record << (doc['useragent']['os'] rescue '')

--- a/app/controllers/sites/query_drilldowns_controller.rb
+++ b/app/controllers/sites/query_drilldowns_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Sites::QueryDrilldownsController < Sites::SetupSiteController
   include CSVResponsive
   HEADER_FIELDS = ['Date', 'Time', 'Request', 'Referrer', 'Vertical', 'Modules', 'Device', 'Browser', 'OS', 'Country Code', 'Region', 'Client IP', 'User Agent']
@@ -35,7 +37,7 @@ class Sites::QueryDrilldownsController < Sites::SetupSiteController
     record << doc['request']
     record << doc['referrer']
     record << doc['vertical']
-    record << (doc['modules'].join(' ') rescue '')
+    record << format_modules(doc['modules'])
     record << (doc['useragent']['device'] rescue '')
     record << (doc['useragent']['name'] rescue '')
     record << (doc['useragent']['os'] rescue '')

--- a/lib/csv_responsive.rb
+++ b/lib/csv_responsive.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module CSVResponsive
   def csv_response(filename, header, arr)
     respond_to do |format|
@@ -11,6 +13,14 @@ module CSVResponsive
       rows.each { |row| csv << row }
     end
 
-    send_data file, type: 'text/csv; charset=utf-8; header=present', disposition: "attachment;filename=#{filename}.csv"
+    send_data(
+      file,
+      type: 'text/csv; charset=utf-8; header=present',
+      disposition: "attachment;filename=#{filename}.csv"
+    )
+  end
+
+  def format_modules(modules)
+    Array(modules).join(' ')
   end
 end

--- a/spec/controllers/sites/click_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/click_drilldowns_controller_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Sites::ClickDrilldownsController do

--- a/spec/fixtures/json/rtu_dashboard/drilldown_clicks.json
+++ b/spec/fixtures/json/rtu_dashboard/drilldown_clicks.json
@@ -42,7 +42,9 @@
             "position": 2,
             "affiliate": "usagov"
           },
-          "modules": "BWEB",
+          "modules": [
+            "BWEB"
+          ],
           "vertical": "web",
           "type": "click"
         },

--- a/spec/lib/csv_responsive_spec.rb
+++ b/spec/lib/csv_responsive_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe CSVResponsive do
+  let(:klass) { Class.new { extend CSVResponsive } }
+
+  describe '.format_modules' do
+    subject(:format_modules) { klass.format_modules(modules) }
+
+    context 'when the modules are a string' do
+      let(:modules) { 'FOO' }
+
+      it { is_expected.to eq 'FOO' }
+    end
+
+    context 'when the modules are an array' do
+      let(:modules) { %w[FOO BAR] }
+
+      it { is_expected.to eq 'FOO BAR' }
+    end
+  end
+end


### PR DESCRIPTION
This PR ensures that the click module in the downloaded CSV appears as a string (`BWEB`), regardless of whether it is stored in Elasticsearch as an array or a string.