### PR TITLE
SRCH-1649 temporarily remove link to click API instructions

### DIFF
--- a/app/controllers/sites/click_tracking_api_instructions_controller.rb
+++ b/app/controllers/sites/click_tracking_api_instructions_controller.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Sites
-  class ClickTrackingApiInstructionsController < Sites::SetupSiteController
-    def show; end
-  end
-end

--- a/app/views/sites/shared/_activate_search_sub_nav.html.haml
+++ b/app/views/sites/shared/_activate_search_sub_nav.html.haml
@@ -7,4 +7,3 @@
   %li{ site_nav_css_class_hash('type_ahead_api_instructions') }= link_to 'Type-ahead API Instructions', site_type_ahead_api_instructions_path(@site)
   - if @site.gets_i14y_results?
     %li{ site_nav_css_class_hash('i14y_api_instructions') }= link_to 'i14y Content Indexing API Instructions', site_i14y_api_instructions_path(@site)
-  %li{ site_nav_css_class_hash('click_tracking_api_instructions') }= link_to 'Click Tracking API Instructions', site_click_tracking_api_instructions_path(@site)

--- a/features/admin_center_activate_search.feature
+++ b/features/admin_center_activate_search.feature
@@ -53,6 +53,8 @@ Feature: Activate Search
     Then I should see "i14y Content Indexing API Instructions" within the Admin Center content
     And I should see "manage your i14y drawers"
 
+  # To be implemented in SRCH-1680
+  @wip
   Scenario: Visiting the Click Tracking API Instructions
     Given the following Affiliates exist:
       | display_name | name    | contact_email | first_name   | last_name         |


### PR DESCRIPTION
This PR removes the link to the click tracking API instructions, enabling us to do a soft release of the click tracking changes.