### PR TITLE
SRCH-1685 enable click referrer tracking for API users

### DIFF
--- a/app/controllers/api/v2/click_controller.rb
+++ b/app/controllers/api/v2/click_controller.rb
@@ -18,11 +18,23 @@ module Api
 
       private
 
+      def permitted_params
+        params.permit(
+          :url,
+          :query,
+          :position,
+          :module_code,
+          :affiliate,
+          :vertical,
+          :client_ip,
+          :user_agent,
+          :access_key,
+          :referrer
+        )
+      end
+
       def click_params
-        permitted = params.permit(:url, :query, :position,
-                                  :module_code, :affiliate, :vertical,
-                                  :client_ip, :user_agent, :access_key)
-        permitted.to_hash.symbolize_keys
+        permitted_params.to_hash.symbolize_keys
       end
 
       def status(click)

--- a/spec/requests/api/v2/click_spec.rb
+++ b/spec/requests/api/v2/click_spec.rb
@@ -12,7 +12,8 @@ describe '/api/v2/click' do
       vertical: 'test_vertical',
       module_code: 'BWEB',
       user_agent: 'test_user_agent',
-      access_key: 'basic_key'
+      access_key: 'basic_key',
+      referrer: 'https://search.gov/serp'
     }
   end
   let(:click_model) { ApiClick }


### PR DESCRIPTION
This fixes a bug that prevented API users from sending referrer data for a click.