### PR TITLE
SRCH-1687 log clicks on encoded URLs

### DIFF
--- a/app/models/click.rb
+++ b/app/models/click.rb
@@ -9,7 +9,7 @@ class Click
   attr_reader :affiliate, :query, :position,
               :module_code, :client_ip, :user_agent, :vertical, :referrer
 
-  before_validation :unescape_url
+  before_validation :validate_url_encoding
 
   validates :query, :position, :module_code, :client_ip, :user_agent, :url, presence: true
   validates :position, numericality: { only_integer: true,
@@ -39,11 +39,12 @@ class Click
 
   private
 
-  def unescape_url
+  # prevent validation from choking on "invalid byte sequence in UTF-8"
+  def validate_url_encoding
     return unless url
 
     unescaped_url = CGI.unescape(url)
-    self.url = unescaped_url.valid_encoding? ? unescaped_url : 'invalid URL'
+    self.url = 'invalid URL' unless unescaped_url.valid_encoding?
   end
 
   def module_code_validation

--- a/spec/models/click_spec.rb
+++ b/spec/models/click_spec.rb
@@ -64,9 +64,10 @@ describe Click do
       context 'when the URL is encoded' do
         let(:url) { 'https://search.gov/%28%3A%7C%29'  }
 
-        it 'logs the escaped URL' do
+        it 'logs the encoded URL' do
           click.log
-          expect(Rails.logger).to have_received(:info).with(%r{https://search.gov/(:|)})
+          expect(Rails.logger).to have_received(:info).
+            with(%r{https://search.gov/%28%3A%7C%29})
         end
       end
 
@@ -142,6 +143,12 @@ describe Click do
         click.validate
         expect(click.errors.full_messages).to eq ['Url is not a valid format']
       end
+    end
+
+    context 'when the URL contains a space' do
+      let(:url) { 'https://search.gov/foo%20bar'  }
+
+      it { is_expected.to be_valid }
     end
   end
 


### PR DESCRIPTION
This PR fixes a bug that blocked click tracking for certain encoded  URLs.