### PR TITLE
SRCH-1683 fix intermittent spec failure

### DIFF
--- a/spec/system/click_tracking_spec.rb
+++ b/spec/system/click_tracking_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 describe 'A user searches', js: true, vcr: { preserve_exact_body_bytes: true } do
+  before { Rails.application.env_config['HTTP_USER_AGENT'] = 'test_user_agent' }
+
+  after { Rails.application.env_config['HTTP_USER_AGENT'] = nil }
+
   context "a searchgov site" do
     let!(:affiliate) { affiliates(:searchgov_affiliate) }
 
@@ -43,7 +47,7 @@ describe 'A user searches', js: true, vcr: { preserve_exact_body_bytes: true } d
             expect(logline).to include('"position":"1"')
             expect(logline).to include('"modules":"BOOS"')
             expect(logline).to include('"vertical":"i14y"')
-            expect(logline).to include('"user_agent":')
+            expect(logline).to include('"user_agent":"test_user_agent"')
             expect(logline).to include('"referrer":')
           end
         end
@@ -83,7 +87,7 @@ describe 'A user searches', js: true, vcr: { preserve_exact_body_bytes: true } d
             expect(logline).to include('"position":"1"')
             expect(logline).to include('"modules":"BWEB"')
             expect(logline).to include('"vertical":"web"')
-            expect(logline).to include('"user_agent":')
+            expect(logline).to include('"user_agent":"test_user_agent"')
           end
         end
       end


### PR DESCRIPTION
This fixes an intermittent spec failure caused by a missing user agent at the time the click tracking system spec is run. This sets the user agent explicitly and adds a spec for the user agent logging.