### PR TITLE
SRCH-1697 extract browser info from client-side click api requests

### DIFF
--- a/app/controllers/api/v2/click_controller.rb
+++ b/app/controllers/api/v2/click_controller.rb
@@ -2,42 +2,18 @@
 
 module Api
   module V2
-    class ClickController < ApplicationController
-      skip_before_action :verify_authenticity_token
-
-      def create
-        click = ApiClick.new(click_params)
-
-        if click.valid?
-          click.log
-          head :ok
-        else
-          render json: click.errors.full_messages, status: status(click)
-        end
-      end
-
+    class ClickController < ClickedController
       private
 
+      def click_class
+        ApiClick
+      end
+
       def permitted_params
-        params.permit(
-          :url,
-          :query,
-          :position,
-          :module_code,
-          :affiliate,
-          :vertical,
-          :client_ip,
-          :user_agent,
-          :access_key,
-          :referrer
-        )
+        super.merge(params.permit(:access_key))
       end
 
-      def click_params
-        permitted_params.to_hash.symbolize_keys
-      end
-
-      def status(click)
+      def invalid_click_status
         if click.errors.full_messages.include? 'Access key is invalid'
           :unauthorized
         else

--- a/app/controllers/clicked_controller.rb
+++ b/app/controllers/clicked_controller.rb
@@ -3,18 +3,24 @@
 class ClickedController < ApplicationController
   skip_before_action :verify_authenticity_token
 
-  def index
-    click = Click.new(click_params)
+  attr_reader :click
+
+  def create
+    @click = click_class.new(click_params)
 
     if click.valid?
       click.log
       head :ok
     else
-      render json: click.errors.full_messages, status: :bad_request
+      render json: click.errors.full_messages, status: invalid_click_status
     end
   end
 
   private
+
+  def click_class
+    Click
+  end
 
   def permitted_params
     params.permit(
@@ -29,9 +35,13 @@ class ClickedController < ApplicationController
 
   def click_params
     permitted_params.to_hash.symbolize_keys.merge(
-      client_ip: request.env['REMOTE_ADDR'],
-      user_agent: request.env['HTTP_USER_AGENT'],
-      referrer: request.env['HTTP_REFERER']
+      client_ip: request.remote_ip,
+      user_agent: request.user_agent,
+      referrer: request.referer
     )
+  end
+
+  def invalid_click_status
+    :bad_request
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -34,7 +34,7 @@ Rails.application.routes.draw do
   mount SearchConsumer::API => '/api/c'
 
   get '/sayt' => 'sayt#index'
-  post '/clicked' => 'clicked#index'
+  post '/clicked' => 'clicked#create'
   get '/healthcheck' => 'health_checks#new'
   get '/login' => 'user_sessions#security_notification', as: :login
   get '/signup' => 'user_sessions#security_notification', as: :signup

--- a/spec/controllers/human_sessions_controller_spec.rb
+++ b/spec/controllers/human_sessions_controller_spec.rb
@@ -52,8 +52,12 @@ describe HumanSessionsController do
     context 'when the result is actually a success' do
       let(:challenge_outcome) { true }
 
-      before { allow(Digest::SHA256).to receive(:hexdigest).and_return('sha-na-na') }
-      before { travel_to(Time.gm(1997, 8, 4, 5, 14)) }
+      before do
+        allow(Digest::SHA256).to receive(:hexdigest).and_return('sha-na-na')
+        allow(request).to receive(:remote_ip).and_return('0.0.0.0')
+        travel_to(Time.gm(1997, 8, 4, 5, 14))
+      end
+
       after { travel_back }
 
       it 'records the "success" captcha activity' do

--- a/spec/requests/api/v2/click_spec.rb
+++ b/spec/requests/api/v2/click_spec.rb
@@ -6,34 +6,29 @@ describe '/api/v2/click' do
     {
       url: 'https://search.gov',
       query: 'test_query',
-      client_ip: '127.0.0.1',
       position: '1',
       affiliate: 'nps.gov',
       vertical: 'test_vertical',
       module_code: 'BWEB',
-      user_agent: 'test_user_agent',
-      access_key: 'basic_key',
-      referrer: 'https://search.gov/serp'
+      access_key: 'basic_key'
     }
   end
   let(:click_model) { ApiClick }
   let(:click_mock) { instance_double(click_model, log: nil) }
 
-  context 'with valid params' do
-    let(:expected_params) { valid_params }
+  include_context 'when the click request is browser-based'
+
+  it_behaves_like 'a successful click request'
+
+  context 'with authenticty token checking turned on' do
+    before do
+      ActionController::Base.allow_forgery_protection = true
+    end
 
     it_behaves_like 'a successful click request'
 
-    context 'with authenticty token checking turned on' do
-      before do
-        ActionController::Base.allow_forgery_protection = true
-      end
-
-      it_behaves_like 'a successful click request'
-
-      after do
-        ActionController::Base.allow_forgery_protection = false
-      end
+    after do
+      ActionController::Base.allow_forgery_protection = false
     end
   end
 
@@ -53,19 +48,16 @@ describe '/api/v2/click' do
       {
         url: nil,
         query: nil,
-        client_ip: nil,
         position: nil,
         affiliate: nil,
         vertical: nil,
         module_code: nil,
-        user_agent: nil,
         access_key: nil
       }
     end
     let(:expected_error_msg) do
       "[\"Query can't be blank\",\"Position can't be blank\","\
-      "\"Module code can't be blank\",\"Client ip can't be blank\","\
-      "\"User agent can't be blank\",\"Url can't be blank\","\
+      "\"Module code can't be blank\",\"Url can't be blank\","\
       "\"Affiliate can't be blank\",\"Access key can't be blank\"]"
     end
 

--- a/spec/requests/clicked_spec.rb
+++ b/spec/requests/clicked_spec.rb
@@ -15,37 +15,19 @@ describe '/clicked' do
   let(:click_model) { Click }
   let(:click_mock) { instance_double(click_model, log: nil) }
 
-  before do
-    Rails.application.env_config['HTTP_USER_AGENT'] = 'test_user_agent'
-    Rails.application.env_config['HTTP_REFERER'] = 'https://example.gov/referrer'
-  end
+  include_context 'when the click request is browser-based'
 
-  after do
-    Rails.application.env_config['HTTP_USER_AGENT'] = nil
-    Rails.application.env_config['HTTP_REFERER'] = nil
-  end
+  it_behaves_like 'a successful click request'
 
-  context 'with valid params' do
-    let(:expected_params) do
-      valid_params.merge(
-        client_ip: '127.0.0.1',
-        user_agent: 'test_user_agent',
-        referrer: 'https://example.gov/referrer'
-      )
+  context 'with authenticty token checking turned on' do
+    before do
+      ActionController::Base.allow_forgery_protection = true
     end
 
     it_behaves_like 'a successful click request'
 
-    context 'with authenticty token checking turned on' do
-      before do
-        ActionController::Base.allow_forgery_protection = true
-      end
-
-      it_behaves_like 'a successful click request'
-
-      after do
-        ActionController::Base.allow_forgery_protection = false
-      end
+    after do
+      ActionController::Base.allow_forgery_protection = false
     end
   end
 

--- a/spec/support/click_tracking_behavior.rb
+++ b/spec/support/click_tracking_behavior.rb
@@ -1,4 +1,12 @@
 shared_examples_for 'a successful click request' do
+  let(:expected_params) do
+    valid_params.merge(
+      client_ip: '127.0.0.1',
+      user_agent: 'test_user_agent',
+      referrer: 'https://example.gov/referrer'
+    )
+  end
+
   it 'is a successful request' do
     post endpoint, params: valid_params
 
@@ -67,5 +75,19 @@ shared_examples_for 'urls with invalid utf-8' do
     post endpoint, params: valid_params
 
     expect(response.body).to eq "[\"Url is not a valid format\"]"
+  end
+end
+
+shared_context 'when the click request is browser-based' do
+  before do
+    Rails.application.env_config['HTTP_USER_AGENT'] = 'test_user_agent'
+    Rails.application.env_config['HTTP_REFERER'] = 'https://example.gov/referrer'
+    Rails.application.env_config['REMOTE_ADDR'] = '127.0.0.1'
+  end
+
+  after do
+    Rails.application.env_config['HTTP_USER_AGENT'] = nil
+    Rails.application.env_config['HTTP_REFERER'] = nil
+    Rails.application.env_config['REMOTE_ADDR'] = nil
   end
 end

--- a/spec/system/click_tracking_spec.rb
+++ b/spec/system/click_tracking_spec.rb
@@ -3,9 +3,7 @@
 require 'spec_helper'
 
 describe 'A user searches', js: true, vcr: { preserve_exact_body_bytes: true } do
-  before { Rails.application.env_config['HTTP_USER_AGENT'] = 'test_user_agent' }
-
-  after { Rails.application.env_config['HTTP_USER_AGENT'] = nil }
+  include_context 'when the click request is browser-based'
 
   context "a searchgov site" do
     let!(:affiliate) { affiliates(:searchgov_affiliate) }


### PR DESCRIPTION
This PR updates our click API behavior by automatically extracting browser data from a client-side click request, rather than requiring it in the API params. It also includes some refactoring to DRY up the click controllers & specs.