### PR TITLE
SRCH-1706 add comment re. Twitter credentials

### DIFF
--- a/config/secrets.yml.dev
+++ b/config/secrets.yml.dev
@@ -46,6 +46,9 @@ secret_keys: &SECRET_KEYS
     host: 'localhost:3000'
   newrelic_secrets:
     <<: *NEWRELIC_SECRETS
+# The Twitter gem will log a deprecation warning about the usage of
+# "oauth_token" & "oauth_token_secret". The tweetstream gem uses those,
+# so updating them will require updating tweetstream.
   twitter:
     consumer_key: twitterconsumerkey
     consumer_secret: twitterconsumersecret

--- a/spec/lib/twitter_client_spec.rb
+++ b/spec/lib/twitter_client_spec.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe TwitterClient do
+  describe '.instance' do
+    subject(:instance) { described_class.instance }
+
+    it { is_expected.to be_an_instance_of(Twitter::REST::Client) }
+  end
+end


### PR DESCRIPTION
This PR was originally going to update the keys for the credentials from the deprecated `oauth_*` keys to `access_*`, but it turns out that the old `tweetstream` gem requires the old keys. So for now, I'm just adding a comment to that effect, and a simple unit test for the Twitter client itself, to verify that nothing blows up when the client is initialized.