### PR TITLE
Tweaks to RuboCop settings file.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -835,7 +835,7 @@ Layout/MultilineMethodCallIndentation:
                  that span more than one line.
   Enabled: true
   VersionAdded: 0.49
-  EnforcedStyle: indented_relative_to_receiver
+  EnforcedStyle: indented
   SupportedStyles:
     - aligned
     - indented
@@ -843,8 +843,6 @@ Layout/MultilineMethodCallIndentation:
   # By default, the indentation width from Layout/IndentationWidth is used
   # But it can be overridden by setting this parameter
   IndentationWidth: ~
-  Exclude:
-    - 'spec/**/*'
 Layout/MultilineMethodDefinitionBraceLayout:
   Description: >-
                  Checks that the closing brace in a method definition is
@@ -1641,6 +1639,11 @@ Metrics/BlockLength:
     # By default, exclude the `#refine` method, as it tends to have larger
     # associated blocks.
     - refine
+    # This cop is completely bogus for RSpec describe blocks.
+    - describe
+    - context
+    - include_context
+    - shared_examples_for
 
 Metrics/BlockNesting:
   Description: 'Avoid excessive block nesting'
@@ -4323,3 +4326,11 @@ Style/ZeroLengthPredicate:
   VersionChanged: 0.39
 
 #################### RSpec ###############################
+# See also the list of RSpec statements that we exempt from the block
+# length cop, under Metrics/BlockLength above
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Enabled: false


### PR DESCRIPTION
- Weakened indentation requirements for multi-method
  chaining (e.g. fluent interfaces). Rubocop's strong style for this is
  not the team's preference.

- Turned off block length cop for selected RSpec blocks.

- Turned off Rspec cops for example length and block nesting depth.