### PR TITLE
Turned on secure cookies.

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -76,7 +76,8 @@ module Usasearch
 
     config.i18n.enforce_available_locales = false
 
-    config.ssl_options[:secure_cookies] = false
+    config.ssl_options[:redirect] = { exclude: -> request { request.path == '/favicon.ico' } }
+
     config.active_job.queue_adapter = :resque
 
     ### Rails 5.0 config flags

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -58,6 +58,8 @@ Rails.application.configure do
   # Use an evented file watcher to asynchronously detect changes in source code,
   # routes, locales, etc. This feature depends on the listen gem.
   config.file_watcher = ActiveSupport::EventedFileUpdateChecker
+
+  config.ssl_options[:secure_cookies] = false
 end
 
 ADDITIONAL_BING_PARAMS = { 'traffictype' => 'test' }

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -45,9 +45,8 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  #  This is set to false because we redirect to https. Setting this to true causes 
-  #  issues with the healthcheck called from the loadbalancer
-  config.force_ssl = false 
+  config.force_ssl = true
+  config.ssl_options[:secure_cookies] = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -47,6 +47,8 @@ Rails.application.configure do
   config.action_view.raise_on_missing_translations = true
 
   config.active_job.queue_adapter = :test
+
+  config.ssl_options[:secure_cookies] = false
 end
 
 ADDITIONAL_BING_PARAMS = { 'traffictype' => 'test' }


### PR DESCRIPTION
Disabled force_ssl for /healthcheck. Our ELB's use that path as a
health check, and won't work right if we try to force SSL for it.