### PR TITLE
SRCH-1866 increase suggestion threshold to 100

### DIFF
--- a/app/models/sayt_suggestion_discovery.rb
+++ b/app/models/sayt_suggestion_discovery.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class SaytSuggestionDiscovery
   extend Resque::Plugins::Priority
   extend ResqueJobStats

--- a/app/models/sayt_suggestion_discovery.rb
+++ b/app/models/sayt_suggestion_discovery.rb
@@ -4,7 +4,7 @@ class SaytSuggestionDiscovery
   @queue = :primary
 
   class << self
-    MIN_DOC_COUNT = 5
+    MIN_DOC_COUNT = 100
 
     def perform(affiliate_name, affiliate_id, day_int, limit)
       day = Date.strptime(day_int.to_s, "%Y%m%d")

--- a/spec/models/sayt_suggestion_discovery_spec.rb
+++ b/spec/models/sayt_suggestion_discovery_spec.rb
@@ -13,7 +13,7 @@ describe SaytSuggestionDiscovery, "#perform(affiliate_name, affiliate_id, date_i
       affiliate.name,
       'search',
       field: 'params.query.raw',
-      min_doc_count: 5,
+      min_doc_count: 100,
       size: 10
     ]
   end

--- a/spec/models/sayt_suggestion_discovery_spec.rb
+++ b/spec/models/sayt_suggestion_discovery_spec.rb
@@ -1,11 +1,8 @@
-# coding: utf-8
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SaytSuggestionDiscovery, "#perform(affiliate_name, affiliate_id, date_int, limit)" do
-  fixtures :misspellings, :affiliates
-
-  it_behaves_like 'a ResqueJobStats job'
-
   let(:affiliate) { affiliates(:power_affiliate) }
   let(:date_int) { 20140626 }
   let(:top_n_exists_args) do
@@ -24,6 +21,8 @@ describe SaytSuggestionDiscovery, "#perform(affiliate_name, affiliate_id, date_i
                             ['today term3', 4]])
   end
 
+  it_behaves_like 'a ResqueJobStats job'
+
   context "when searches with results exist for an affiliate" do
     before do
       expect(TopNExistsQuery).to receive(:new).with(*top_n_exists_args).and_call_original
@@ -31,12 +30,12 @@ describe SaytSuggestionDiscovery, "#perform(affiliate_name, affiliate_id, date_i
     end
 
     it "should create unprotected suggestions" do
-      SaytSuggestionDiscovery.perform(affiliate.name, affiliate.id, date_int, 10)
+      described_class.perform(affiliate.name, affiliate.id, date_int, 10)
       expect(SaytSuggestion.find_by_affiliate_id_and_phrase(affiliate.id, "today term1").is_protected).to be false
     end
 
     it "should populate SaytSuggestions based on each entry for the given day" do
-      SaytSuggestionDiscovery.perform(affiliate.name, affiliate.id, date_int, 10)
+      described_class.perform(affiliate.name, affiliate.id, date_int, 10)
       expect(SaytSuggestion.find_by_affiliate_id_and_phrase(affiliate.id, "today term1")).not_to be_nil
       expect(SaytSuggestion.find_by_affiliate_id_and_phrase(affiliate.id, "today term2")).not_to be_nil
       expect(SaytSuggestion.find_by_phrase("yesterday term1")).to be_nil
@@ -48,7 +47,7 @@ describe SaytSuggestionDiscovery, "#perform(affiliate_name, affiliate_id, date_i
       end
 
       it "should update the popularity field with the new count" do
-        SaytSuggestionDiscovery.perform(affiliate.name, affiliate.id, date_int, 10)
+        described_class.perform(affiliate.name, affiliate.id, date_int, 10)
         expect(SaytSuggestion.find_by_affiliate_id_and_phrase(affiliate.id, "today term1").popularity).to eq(55)
       end
     end
@@ -59,7 +58,7 @@ describe SaytSuggestionDiscovery, "#perform(affiliate_name, affiliate_id, date_i
       end
 
       it "should not create a new suggestion, and leave the old suggestion alone" do
-        SaytSuggestionDiscovery.perform(affiliate.name, affiliate.id, date_int, 10)
+        described_class.perform(affiliate.name, affiliate.id, date_int, 10)
         suggestion = SaytSuggestion.find_by_affiliate_id_and_phrase(affiliate.id, "today term1")
         expect(suggestion.deleted_at).not_to be_nil
         expect(suggestion.popularity).to eq(SaytSuggestion::MAX_POPULARITY)
@@ -72,7 +71,7 @@ describe SaytSuggestionDiscovery, "#perform(affiliate_name, affiliate_id, date_i
       end
 
       it "should apply SaytFilters to each eligible term" do
-        SaytSuggestionDiscovery.perform(affiliate.name, affiliate.id, date_int, 10)
+        described_class.perform(affiliate.name, affiliate.id, date_int, 10)
         expect(SaytSuggestion.find_by_affiliate_id_and_phrase(affiliate.id, "today term2")).to be_nil
       end
     end
@@ -84,7 +83,7 @@ describe SaytSuggestionDiscovery, "#perform(affiliate_name, affiliate_id, date_i
       end
 
       it "should factor in the time of day to compute a projected run rate for the term's popularity that day" do
-        SaytSuggestionDiscovery.perform(affiliate.name, affiliate.id, date_int, 10)
+        described_class.perform(affiliate.name, affiliate.id, date_int, 10)
         expect(SaytSuggestion.find_by_affiliate_id_and_phrase(affiliate.id, "today term1").popularity).to eq(164)
       end
     end


### PR DESCRIPTION
This PR bumps the minimum # of searches required to create a type-ahead suggestion from 5 to 100. (Long-term, we should make this configurable in the cookbooks, but this will suffice for now.)