### PR TITLE
SRCH-1094 fix cucumber test for monthly queries downloads

### DIFF
--- a/features/admin_center_clicks_and_queries.feature
+++ b/features/admin_center_clicks_and_queries.feature
@@ -28,6 +28,6 @@ Feature: Clicks and Queries stats
 
     When I follow "Monthly Reports"
     Then I should see "Change Month"
-    When I follow "csv"
+    When I download the top monthly queries report
     Then I should get a CSV download
     And the downloaded file should include "Search Term"

--- a/features/step_definitions/site_analytics_steps.rb
+++ b/features/step_definitions/site_analytics_steps.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+When 'I download the top monthly queries report' do
+  within('#report_links') do
+    click_link('csv', match: :first)
+  end
+end


### PR DESCRIPTION
This PR resolves the following cucumber failure:
```
Scenario: Viewing the Site's Analytics

When I follow "csv"

Message:

Ambiguous match, found 2 elements matching visible link "csv" (Capybara::Ambiguous)
```