### PR TITLE
SRCH-1926 update CircleCi config to use updated ruby 2.5.5 image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,8 @@ executors:
     working_directory: ~/search-gov
 
     docker:
-      # using custom image, see .circleci/images/primary/Dockerfile
-      - image: searchgov/circleci:20190417
+      # using custom images, see .circleci/images/primary/
+      - image: searchgov/ruby:2.5.5
         environment:
           RAILS_ENV: test
 
@@ -92,7 +92,10 @@ jobs:
       - restore_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
 
-      - ruby/install-deps
+      - ruby/install-deps:
+          # Need to clear the gem cache? Set or bump the CACHE_VERSION in your
+          # CircleCi project: Project Settings > Environment Variables
+          key: gems-v{{ .Environment.CACHE_VERSION }}
 
 
   rspec:
@@ -104,7 +107,8 @@ jobs:
       - restore_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
 
-      - ruby/install-deps
+      - ruby/install-deps:
+          key: gems-v{{ .Environment.CACHE_VERSION }}
 
       - prepare_database
 
@@ -146,7 +150,9 @@ jobs:
       - restore_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
 
-      - ruby/install-deps
+      - ruby/install-deps:
+          key: gems-v{{ .Environment.CACHE_VERSION }}
+
       - prepare_database
 
       - run:
@@ -187,7 +193,8 @@ jobs:
       - restore_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
 
-      - ruby/install-deps
+      - ruby/install-deps:
+          key: gems-v{{ .Environment.CACHE_VERSION }}
 
       - attach_workspace:
           at: ~/search-gov/coverage

--- a/.circleci/images/primary/Dockerfile.ruby255
+++ b/.circleci/images/primary/Dockerfile.ruby255
@@ -4,7 +4,7 @@ FROM circleci/ruby:2.5.5-browsers-legacy
 USER root
 
 RUN apt-get update && apt-get install -y \
-  mysql-client \
+  default-mysql-client \
   libprotobuf-dev \
   protobuf-compiler
 


### PR DESCRIPTION
This PR updates the Dockerfile used to create our our custom Ruby 2.5.5 image: https://hub.docker.com/repository/docker/searchgov/ruby

It also  updates our CircleCi config to use the updated image. This lays the groundwork necessary to run our search-gov specs against multiple Ruby versions in CircleCi. I