### PR TITLE
Logout tests.

### DIFF
--- a/features/user_sessions.feature
+++ b/features/user_sessions.feature
@@ -51,8 +51,8 @@ Feature: User sessions
     Then I should be on the login page
 
   @javascript
-  Scenario: Already logged-in user logs out
-    Given I am logged in with email "affiliate_manager@fixtures.org"
+  Scenario: Already logged-in super-user logs out
+    Given I am logged in with email "affiliate_admin@fixtures.org"
     When I go to the usagov's Dashboard page
     Then I should not see "Security Notification"
     When I sign out
@@ -60,8 +60,8 @@ Feature: User sessions
     Then I should see "Security Notification"
 
   @javascript
-  Scenario: Already logged-in super-user logs out
-    Given I am logged in with email "affiliate_admin@fixtures.org"
+  Scenario: Already logged-in user logs out
+    Given I am logged in with email "affiliate_manager@fixtures.org"
     When I go to the usagov's Dashboard page
     Then I should not see "Security Notification"
     When I sign out

--- a/features/user_sessions.feature
+++ b/features/user_sessions.feature
@@ -5,11 +5,6 @@ Feature: User sessions
     Given I am logged in with email "affiliate_admin@fixtures.org"
     And I go to the login page
     Then I should see "Contact Information"
-    When I sign out
-    # SRCH-1552
-    # Commented out until we figure out how to handle login.gov sign
-    # out properly
-    # Then I should be on the login page
 
   # to be updated in SRCH-947 for login.gov
   @wip
@@ -51,9 +46,9 @@ Feature: User sessions
     Then I should be on the login page
 
   @javascript
-  Scenario: Already logged-in super-user logs out
+  Scenario: Already logged-in super admin logs out
     Given I am logged in with email "affiliate_admin@fixtures.org"
-    When I go to the usagov's Dashboard page
+    When I go to the admin home page
     Then I should not see "Security Notification"
     When I sign out
     And I go to the usagov's Dashboard page

--- a/features/user_sessions.feature
+++ b/features/user_sessions.feature
@@ -49,3 +49,21 @@ Feature: User sessions
     And the time becomes 2017-03-30 12:00
     And I follow "Add Site"
     Then I should be on the login page
+
+  @javascript
+  Scenario: Already logged-in user logs out
+    Given I am logged in with email "affiliate_manager@fixtures.org"
+    When I go to the usagov's Dashboard page
+    Then I should not see "Security Notification"
+    When I sign out
+    And I go to the usagov's Dashboard page
+    Then I should see "Security Notification"
+
+  @javascript
+  Scenario: Already logged-in super-user logs out
+    Given I am logged in with email "affiliate_admin@fixtures.org"
+    When I go to the usagov's Dashboard page
+    Then I should not see "Security Notification"
+    When I sign out
+    And I go to the usagov's Dashboard page
+    Then I should see "Security Notification"

--- a/features/user_sessions.feature
+++ b/features/user_sessions.feature
@@ -50,8 +50,8 @@ Feature: User sessions
     Given I am logged in with email "affiliate_admin@fixtures.org"
     When I go to the admin home page
     Then I should not see "Security Notification"
-    When I sign out
-    And I go to the usagov's Dashboard page
+    When I follow "Sign Out"
+    And I go to the admin home page
     Then I should see "Security Notification"
 
   @javascript

--- a/spec/controllers/user_sessions_controller_spec.rb
+++ b/spec/controllers/user_sessions_controller_spec.rb
@@ -2,6 +2,10 @@
 
 require 'spec_helper'
 
+# We actually need to use multiple befores as part of our fake
+# login
+# rubocop:disable RSpec/ScatteredSetup
+
 describe UserSessionsController do
   fixtures :users
 
@@ -22,4 +26,38 @@ describe UserSessionsController do
       it { is_expected.to redirect_to(account_path) }
     end
   end
+
+  describe 'logging out' do
+    let(:login_uri) do
+      "#{request.protocol}#{request.host_with_port}/login"
+    end
+
+    let(:id_token) { 'fake_id_token' }
+
+    let(:expected_login_dot_gov_logout_uri) do
+      base_uri = URI(Rails.application.secrets.login_dot_gov[:idp_base_url])
+      URI::HTTPS.build(
+        host: base_uri.host,
+        path: '/openid_connect/logout',
+        query: {
+          id_token_hint: id_token,
+          post_logout_redirect_uri: login_uri,
+          state: '1234567890123456789012'
+        }.to_query
+      ).to_s
+    end
+
+    before do
+      activate_authlogic
+      session[:id_token] = id_token
+    end
+
+    include_context 'approved user logged in'
+
+    before { delete :destroy }
+
+    it { is_expected.to redirect_to(expected_login_dot_gov_logout_uri) }
+  end
 end
+
+# rubocop:enable RSpec/ScatteredSetup


### PR DESCRIPTION
The RuboCop comment in `user_sessions_controller_spec.rb` could be replaced by an exclusion in the appropriate config file, since it's disabling the ScatteredSetup cop for the whole file. I judged it better to use the pseudo-comment facility, because the exclusion results from what the specs are doing, rather than from the type (system, controller, etc.) of the spec.