### PR TITLE
SRCH-1982 merge "IgnoredMethods" in Rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ inherit_from:
 inherit_mode:
   merge:
     - Exclude
+    - IgnoredMethods
 
 AllCops:
   Exclude:
@@ -25,7 +26,6 @@ Style/LambdaCall:
 
 Style/MethodCallWithArgsParentheses:
   IgnoreMacros: true
-  IgnoredMethods: ['require']
   Exclude:
     # Exclude files relying on Jbuilder DSL
     - 'app/models/elastic_data/*'


### PR DESCRIPTION
This PR ensures that `IgnoredMethods` for certain cops as specified by the `searchgov_style` gem are merged with `IgnoredMethods` specific to this repo. It also removes the existing `IgnoredMethods: ['require']` line for the `Style/MethodCallWithArgsParentheses` cop, as that is specified in searchgov_style:
https://github.com/GSA/searchgov_style/blob/main/.default.yml#L112
