### PR TITLE
SRCH-2013 remove references to disabled LineLength cop

### DIFF
--- a/app/controllers/admin/rss_feed_urls_controller.rb
+++ b/app/controllers/admin/rss_feed_urls_controller.rb
@@ -34,9 +34,7 @@ class Admin::RssFeedUrlsController < Admin::AdminController
       )
     else
       rss_feed_url.enqueue_destroy_news_items_with_404(:high)
-      # rubocop:disable LineLength
       render(plain: "You have submitted a request to delete #{rss_feed_url.url} news items with status code 404.")
-      # rubocop:enable LineLength
     end
   end
 

--- a/app/models/low_query_ctr_watcher.rb
+++ b/app/models/low_query_ctr_watcher.rb
@@ -34,8 +34,6 @@ class LowQueryCtrWatcher < Watcher
   end
 
   def transform_script
-    # rubocop:disable LineLength
     "ctx.payload.aggregations.agg.buckets.findAll(it -> it.ctr.value < #{low_ctr_threshold}).collect(it -> it.key).join('\",\"')"
-    # rubocop:enable LineLength
   end
 end


### PR DESCRIPTION
This PR silences the following warnings related to the now-disabled LineLength cop:
```
/Users/Moth/src/GSA/search-gov/app/controllers/admin/rss_feed_urls_controller.rb: Warning: no department given for LineLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
/Users/Moth/src/GSA/search-gov/app/controllers/admin/rss_feed_urls_controller.rb: Warning: no department given for LineLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
/Users/Moth/src/GSA/search-gov/app/models/low_query_ctr_watcher.rb: Warning: no department given for LineLength. Run `rubocop -a --only Migration/DepartmentName` to fix.
/Users/Moth/src/GSA/search-gov/app/models/low_query_ctr_watcher.rb: Warning: no department given for LineLength. Run `rubocop -a --only Migration/DepartmentName` to fix. 
```