### PR TITLE
SRCH-2299 add integration test for agency job search

### DIFF
--- a/features/mobile_searches.feature
+++ b/features/mobile_searches.feature
@@ -456,7 +456,7 @@ Feature: Searches using mobile device
     And I fill in "Enter your search term" with "jobs"
     And I press "Search"
     Then I should see "Federal Job Openings"
-    And I should see 10 job postings
+    And I should see at least 10 job postings
     And I should see an annual salary
     And I should see an application deadline
     And I should see an image link to "USAJobs.gov" with url for "https://www.usajobs.gov/"
@@ -475,6 +475,19 @@ Feature: Searches using mobile device
     Then I should see an image link to "USAJobs.gov" with url for "https://www.usajobs.gov/"
     And I should see "Ninguna oferta de trabajo en su región coincide con su búsqueda"
     And I should see a link to "​Más trabajos en el gobierno federal en USAJobs.gov" with url for "https://www.usajobs.gov/Search/Results?hp=public"
+
+  Scenario: Agency job search
+    Given the following Agencies exist:
+      | name                            | abbreviation | organization_codes |
+      | General Services Administration | GSA          | GS                 |
+    And the following Affiliates exist:
+      | display_name | name       | agency_abbreviation | jobs_enabled | contact_email                |
+      | English site | agency.gov | GSA                 | true         | affiliate_admin@fixtures.org |
+    When I am on agency.gov's search page
+    And I search for "jobs"
+    Then I should see "Job Openings at GSA"
+    And I should see at least 1 job posting
+    And I should see a link to "More GSA job openings on USAJobs.gov" with url for "https://www.usajobs.gov/Search/Results?a=GS&hp=public"
 
   Scenario: When using tablet device
     Given I am using a mobile device

--- a/features/mobile_searches_bing_v7.feature
+++ b/features/mobile_searches_bing_v7.feature
@@ -449,17 +449,6 @@ Feature: Searches using mobile device
     When I am on en.agency.gov's "Inactive news search" mobile news search page
     Then I should see "Inactive news search" within the SERP active navigation
 
-  Scenario: Job search
-    Given the following Affiliates exist:
-      | display_name | name   | contact_email    | first_name | last_name | jobs_enabled | search_engine |
-      | English site | usagov | admin@agency.gov | John       | Bar       | 1            | BingV7        |
-    When I am on usagov's mobile search page
-    And I fill in "Enter your search term" with "jobs"
-    And I press "Search"
-    Then I should see "Federal Job Openings"
-    And I should see an image link to "USAJobs.gov" with url for "https://www.usajobs.gov/"
-    And I should see a link to "More federal job openings on USAJobs.gov" with url for "https://www.usajobs.gov/Search/Results?hp=public"
-
   Scenario: When using tablet device
     Given I am using a mobile device
     And the following Affiliates exist:

--- a/features/step_definitions/agency_steps.rb
+++ b/features/step_definitions/agency_steps.rb
@@ -1,0 +1,10 @@
+Given "the following Agencies exist:" do |table|
+  table.hashes.each do |hash|
+    organization_codes = hash.delete('organization_codes').split(',')
+    agency = Agency.new(hash)
+    organization_codes.each do |code|
+      agency.agency_organization_codes <<  AgencyOrganizationCode.new(organization_code: code)
+    end
+    agency.save!
+  end
+end

--- a/features/step_definitions/job_steps.rb
+++ b/features/step_definitions/job_steps.rb
@@ -1,5 +1,5 @@
-Then /^I should see (\d+) job postings?$/ do |num_results|
-  page.should have_selector('.content-block-item.job.result')
+Then /^I should see at least (\d+) job postings?$/ do |num_results|
+  page.should have_selector('.content-block-item.job.result', minimum: num_results)
 end
 
 Then /I should see an annual salary/ do

--- a/features/vcr_cassettes/Searches_using_mobile_device/Agency_job_search.yml
+++ b/features/vcr_cassettes/Searches_using_mobile_device/Agency_job_search.yml
@@ -1,0 +1,6289 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.cognitive.microsoft.com/bing/v7.0/search?count=20&mkt=en-US&offset=0&q=jobs%20(site:gov%20OR%20site:mil)&responseFilter=WebPages&safeSearch=moderate&textDecorations=true&traffictype=test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - USASearch
+      Ocp-Apim-Subscription-Key:
+      - "<BING_V7_SUBSCRIPTION_ID>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, max-age=0
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - Fri, 28 May 2021 17:28:49 GMT
+      Vary:
+      - Accept-Encoding
+      P3p:
+      - CP="NON UNI COM NAV STA LOC CURa DEVa PSAa PSDa OUR IND"
+      X-Snr-Routing:
+      - '1'
+      Bingapis-Traceid:
+      - B0DFC06A21054589B27F917F410C6D20
+      Bingapis-Sessionid:
+      - 73C419B542394A06B30155FFEF846D20
+      X-Msedge-Clientid:
+      - 305166AE56466D5A235A76EB57BB6C30
+      X-Msapi-Userstate:
+      - dd9f
+      Bingapis-Market:
+      - en-US
+      X-Search-Responseinfo:
+      - InternalResponseTime=258,MSDatacenter=BN2B
+      X-Cache:
+      - CONFIG_NOCACHE
+      X-Msedge-Ref:
+      - 'Ref A: B0DFC06A21054589B27F917F410C6D20 Ref B: BLUEDGE0323 Ref C: 2021-05-28T17:29:49Z'
+      Apim-Request-Id:
+      - 7fe418ba-fa4f-45dd-9cd8-80e2e7ad0879
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Csp-Billing-Usage:
+      - CognitiveServices.BingSearchV7.Transaction=1
+      Date:
+      - Fri, 28 May 2021 17:29:49 GMT
+    body:
+      encoding: UTF-8
+      string: '{"_type": "SearchResponse", "queryContext": {"originalQuery": "jobs
+        (site:gov OR site:mil)"}, "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=jobs+(site%3agov+OR+site%3amil)",
+        "totalEstimatedMatches": 31700000, "value": [{"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0",
+        "name": "USAJOBS - The Federal Government''s Official Jobs Site", "url":
+        "https:\/\/www.usajobs.gov\/", "isFamilyFriendly": true, "displayUrl": "https:\/\/www.usajobs.gov",
+        "snippet": "USAJOBS is the Federal Government''s official one-stop source
+        for Federal jobs and employment information.", "dateLastCrawled": "2021-05-24T21:36:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1",
+        "name": "Work for Us (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/aboutus\/workwithus.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/aboutus\/workwithus.htm",
+        "snippet": "Jobs for 55+ The Experienced Services Program offers temporary
+        employment opportunities for individuals 55 years or older to work on specific
+        projects. Volunteer. Discover the many ways to volunteer, from one-time to
+        recurring opportunities for youth, families, groups, and individuals.", "dateLastCrawled":
+        "2021-05-16T16:32:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2", "name":
+        "Jobs at TSA | Transportation Security Administration", "url": "https:\/\/www.tsa.gov\/about\/jobs-at-tsa",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.tsa.gov\/about\/jobs-at-tsa",
+        "snippet": "Jobs at TSA. TSA offers a wide range of career opportunities
+        — whether you are an experienced business professional, recent college or
+        high school graduate, or transitioning military personnel. We are currently
+        hiring Transportation Security Officers (TSOs) nationwide. TSOs are the backbone
+        of TSA and represent the public face of the agency ...", "dateLastCrawled":
+        "2021-05-25T17:20:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3", "name":
+        "Waukesha County - Jobs", "url": "https:\/\/www.waukeshacounty.gov\/jobs\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.waukeshacounty.gov\/jobs",
+        "snippet": "Jobs; News Events; Social Media; Speakers Bureau; Strategic
+        Plan; Sustainability; Volunteers; WC Info; Connect with us! Facebook Linkedin
+        Twitter YouTube Flickr I Want To Services Departments We value your feedback.
+        Please visit the Customer Satisfaction Survey to tell us how ...", "dateLastCrawled":
+        "2021-05-25T10:15:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4", "name":
+        "Jobs - City of New Orleans", "url": "https:\/\/www.nola.gov\/jobs\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nola.gov\/jobs",
+        "snippet": "Jobs at the City are divided into unclassified and classified
+        service. Classified Jobs. Most city jobs are classified positions. There
+        are dozens of classified jobs listed at the City of New Orleans job portal.
+        Search Jobs. Promotional Jobs. You can apply for these jobs if you already
+        work in a classified City of New Orleans Civil Service position.", "dateLastCrawled":
+        "2021-05-25T12:18:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5", "name":
+        "Jobs | City of Philadelphia", "url": "https:\/\/www.phila.gov\/jobs\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.phila.gov\/jobs",
+        "snippet": "Jobs. Use the job board to explore current openings and find
+        work with the City of Philadelphia. To learn more about the hiring process,
+        see how to apply for a City job or internship. Interested in a civil service
+        position?", "dateLastCrawled": "2021-05-25T11:30:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6",
+        "name": "Nevada Jobs - NV", "url": "https:\/\/nv.gov\/jobs", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/nv.gov\/jobs", "snippet": "State of Nevada
+        Jobs Unemployment File for Unemployment Workplace Issues Worker''s Compensation
+        Forms Employment Quick Tips. 1. Treat finding a job like a job. Your goal
+        should be to spend more than 20 hours a week searching 2. Get involved in
+        your local community. Many hires are based on someone the employer knows 3.
+        Research the company you''re ...", "dateLastCrawled": "2021-05-24T17:38:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7",
+        "name": "Jobs - ScottsdaleAZ", "url": "http:\/\/www.scottsdaleaz.gov\/HR\/Jobs.asp",
+        "isFamilyFriendly": true, "displayUrl": "www.scottsdaleaz.gov\/HR\/Jobs.asp",
+        "snippet": "Jobs with the city of Scottsdale. Current Job Openings. Job
+        Description. Internal Opportunities. Job Interest Card. Private Jobs in
+        the city of Scottsdale. Interested in living and working in Scottsdale?
+        Search our list of active job recruitments with Scottsdale companies. Scottsdale.Jobs.",
+        "dateLastCrawled": "2021-05-25T00:26:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8",
+        "name": "IDOE School Personnel Job Bank | IDOE", "url": "https:\/\/www.doe.in.gov\/jobs",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.doe.in.gov\/jobs",
+        "snippet": "Home Jobs IDOE School Personnel Job Bank. IDOE School Personnel
+        Job Bank. Posted: Wed, 06\/12\/2019 - 9:19am Updated: Mon, 05\/17\/2021 -
+        9:20am. The purpose of the IDOE School Personnel Job Bank is to help local
+        schools post\/manage open positions and to help potential candidates search
+        for available school personnel positions throughout Indiana ...", "dateLastCrawled":
+        "2021-05-25T02:11:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9", "name":
+        "Employment - Kentucky", "url": "https:\/\/kentucky.gov\/employment\/Pages\/default.aspx",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/kentucky.gov\/employment",
+        "snippet": "A great place to live and work! Kentucky is a great place to
+        find employment! The Kentucky Career Center offers assistance in focusing
+        employment possibilities, filing unemployment claims or accessing existing
+        claims, as well as in-person assistance.", "dateLastCrawled": "2021-05-25T08:05:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10",
+        "name": "Current job openings | City of Lexington", "url": "https:\/\/www.lexingtonky.gov\/jobs",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.lexingtonky.gov\/jobs",
+        "snippet": "Jobs and contracts. City contracts, RFPs, bids and job opportunities
+        with the city government and related agencies. Licensing, permits and development.
+        Includes applications for starting a business, tax forms, building and zoning
+        permits. Neighborhoods and housing.", "dateLastCrawled": "2021-05-24T23:06:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11",
+        "name": "Jobs | City of Alexandria, VA", "url": "https:\/\/www.alexandriava.gov\/Jobs",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.alexandriava.gov\/Jobs",
+        "snippet": "Jobs. Alexandria offers wide range of job opportunities and
+        services. Work for City government or City Public Schools, find out about
+        an internship opportunity or learn about workforce development and career
+        training options. Page updated on Sep 8, 2020 at 1:10 PM + Page Menu", "dateLastCrawled":
+        "2021-05-25T09:16:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12", "name":
+        "State Employment Center - Home - Kansas", "url": "http:\/\/admin.ks.gov\/services\/state-employment-center\/sec-home",
+        "isFamilyFriendly": true, "displayUrl": "admin.ks.gov\/services\/state-employment-center\/sec-home",
+        "snippet": "Welcome to the State of Kansas Employment Center & Careers Portal!
+        Thank you for your interest in working for the State of Kansas. Find a great
+        job and meaningful work in public service to Kansas and its citizens.",
+        "dateLastCrawled": "2021-05-24T15:05:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13",
+        "name": "City of Rochester | Jobs", "url": "https:\/\/www.cityofrochester.gov\/jobs\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.cityofrochester.gov\/jobs",
+        "snippet": "Jobs The City of Rochester employs about 3,500 people in several
+        hundred occupations that focus on a single goal: provide our customers with
+        outstanding service. City employees enjoy competitive pay, generous benefits
+        and opportunities for advancement while performing work that is interesting
+        and challenging.", "dateLastCrawled": "2021-05-24T20:27:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14",
+        "name": "Jobs - PA.Gov", "url": "https:\/\/www.health.pa.gov\/topics\/Administrative\/Pages\/Jobs.aspx",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.health.pa.gov\/topics\/Administrative\/Pages\/Jobs.aspx",
+        "snippet": "Join Our Team! Learn about many DOH jobs that will allow you
+        to help people, earn great pay and receive excellent benefits!; Contribute
+        to the health of the commonwealth and receive satisfaction from helping to
+        change lives!; Grow by applying your special talents and skills in a unique
+        work environment!; Open DOH Vacancy Postings. DOH Public Health Internships",
+        "dateLastCrawled": "2021-05-24T19:22:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15",
+        "name": "Jobs - City of Huntsville", "url": "https:\/\/www.huntsvilleal.gov\/government\/jobs\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.huntsvilleal.gov\/government\/jobs",
+        "snippet": "Jobs. Application Process. Learn about the hiring process and
+        apply. Benefits & Compensation. Support services, pay and benefits for employees
+        of the City of Huntsville Equal Employment Opportunity. The City of Huntsville’s
+        non-discrimination policy as an Equal Employment Opportunity employer", "dateLastCrawled":
+        "2021-05-25T01:27:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16", "name":
+        "Careers - United States Navy", "url": "https:\/\/www.navfac.navy.mil\/jobs.html",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.navfac.navy.mil\/jobs.html",
+        "snippet": "Equal Employment Opportunity. The Department of Navy is an Equal
+        Opportunity Employer. All qualified candidates will receive consideration
+        without regard to race, color, religion, sex, national origin, age, disability,
+        marital status, political affiliation, sexual orientation, or any other non-merit
+        factor.", "dateLastCrawled": "2021-05-24T23:28:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17",
+        "name": "Job Opportunities - SPD - State of Alabama Personnel ...", "url":
+        "https:\/\/personnel.alabama.gov\/Jobs", "isFamilyFriendly": true, "displayUrl":
+        "https:\/\/personnel.alabama.gov\/Jobs", "snippet": "This is a temporary
+        job in the State service. Employees in this class perform office work which
+        consists of routine clerical stenographic and typing duties and which follows
+        well-established procedures that can be readily learned on the job.", "dateLastCrawled":
+        "2021-05-24T21:37:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18", "name":
+        "Browse City Jobs | City of San Jose", "url": "https:\/\/www.sanjoseca.gov\/your-government\/departments-offices\/human-resources\/employment\/apply-for-a-job-4903",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.sanjoseca.gov\/your-government\/departments-offices\/human-resources\/...",
+        "snippet": "The City of San José is an equal opportunity employer. Applicants
+        for all job openings will be considered without regard to age, race, color,
+        religion, sex, national origin, sexual orientation, disability, veteran status
+        or any other consideration made unlawful under any federal, state or local
+        laws.", "dateLastCrawled": "2021-05-25T13:06:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19",
+        "name": "LA County Public Health - Human Resources", "url": "http:\/\/www.publichealth.lacounty.gov\/hr\/index.htm",
+        "isFamilyFriendly": true, "displayUrl": "www.publichealth.lacounty.gov\/hr\/index.htm",
+        "snippet": "DPH Jobs for current openings The Department of Public Health
+        is an equal employment opportunity employer and has nondiscrimination policies
+        that cover applicants. These policies may be obtained from the Human Resources
+        Department.", "dateLastCrawled": "2021-05-24T06:19:00.0000000Z", "language":
+        "en", "isNavigational": false}]}, "rankingResponse": {"mainline": {"items":
+        [{"answerType": "WebPages", "resultIndex": 0, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0"}},
+        {"answerType": "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1"}},
+        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2"}},
+        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3"}},
+        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4"}},
+        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5"}},
+        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6"}},
+        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7"}},
+        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8"}},
+        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9"}},
+        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10"}},
+        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11"}},
+        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12"}},
+        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13"}},
+        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14"}},
+        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15"}},
+        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16"}},
+        {"answerType": "WebPages", "resultIndex": 17, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17"}},
+        {"answerType": "WebPages", "resultIndex": 18, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18"}},
+        {"answerType": "WebPages", "resultIndex": 19, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19"}}]}}}'
+    http_version:
+  recorded_at: Fri, 28 May 2021 17:29:50 GMT
+- request:
+    method: get
+    uri: https://data.usajobs.gov/api/search?Keyword=&LocationName&Organization=GS&Radius=75&ResultsPerPage=10
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Authorization-Key:
+      - "<JOBS_AUTHORIZATION_KEY>"
+      User-Agent:
+      - "<JOBS_USER_AGENT>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/hr+json; charset=utf-8
+      Server:
+      - Microsoft-IIS/10.0
+      X-Powered-By:
+      - ASP.NET
+      Vary:
+      - Accept-Encoding
+      Date:
+      - Fri, 28 May 2021 17:29:50 GMT
+      Transfer-Encoding:
+      - chunked
+      Connection:
+      - Transfer-Encoding
+      - keep-alive
+      Set-Cookie:
+      - akavpau_DATA_USAJ=1622223290~id=4929ee2dd7d821c60387ea24bec69de6; Domain=data.usajobs.gov;
+        Path=/; Secure; SameSite=None
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+    body:
+      encoding: UTF-8
+      string: '{"LanguageCode":"EN","SearchParameters":{},"SearchResult":{"SearchResultCount":25,"SearchResultCountAll":94,"SearchResultItems":[{"MatchedObjectId":"570960700","MatchedObjectDescriptor":{"PositionID":"20FASC168SVGOTR","PositionTitle":"IT
+        Specialist (PLCYPLAN) (2210)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/570960700","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/570960700?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"San Francisco, California","CountryCode":"United
+        States","CountrySubDivisionCode":"California","CityName":"San Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Washington,
+        District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Salt
+        Lake City, Utah","CountryCode":"United States","CountrySubDivisionCode":"Utah","CityName":"Salt
+        Lake City, Utah","Longitude":-111.88823,"Latitude":40.75952},{"LocationName":"Seattle,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Seattle,
+        Washington","Longitude":-122.32945,"Latitude":47.60358},{"LocationName":"Phoenix,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix,
+        Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"Los
+        Angeles, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Los
+        Angeles, California","Longitude":-118.245,"Latitude":34.0535},{"LocationName":"San
+        Francisco, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Denver,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Denver,
+        Colorado","Longitude":-104.992256,"Latitude":39.74001},{"LocationName":"Washington,
+        District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904},{"LocationName":"Miami,
+        Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Miami,
+        Florida","Longitude":-80.23742,"Latitude":25.728985},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Indianapolis,
+        Indiana","CountryCode":"United States","CountrySubDivisionCode":"Indiana","CityName":"Indianapolis,
+        Indiana","Longitude":-86.14996,"Latitude":39.76691},{"LocationName":"New Orleans,
+        Louisiana","CountryCode":"United States","CountrySubDivisionCode":"Louisiana","CityName":"New
+        Orleans, Louisiana","Longitude":-90.07771,"Latitude":29.95369},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Minneapolis,
+        Minnesota","CountryCode":"United States","CountrySubDivisionCode":"Minnesota","CityName":"Minneapolis,
+        Minnesota","Longitude":-93.26493,"Latitude":44.979034},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Albuquerque,
+        New Mexico","CountryCode":"United States","CountrySubDivisionCode":"New Mexico","CityName":"Albuquerque,
+        New Mexico","Longitude":-106.649,"Latitude":35.0842},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Oklahoma
+        City, Oklahoma","CountryCode":"United States","CountrySubDivisionCode":"Oklahoma","CityName":"Oklahoma
+        City, Oklahoma","Longitude":-97.52033,"Latitude":35.472004},{"LocationName":"Portland,
+        Oregon","CountryCode":"United States","CountrySubDivisionCode":"Oregon","CityName":"Portland,
+        Oregon","Longitude":-122.67563,"Latitude":45.511795},{"LocationName":"Austin,
+        Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Austin,
+        Texas","Longitude":-97.743,"Latitude":30.2676}],"OrganizationName":"Technology
+        Transformation Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Information
+        Technology Management","Code":"2210"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"TERM
+        appointment. Initial appointments to last longer than 1 year, but NTE 4 years.
+        GSA, may extend appt up to 4 additional years. No individual hired under this
+        DHA can serve in excess of 8 years with GSA.","Code":"15319"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.The
+        GS15 step 1 salary range starts at$128,078.00 per year. The total salary will
+        be determined upon selection and based on the associated GSlocality pay table
+        for yourassigned duty location.\nFor specific details on locality pay, please
+        visitOPM&rsquo;s Salaries &amp; Wages pageor for a salary calculator please
+        go toOPM''s 2019 General Schedule (GS) Salary Calculator.\nIf you are a new
+        federal employee, your starting salary will likely be set at the Step 1 of
+        the grade for which you are selected.\nQUALIFICATIONS\nBASIC REQUIREMENTS:
+        Have IT-related experience demonstrating EACH of the four competencies listed
+        below:\nAttention to Detail- This skill is generally demonstrated by assignments
+        where the applicant keeps abreast of latest technology, information, research,
+        etc., to maintain knowledge in field of expertise (for example, reads trade
+        journals, participates in professional/technical associations, maintains credentials).\nCustomer
+        Service- skill is generally demonstrated by assignments where the applicant
+        promotes or develops and maintains good working relationships with key individuals
+        or groups.\nOral Communication- This skill is generally demonstrated by assignments
+        where the applicant serves on panels, committees, or task forces as a representative
+        for the organization on technical or professional issues.\nProblem Solving
+        -This skill is generally demonstrated by assignments where the applicant monitors
+        current trends or events (for example, technological, economic, political,
+        social, educational, or employment trends or events) and applies the information
+        as appropriate;AND\nSPECIALIZED EXPERIENCE REQUIREMENTS: In addition to the
+        Basic Requirements listed above, you must have one year of specialized experience
+        equivalent to the GS-14 level in the Federal service. Specialized experienceis
+        defined as: Experience leading the development, delivery or integration of
+        highly complex digital products or services; Experience applying leading industry
+        practices in the design, development and delivery of digital products or services.
+        This experience may include experimentation based frameworks, iterative development
+        methodologies, user-centered design, planning tools or continuous delivery
+        methodologies; Experience crafting or creating product vision, strategy or
+        road maps; Experience working with cross-functional teams.","PositionRemuneration":[{"MinimumRange":"128078.0","MaximumRange":"172500.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2020-06-16","PositionEndDate":"2021-06-11","PublicationStartDate":"2020-06-16","ApplicationCloseDate":"2021-06-11","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"THIS
+        IS A PUBLIC NOTICE.\nThis position is located in GSA, Federal Acquisition
+        Service (FAS), Technology Transformation Services (TTS),Office of Clients
+        and Markets, 18F Division, Branch A. This Branch houses the different disciplines
+        needed to carry out the work of 18F including Product and Acquisition.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"15","HighGrade":"15","OrganizationCodes":"GS/GS18","Relocation":"False","HiringPath":["public"],"MCOTags":["01"],"TotalOpenings":"FEW","AppointmentExplanationText":"Term
+        appt, NTE 4 yrs","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=102808","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=102808&S=1","MajorDuties":["This
+        Notice is issued under direct-hire authority to recruit new talent to occupations
+        for which there is a severe shortage of candidates. We have a severe shortage
+        of qualified applicants for our Information Technology Specialist positions.
+        To help us fill these jobs, we have been granted &ldquo;Direct Hire Authority&rdquo;
+        or DHA for IT Specialist by Executive Order 13833. This means that when we
+        have a vacant job, we can hire any qualified candidate, either from this notice
+        or from any source. The benefit of applying to this notice is that your application
+        may be shared with a hiring manager if they request resumes from this notice.\nInitial
+        appointments are made lasting longer than 1 year, but not to exceed 4 years.
+        GSA, may extend an appointment up to 4 additional years. No individual hired
+        under this DHA can serve in excess of 8 years with GSA, and cannot be transferred
+        to positions that are not IT positions.\nKey facts about this DHA notice:
+        TTS is seeking to fill multiple TERM appointments at the GS-15 level.\nPositions
+        may be located inWashington, DC; San Francisco, CA; Chicago, IL; New York,
+        NY or Full-time Telework.\nSalary to be determined upon selection, depending
+        on duty location.\nFull Time telework is negotiable after the selection (i.e.,
+        official worksite/duty location is the residence of the selectee).\nCurrent
+        civil service employees will receive new appointments if selected under this
+        Direct Hire Authority. You must perform the following Major Duties utilizing
+        expert level skill, mastery knowledge and significant IT experience:\nExpert
+        IT Policy and Planning Consultant: Serves as a senior IT expert and authoritative
+        technical consultant within 18F. Engages with the larger and more complex
+        customer agencies to develop and revise highly complex and intricate IT policies,
+        practices, products, services, and strategies based on laws, regulations,
+        business needs, and user needs.\nApplies innovative IT theories to problems
+        not susceptible to treatment by standard methods and makes decisions or recommendations
+        significantly changing, interpreting, or developing important IT policies,
+        programs, or initiatives. Expert IT Project Leadership: Provides sound direction
+        and vision during the entire IT project. Ensures the IT project is led in
+        a manner consistent with the goals of engagement and with the right team members.
+        Engages leadership in the creation process and the project vision. Establishes
+        a shared understanding across team members and stakeholders. Provides Leadership
+        to Ad Hoc Teams: Leads cross functional teams to develop innovative IT services.
+        Plans, develops, and executes highly complex and intricate IT projects that
+        transform the manner in which work is accomplished within the federal government.
+        Relationship Management: Serves as a liaison to program personnel within the
+        agency to convey information regarding Agile Technology Program activities,
+        policies and goals; to clarify procedures; and to interpret directives as
+        needed. Utilizes interpersonal skills to develop cooperative relationships.
+        Works closely with customer agencies in a leadership role and navigates and
+        works through conflicting priorities from stakeholders. Uses empathy, creativity,
+        coalition building, situational awareness and tact to problem solve and manage
+        stakeholders."],"Education":"","Requirements":"If selected, you must meet
+        the following conditions: Receive authorization from OPM on any job offer
+        you receive, if you are or were (within the last 5 years) a political Schedule
+        A, Schedule C or Non-Career SES employee in the Executive Branch.\nServe a
+        one year probationary period, if required.\nUndergo and pass a background
+        investigation (Tier 2 investigation level).\nHave your identity and work status
+        eligibility verified if you are not a GSA employee. We will use the Department
+        of Homeland Security&rsquo;s e-Verify system for this. Any discrepancies must
+        be resolved as a condition of continued employment.\nComplete a financial
+        disclosure report to verify that no conflict, or an appearance of conflict,
+        exists between your financial interest and this position.","Evaluations":"Applications
+        will be evaluated against the basic qualifications. Qualified candidates will
+        be considered inaccordance with the Office of Personnel Management Direct
+        Hire Guidelines. Veterans'' Preference does not applyto the direct hire recruitment
+        procedures. Certain selections made under this notice will be processed as
+        newappointments to the civil service. Current civil service employees might
+        be given new appointments to the civilservice. You may not be considered for
+        the position, if any part of the application is incomplete or missing therequired
+        supporting documentation. Falsifying your background, education and/or experience
+        is cause for nothiring you or dismissing you if hired.\nAdditional assessments
+        may be used, and, if so, you will be provided with further instructions.\nIf
+        you are an Interagency Career Transition Assistance Plan eligible or a GSA
+        Career Transition Assistanceeligible, you must be considered well qualified
+        to receive priority. ICTAP/CTAP. Well qualified is defined aspossession of
+        the majority of competencies required for the position and will be determined,
+        based upon a reviewof your resume against the competencies required for the
+        position being filled. To preview questions please click here.","HowToApply":"This
+        Direct Hire Public Notice will be used to build a list/inventory of applicants
+        that may be referred as vacancies become available.\nYou must submit a complete
+        online application including any required documents prior to 11:59 pm Eastern
+        Time on the closing date of the Announcement. Errors or omissions may result
+        in your not being considered for this vacancy. You can modify/complete your
+        application any time before the vacancy date/time deadline. Simply return
+        to USAJOBS, select the vacancy, and update your application. For more detailed
+        instructions on how to apply, read the Apply for a GSA Job on the GSA website.To
+        begin, click the Apply Online button on the vacancy announcement. Sign in
+        or register on USAJobs and select a resume and documents to include in your
+        application.\nOnce you have clicked Apply for this position now, you will
+        be taken to the GSA site to complete the application process.\nClick the Apply
+        To This Vacancy and complete all steps in the application process until the
+        Confirmation indicates your application is complete. If you click Return to
+        USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this vacancy.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        before the announcement closing.","WhatToExpectNext":"This Notice is issued
+        under direct-hire authority to recruit new talent to occupations for which
+        there is a severe shortage of candidates. We have a severe shortage of qualified
+        applicants for our Information Technology positions. To help us fill these
+        jobs, we have been granted &ldquo;Direct Hire Authority&rdquo; or DHA. This
+        means that when we have a vacant job, we can hire any qualified candidate,
+        either from this notice or from any source. The benefit of applying to this
+        notice is that your application may be shared with a hiring manager if they
+        request resumes from this notice.\nThank you for your interest in working
+        for U.S. General Services Administration!","RequiredDocuments":"ALL required
+        documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are ICTAP/CTAPeligible -
+        submit a, b, and c: (a) proof of eligibility including agency notice; (b)
+        SF-50, and (c) most recent performance appraisal.\nCurrent or Former Political
+        Appointees: Submit an SF-50 (Notice of Personnel Action) or an equivalentagency
+        Notice of Personnel Action form is acceptable.","Benefits":"You will have
+        access to many benefits including: Health insurance (choose from a wide range
+        of plans)\nLife insurance coverage with several options\nSick leave and vacation
+        time, including 10 paid holidays per year\nThrift Savings Plan (similar to
+        a 401(k) plan)\nFlexible work schedules\nTransit and child care subsidies\nFlexible
+        spending accounts\nLong-term care insurance\nTraining and development","OtherInformation":"Bargaining
+        Unit status: Non Bargaining Unit\nRelocation-related expenses arenotapproved
+        and will be your responsibility. Additional vacancies may be filled from this
+        announcement as needed.\nThis vacancy announcement does notpreclude filling
+        this position by other means. Management also has the right not to fill the
+        position.","KeyRequirements":["US Citizens and National (Residents of American
+        Samoa and Swains Island)","Meet all eligibility criteria within 30 days of
+        the closing date","Register with Selective Service, if you are a male born
+        after 12/31/1959","Direct Deposit of salary check to financial organization
+        required."],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"sylvia.velez-zuniga@gsa.gov","AgencyContactPhone":"202-258-7825","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"Moderate
+        Risk (MR)","AdjudicationType":["Credentialing","Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"584187800","MatchedObjectDescriptor":{"PositionID":"21FASC052LUOTR","PositionTitle":"IT
+        Specialist (APPSW) (2210)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/584187800","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/584187800?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"San Francisco, California","CountryCode":"United
+        States","CountrySubDivisionCode":"California","CityName":"San Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Washington,
+        District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Salt
+        Lake City, Utah","CountryCode":"United States","CountrySubDivisionCode":"Utah","CityName":"Salt
+        Lake City, Utah","Longitude":-111.88823,"Latitude":40.75952},{"LocationName":"Seattle,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Seattle,
+        Washington","Longitude":-122.32945,"Latitude":47.60358},{"LocationName":"Phoenix,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix,
+        Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"Los
+        Angeles, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Los
+        Angeles, California","Longitude":-118.245,"Latitude":34.0535},{"LocationName":"San
+        Francisco, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Denver,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Denver,
+        Colorado","Longitude":-104.992256,"Latitude":39.74001},{"LocationName":"Washington,
+        District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904},{"LocationName":"Miami,
+        Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Miami,
+        Florida","Longitude":-80.23742,"Latitude":25.728985},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Indianapolis,
+        Indiana","CountryCode":"United States","CountrySubDivisionCode":"Indiana","CityName":"Indianapolis,
+        Indiana","Longitude":-86.14996,"Latitude":39.76691},{"LocationName":"New Orleans,
+        Louisiana","CountryCode":"United States","CountrySubDivisionCode":"Louisiana","CityName":"New
+        Orleans, Louisiana","Longitude":-90.07771,"Latitude":29.95369},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Minneapolis,
+        Minnesota","CountryCode":"United States","CountrySubDivisionCode":"Minnesota","CityName":"Minneapolis,
+        Minnesota","Longitude":-93.26493,"Latitude":44.979034},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Albuquerque,
+        New Mexico","CountryCode":"United States","CountrySubDivisionCode":"New Mexico","CityName":"Albuquerque,
+        New Mexico","Longitude":-106.649,"Latitude":35.0842},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Oklahoma
+        City, Oklahoma","CountryCode":"United States","CountrySubDivisionCode":"Oklahoma","CityName":"Oklahoma
+        City, Oklahoma","Longitude":-97.52033,"Latitude":35.472004},{"LocationName":"Portland,
+        Oregon","CountryCode":"United States","CountrySubDivisionCode":"Oregon","CityName":"Portland,
+        Oregon","Longitude":-122.67563,"Latitude":45.511795},{"LocationName":"Austin,
+        Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Austin,
+        Texas","Longitude":-97.743,"Latitude":30.2676}],"OrganizationName":"Technology
+        Transformation Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Information
+        Technology Management","Code":"2210"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"TERM
+        appointment. Initial appointments to last longer than 1 year, but NTE 4 years.
+        GSA, may extend appt up to 4 additional years. No individual hired under this
+        DHA can serve in excess of 8 years with GSA.","Code":"15319"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.The
+        GS15 step 1 basesalary range starts at$109,366, per year. The total salary
+        will be determined upon selection and based on the associated GSlocality pay
+        table for yourassigned duty location.\nFor specific details on locality pay,
+        please visitOPM&rsquo;s Salaries &amp; Wages pageor for a salary calculator
+        please go toOPM''s 2019 General Schedule (GS) Salary Calculator.\nIf you are
+        a new federal employee, your starting salary will likely be set at the Step
+        1 of the grade for which you are selected.\nQUALIFICATIONS\nBASIC REQUIREMENTS:
+        Have IT-related experience demonstrating EACH of the four competencies listed
+        below:\nAttention to Detail- This skill is generally demonstrated by assignments
+        where the applicant keeps abreast of latest technology, information, research,
+        etc., to maintain knowledge in field of expertise (for example, reads trade
+        journals, participates in professional/technical associations, maintains credentials).\nCustomer
+        Service- skill is generally demonstrated by assignments where the applicant
+        promotes or develops and maintains good working relationships with key individuals
+        or groups.\nOral Communication- This skill is generally demonstrated by assignments
+        where the applicant serves on panels, committees, or task forces as a representative
+        for the organization on technical or professional issues.\nProblem Solving
+        -This skill is generally demonstrated by assignments where the applicant monitors
+        current trends or events (for example, technological, economic, political,
+        social, educational, or employment trends or events) and applies the information
+        as appropriate;AND\nSPECIALIZED EXPERIENCE REQUIREMENTS: In addition to the
+        Basic Requirements listed above, you must have one year of specialized experience
+        equivalent to the GS-14 level in the Federal service. Specialized experiencefor
+        this role is defined as experience delivering projects, tools or products
+        as part of an engineering team. This includes experience developing or architecting
+        complex modern web applications or cloud infrastructure using approaches such
+        as test-driven development, continuous integration &amp; deployment, or distributed
+        version control such as github. Candidates should demonstrate experience providing
+        project leadership and experience with agile development methodologies.","PositionRemuneration":[{"MinimumRange":"126810.0","MaximumRange":"170800.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2020-11-11","PositionEndDate":"2021-07-02","PublicationStartDate":"2020-11-11","ApplicationCloseDate":"2021-07-02","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"THIS
+        IS A PUBLIC NOTICE. Notice has been amended to revise the close date to July
+        2, 2021.\nThis position is located in GSA, Federal Acquisition Service (FAS),
+        Technology Transformation Services (TTS), 18F Div and is responsible for improving
+        public&rsquo;s experience by helping federal agencies build, buy, and share
+        technology. The incumbent will serve as agency IT expert and work with customer
+        agencies to design, develop and support new or legacy applications software.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"15","HighGrade":"15","OrganizationCodes":"GS/GS18","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Term
+        appt, NTE 4 yrs","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103495","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103495&S=1","MajorDuties":["This
+        Notice is issued under direct-hire authority to recruit new talent to occupations
+        for which there is a severe shortage of candidates. We have a severe shortage
+        of qualified applicants for our Information Technology Specialist positions.
+        To help us fill these jobs, we have been granted &ldquo;Direct Hire Authority&rdquo;
+        or DHA for IT Specialist by Executive Order 13833. This means that when we
+        have a vacant job, we can hire any qualified candidate, either from this notice
+        or from any source. The benefit of submitting your materials for consideration
+        via this notice is that your submission may be shared with a hiring manager
+        if they request resumes from this notice.\nInitial appointments are made lasting
+        longer than 1 year, but not to exceed 4 years. GSA, may extend an appointment
+        up to 4 additional years. No individual hired under this DHA can serve in
+        excess of 8 years with GSA, and cannot be transferred to positions that are
+        not IT positions.\nKey facts about this DHA notice: TTS is seeking to fill
+        multiple TERM appointments at the GS15 level.\nPositions may be located inWashington,
+        DC; San Francisco, CA; Chicago, IL; New York, NY or Full-time Telework.\nSalary
+        to be determined upon selection, depending on duty location.\nFull Time telework
+        is negotiable after the selection (i.e., official worksite/duty location is
+        the residence of the selectee).\nCurrent civil service employees will receive
+        new appointments if selected under this Direct Hire Authority.\nAny selections
+        made will be contacted by Human Resources. No additional status notifications
+        will be sent.\nYour application status will not change from \"application
+        received/in review\" even after the public notice has closed.\nOnce DHA Public
+        Notice closes, no additional selections can be made. You must perform the
+        following Major Duties utilizing expert level skill, mastery knowledge and
+        significant IT experience:\nExpert Software Engineer/Applications Developer:
+        Serves as an expert software engineer/ applications developer and consultant,
+        managing and directingmultiple highly complex and innovative IT projects and
+        initiatives. This includes translating technicalspecifications into programming
+        specifications; developing, customizing, and/or acquiring applicationssoftware
+        programs; and testing, debugging, and maintaining software program. Project
+        Leadership: Provides expert technical advice, leadership, and direction on
+        all software engineering related issues forthe improvement of the product.
+        Determines project objectives and sets priorities; anticipates potentialthreats
+        and opportunities. Provides expert leadership and guidance in how to use user
+        research findingsto influence software product development.Establishes a shared
+        understanding across team members and stakeholders.\nLeads, coordinates, communicates,
+        integrates and is accountable for the overall success of the program,ensuring
+        alignment with critical agency priorities. Provides Leadership to Ad Hoc Teams:
+        Leads cross functional teams at scale or in highly complex environments to
+        develop innovative softwareand/or services. Focuses team efforts towards current
+        goals and priorities.\nPlans, develops, and executes large scale IT projects
+        that transform the manner in which work isaccomplished. Determines the size,
+        skills, and roles necessary for an ad hoc team to deliver a productand identifies
+        appropriate team members. Relationship Management: Serves as a liaison to
+        high-ranking stakeholders within GSA and customer agencies to conveyinformation
+        regarding Agile Technology Program activities, policies and goals; to clarify
+        procedures; andto interpret directives as needed.\nWorks closely with customer
+        agencies in senior leadership roles and navigates conflicting priorities fromsenior
+        stakeholders or in complex environments. Reinforces, upholds, and advocates
+        for 18F&rsquo;s coreprinciples for building IT services, including building
+        in the open, developing software using agile andlean methodologies, and using
+        user-centered design methods."],"Education":"","Requirements":"If selected,
+        you must meet the following conditions: Receive authorization from OPM on
+        any job offer you receive, if you are or were (within the last 5 years) a
+        political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nUndergo and pass
+        a background investigation (Tier 2 investigation level).\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position.","Evaluations":"Submitted
+        material will be evaluated against the basic qualifications. Qualified candidates
+        will be considered inaccordance with the Office of Personnel Management Direct
+        Hire Guidelines. Veterans'' Preference does not applyto the direct hire recruitment
+        procedures. Certain selections made under this notice will be processed as
+        newappointments to the civil service. Current civil service employees might
+        be given new appointments to the civilservice. You may not be considered for
+        the position, if any part of the application is incomplete or missing therequired
+        supporting documentation. Falsifying your background, education and/or experience
+        is cause for nothiring you or dismissing you if hired.\nIf you are an Interagency
+        Career Transition Assistance Plan eligible or a GSA Career Transition Assistanceeligible,
+        you must be considered well qualified to receive priority. ICTAP/CTAP. Well
+        qualified is defined aspossession of the majority of competencies required
+        for the position and will be determined, based upon a reviewof your resume
+        against the competencies required for the position being filled. To preview
+        questions please click here.","HowToApply":"This Direct Hire Public Notice
+        will be used to build a list/inventory of applicants that may be referred
+        as vacancies become available.\nYou must submit a complete online materials
+        packet including any required documents prior to 11:59 pm Eastern Time on
+        the closing date of the Announcement. Errors or omissions may result in your
+        not being considered for this vacancy. You can modify/complete your submission
+        any time before the vacancy date/time deadline. Simply return to USAJOBS,
+        select the vacancy, and update your submission. For more detailed instructions
+        on how to apply, read the Apply for a GSA Job on the GSA website.To begin,
+        click the Apply Online button on the vacancy announcement. Sign in or register
+        on USAJobs and select a resume and documents to include in your application.\nOnce
+        you have clicked Apply for this position now, you will be taken to the GSA
+        site to complete the application process.\nClick the Apply To This Vacancy
+        and complete all steps in the application process until the Confirmation indicates
+        your application is complete. If you click Return to USAJobs or get timed
+        out prior to receiving confirmation, your application will not be submitted
+        and cannot be considered for this vacancy.\nNote: Review the REQUIRED DOCUMENTS
+        section of this announcement to determine which apply to you and must be submitted
+        online. You may choose one or more of the following options to submit your
+        document(s): Upload (from your computer); USAJOBS (click the \"USAJOBS\" link
+        to complete the transfer process) or FAX (read the &ldquo;Fax instructions&rdquo;
+        provided prior to printing the Fax Cover Sheet and faxing your information).
+        Need Assistance in Applying? Contact the HR representative listed on the Public
+        Notice prior to the submission deadline. We are available to assist you Monday-Friday
+        during normal business hours. You must receive HR approval before deviating
+        from these instructions. Be sure to APPLY EARLY before the Public Notice closes.","WhatToExpectNext":"This
+        Notice is issued under direct-hire authority to recruit new talent to occupations
+        for which there is a severe shortage of candidates. We have a severe shortage
+        of qualified applicants for our Information Technology Specialist positions.
+        To help us fill these jobs, we have been granted &ldquo;Direct Hire Authority&rdquo;
+        or DHA. This means that when we have a vacant job, we can hire any qualified
+        candidate, either from this notice or from any source. The benefit of submitting
+        your materials for considerations to this notice is that your submission may
+        be shared with a hiring manager if they request resumes from this notice.\nThank
+        you for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are ICTAP/CTAPeligible -
+        submit a, b, and c: (a) proof of eligibility including agency notice; (b)
+        SF-50, and (c) most recent performance appraisal.\nCurrent or Former Political
+        Appointees: Submit an SF-50 (Notice of Personnel Action) or an equivalentagency
+        Notice of Personnel Action form is acceptable.","Benefits":"You will have
+        access to many benefits including: Health insurance (choose from a wide range
+        of plans)\nLife insurance coverage with several options\nSick leave and vacation
+        time, including 10 paid holidays per year\nThrift Savings Plan (similar to
+        a 401(k) plan)\nFlexible work schedules\nTransit and child care subsidies\nFlexible
+        spending accounts\nLong-term care insurance\nTraining and development","OtherInformation":"Bargaining
+        Unit status: Non Bargaining Unit\nRelocation-related expenses arenotapproved
+        and will be your responsibility. Travelexpenses associated with interviewsmaybeapproved.Determinations
+        will be made on a case-by-case basis.\nAdditional vacancies may be filled
+        from this Public Notice in this or other GSA Organizations within the same
+        commuting area through other means, or not at all.","KeyRequirements":["US
+        Citizens and National (Residents of American Samoa and Swains Island)","Meet
+        all eligibility criteria within 30 days of the closing date","Register with
+        Selective Service, if you are a male born after 12/31/1959","Direct Deposit
+        of salary check to financial organization required."],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"loyola.ukpokodu@gsa.gov","AgencyContactPhone":"816-216-3423","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"Noncritical-Sensitive
+        (NCS)/Moderate Risk","AdjudicationType":["Credentialing","Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"585251700","MatchedObjectDescriptor":{"PositionID":"21NRCA009LB-DHA","PositionTitle":"Project
+        Manager","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/585251700","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/585251700?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Birmingham, Alabama","CountryCode":"United
+        States","CountrySubDivisionCode":"Alabama","CityName":"Birmingham, Alabama","Longitude":-86.8115,"Latitude":33.5203},{"LocationName":"Huntsville,
+        Alabama","CountryCode":"United States","CountrySubDivisionCode":"Alabama","CityName":"Huntsville,
+        Alabama","Longitude":-86.585,"Latitude":34.7291},{"LocationName":"Phoenix,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix,
+        Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"Tucson,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Tucson,
+        Arizona","Longitude":-110.96976,"Latitude":32.221554},{"LocationName":"Los
+        Angeles, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Los
+        Angeles, California","Longitude":-118.245,"Latitude":34.0535},{"LocationName":"Sacramento,
+        California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Sacramento,
+        California","Longitude":-121.491,"Latitude":38.57906},{"LocationName":"San
+        Diego, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Diego, California","Longitude":-117.162,"Latitude":32.7157},{"LocationName":"San
+        Francisco, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Lakewood,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Lakewood,
+        Colorado","Longitude":-105.08274,"Latitude":39.71095},{"LocationName":"Washington,
+        District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904},{"LocationName":"Fort
+        Lauderdale, Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Fort
+        Lauderdale, Florida","Longitude":-80.14356,"Latitude":26.12367},{"LocationName":"Miami,
+        Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Miami,
+        Florida","Longitude":-80.23742,"Latitude":25.728985},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Savannah,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Savannah,
+        Georgia","Longitude":-81.09072,"Latitude":32.08078},{"LocationName":"Honolulu,
+        Hawaii","CountryCode":"United States","CountrySubDivisionCode":"Hawaii","CityName":"Honolulu,
+        Hawaii","Longitude":-157.858,"Latitude":21.3047},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Louisville,
+        Kentucky","CountryCode":"United States","CountrySubDivisionCode":"Kentucky","CityName":"Louisville,
+        Kentucky","Longitude":-85.7664,"Latitude":38.25486},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Baltimore,
+        Maryland","CountryCode":"United States","CountrySubDivisionCode":"Maryland","CityName":"Baltimore,
+        Maryland","Longitude":-76.609604,"Latitude":39.290554},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Jackson,
+        Mississippi","CountryCode":"United States","CountrySubDivisionCode":"Mississippi","CityName":"Jackson,
+        Mississippi","Longitude":-90.18049,"Latitude":32.29869},{"LocationName":"Charlotte,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Charlotte, North Carolina","Longitude":-80.83754,"Latitude":35.2225},{"LocationName":"Raleigh,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Raleigh, North Carolina","Longitude":-78.64267,"Latitude":35.78551},{"LocationName":"Camden,
+        New Jersey","CountryCode":"United States","CountrySubDivisionCode":"New Jersey","CityName":"Camden,
+        New Jersey","Longitude":-75.1191,"Latitude":39.9453},{"LocationName":"Las
+        Vegas, Nevada","CountryCode":"United States","CountrySubDivisionCode":"Nevada","CityName":"Las
+        Vegas, Nevada","Longitude":-115.14,"Latitude":36.1719},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Philadelphia,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Philadelphia,
+        Pennsylvania","Longitude":-75.16237,"Latitude":39.95227},{"LocationName":"Pittsburgh,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Pittsburgh,
+        Pennsylvania","Longitude":-79.99746,"Latitude":40.43831},{"LocationName":"Columbia,
+        South Carolina","CountryCode":"United States","CountrySubDivisionCode":"South
+        Carolina","CityName":"Columbia, South Carolina","Longitude":-81.04525,"Latitude":33.99855},{"LocationName":"Memphis,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Memphis,
+        Tennessee","Longitude":-90.04893,"Latitude":35.14968},{"LocationName":"Nashville,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Nashville,
+        Tennessee","Longitude":-86.778366,"Latitude":36.16778},{"LocationName":"Fort
+        Worth, Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Fort
+        Worth, Texas","Longitude":-97.32925,"Latitude":32.74863},{"LocationName":"Norfolk,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Norfolk,
+        Virginia","Longitude":-76.28507,"Latitude":36.846825},{"LocationName":"Richmond,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Richmond,
+        Virginia","Longitude":-77.433655,"Latitude":37.5407},{"LocationName":"Roanoke,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Roanoke,
+        Virginia","Longitude":-79.9405,"Latitude":37.2715},{"LocationName":"Auburn,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Auburn,
+        Washington","Longitude":-122.23041,"Latitude":47.3074},{"LocationName":"Charleston,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Charleston, West Virginia","Longitude":-81.63893,"Latitude":38.350216},{"LocationName":"Martinsburg,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Martinsburg, West Virginia","Longitude":-77.96456,"Latitude":39.45637}],"OrganizationName":"General
+        Services Administration - Agency Wide","DepartmentName":"General Services
+        Administration","JobCategory":[{"Name":"General Business And Industry","Code":"1101"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nStarting
+        Pay for all locations will be dependent upon the associated GS-Locality Pay
+        Table for that area.If you are a new federal employee, your starting salary
+        will likely be set at the Step 1 of the grade for which you are selected.
+        The GS-12salary range starts as low as $76,721.00 and as high as $121,668.00
+        per year, depending on the locality pay of the duty location.The GS-13salary
+        range starts as low as $91,231.00 and as high as $144,676.00 per year, depending
+        on the locality pay of the duty location.\nTo qualify for the GS-12, you must
+        have 1 year of specialized experienceequivalent to at least GS-11.\nSpecialized
+        experience is utilizing project management practices and tools to simultaneously
+        manage multiple lease acquisition, construction and/or repair and alteration
+        projects in a real estate environment. This experience must include: Managing
+        projects (balancing scope/quality, schedule and budget) requiring the services
+        of multiple disciplines (i.e., construction, design, IT, telecommunications,
+        interior furnishings, etc.) from project initiation phase through financial
+        closeout;\nInterpreting customer needs and developing them into actionable
+        requirements;\nDeveloping, managing, and balancing project plans, budgets,
+        and schedules;\nCoordinating and facilitating decisions by managing multiple
+        stakeholders;\nApplying procurement knowledge and experience to manage contracts
+        supporting assigned projects; and\nNegotiating sound real estate business
+        transactions. To qualify for the GS-13, you must have 1 year of specialized
+        experienceequivalent to at least GS-12.\nSpecialized experience isutilizing
+        project management practices and tools to simultaneously manage multiple complex
+        and high risk construction and/or repair and alteration projects in a real
+        estate environment. This experience must include:\nSpecialized experience
+        is utilizing project management practices and tools to simultaneously manage
+        multiple complex and high risk lease acquisition, construction and/or repair
+        and alteration projects in a real estate environment. This experience must
+        include: Managing complex projects (balancing scope/quality, schedule, budget
+        and risk) requiring the services of multiple disciplines (i.e., construction,
+        design, IT, telecommunications, interior furnishings, etc.) from project initiation
+        phase through financial closeout;\nInterpreting multi-level customer needs
+        and developing them into actionable requirements;\nDeveloping, managing, and
+        balancing project plans, budgets, and schedules, including assessing risk
+        and developing appropriate mitigation strategies;\nManaging multiple stakeholders
+        by developing relationship strategies;\nApplying procurement knowledge and
+        experience to manage contracts supporting assigned projects; and\nNegotiating
+        sound real estate business transactions.","PositionRemuneration":[{"MinimumRange":"77488.0","MaximumRange":"146120.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2020-11-23","PositionEndDate":"2021-09-03","PublicationStartDate":"2020-11-23","ApplicationCloseDate":"2021-09-03","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"CLOSING
+        DATE CHANGED FROM 9/30 TO 9/3/21.\nTHIS IS A PUBLIC NOTICE: Please review
+        further information below regarding how this posting will be used.\nAs a Project
+        Manager, you will be responsible for overall project management of High Risk
+        Lease Prospectus Level projects, which comprise the most major, politically
+        sensitive, and complex initiatives.\nPositions are in the Public Buildings
+        Service (PBS). These positions are being filled to directly support the Lease
+        Cost Avoidance Program.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"12","HighGrade":"13","OrganizationCodes":"GS/GS00","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103253","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103253&S=1","MajorDuties":["We
+        are currently filling many vacancies in a variety of locations. This Notice
+        is issued under direct-hire authority to recruit new talent to occupations
+        for which there is a critical need of candidates. We have a critical need
+        of qualified applicants for our Project Manager positions. To help us fill
+        these jobs, we have been granted &ldquo;Direct Hire Authority&rdquo; or DHA.
+        This means that when we have a vacant job, we can hire any qualified candidate,
+        either from this notice or from any source. The benefit of applying to this
+        notice is that your application may be shared with a hiring manager if they
+        request resumes from this notice.\nA few key facts about this DHA notice:
+        Many vacancies may be filled at the GS-12 or 13 levels.\nJobs may be located
+        in any of the metropolitan areas listed.\nAvailability of positions vary by
+        location.\nCurrent civil service employees will receive new appointments,
+        if selected under this Direct Hire Authority. Each metropolitan area will
+        independently review applications and decide who to interview. For questions
+        specifically related to any individual location, please send an inquiry (indicating
+        the location of interest) to:pbsbvacancyinquiries@gsa.gov If you have general
+        questions about this job posting, or are having difficulty applying, contact
+        us at 816-823-2006 or nrc@gsa.gov.\nFor information on DHA, please visit https://www.opm.gov/directhire/index.asp.\nYou
+        will be responsible for:\nProject Management Project Planning - Senior project
+        manager responsible for project management of prospectus level or equally
+        complex or precedent settingprojects. Establishes evaluation criteria and
+        measurements to assess projects.\nProject Execution - Manages all aspects
+        of the project''s finances. Ensures latest trends and state of the art technologies
+        in facility design, construction, alterations, space management, contracting,
+        negotiations, and knowledge management are applied. Independently develops
+        innovative solutions to address unanticipated project complications.\nProject
+        Closeout - Ensures completion of project documents; makes certain they are
+        uploaded into systems of record to track established performance metrics and
+        historical trends. Conducts and documents lessons learned. Relationship Management
+        Customer - Negotiates and coordinates project plans, budget objectives and
+        schedules with customer agencies to establish and/or manage customer expectations.
+        Informs customer officials of project status.\nStakeholders - Maintains and/or
+        oversees continuous contact with Federal, State and local officials, and the
+        media (in coordination with Public Affairs) with regard to project issues
+        and status. Briefs key leadership on costs, impact, feasibility, alternatives,
+        issues, recommendations and status of project development.\nGSA Relationships
+        - Leads and facilitates efforts and expertise of a wide range of disciplines.
+        Contract Management Directs acquisition and management of large numbers and
+        types of contracts supporting all aspects of leasing and/or Federal construction
+        projects. Monitors progress and evaluates performance against contract requirements.\nPrepares
+        or assists Contracting Officer and/or the COR in preparation of statements
+        of work, determinations, findings and solicitation documents.\nWith the Contracting
+        Officer and/or the COR, directs preparation and issuance of modifications
+        and may serve as lead negotiator for assigned projects. Oversees and/or reviews
+        project designs; coordinates development of design and specification packages
+        for purposes of bid and determines construction completion times and prepares/reviews
+        overall cost estimates. Participates in A/E and/or Lessor selection process
+        and negotiations for design supervision and post-construction contract award
+        services. Coordinates, leads and manages the design process within a lease
+        project.\nNegotiates contract specifications and design changes. Participates
+        in review of bids, contractors'' negotiations, and technical and business
+        discussions with contractors. Business Transaction Management Negotiates the
+        business transaction with customer agencies, including utilization rates and
+        financial obligations; develops complex, accurate requests for funding and
+        tracks financial obligations and expenses."],"Education":"Note: If you are
+        using foreign education to meet qualification requirements, you must send
+        a Certificate of Foreign Equivalency with your transcript in order to receive
+        credit for that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position\nYou
+        may be required to participate in the Region''s Continuity of Operations Plan
+        (COOP), representing the Service and/or GSA as a whole. This may involve participating
+        in COOP meetings and planning activities;performing mission-critical work
+        at a designated location other than the traditional GSA office site (whichmay
+        be outside of the commuting area); and ensuring that GSA''s needs are still
+        being met in the event ofan emergency, disaster or otherwise unforeseen circumstance
+        disrupting traditional office operations.","Evaluations":"Applications will
+        be evaluated against the basic qualifications. Qualified candidates will be
+        considered inaccordance with the Office of Personnel Management Direct Hire
+        Guidelines. Veterans'' Preference does not applyto the direct hire recruitment
+        procedures. Certain selections made under this notice will be processed as
+        newappointments to the civil service. Current civil service employees might
+        be given new appointments to the civilservice. You may not be considered for
+        the position, if any part of the application is incomplete or missing therequired
+        supporting documentation. Falsifying your background, education and/or experience
+        is cause for nothiring you or dismissing you if hired.\nIf you are an Interagency
+        Career Transition Assistance Plan eligible or a GSA Career Transition Assistanceeligible,
+        you must be considered well qualified to receive priority(ICTAP/CTAP). Well
+        qualified is defined aspossession of the majority of competencies or knowledge,
+        skills and abilities required for the position and will be determined, based
+        upon a reviewof your resume against the following: Mastery of business management,
+        concepts, principles and practices sufficient to permit the incumbent to serve
+        as the manager of designated major projects from planning, execution and project
+        closeout stages.\nExpert ability to manage projects impacted by multiple competing
+        priorities and requirements and to successfully integrate these requirements
+        to meet the goals and objectives outlined. Skill in allocating fiscal, staff
+        and time resources to produce maximum results.\nSkill in assessment and evaluation
+        techniques, cost/benefit analysis, acquisition planning, risk management,
+        knowledge management and forecasting are required.Ability to work with GSA
+        and Private sector electronic project management systems.\nDemonstrated expertise
+        in innovation, business acumen, communication, political and business savvy
+        to be able to facilitate decisions of a large group of people and leadership.\nComprehensive
+        knowledge of the Federal budget process and principles of budget to apply
+        to budget and financial challenges.\nMastery of the full range of qualitative
+        and quantitative analysis techniques and methodologies. Ability to assess
+        project requirements and develop recommendations that meet goals, as well
+        as integrate the goals and objectives of various stakeholders.\nAbility to
+        satisfy and support a diverse customer base by working effectively with customers,
+        assessing their needs and satisfying their expectations within sound business
+        practices. Negotiating and balancing between customer objectives and GSA objectives.\nDemonstrated
+        expertise in developing and executing relationship management strategies for
+        customers and stakeholders.\nAbility to communicate both orally and in writing.\nKnowledge
+        of procurement principles and procedures and of different types of contract
+        vehicles for various goods and services i.e. construction, leasing, design,
+        furniture, IT, etc.\nGeneral knowledge of real estate processes and programs
+        to include site acquisition, lease procurement, construction management, real
+        estate markets and financial management as it relates to real estate.Expert
+        ability to effectively manage project financial planning and analysis. Use
+        of financial management knowledge, techniques, and innovation to achieve project
+        results with on-budget, fiscal integrity. To preview questions please click
+        here.","HowToApply":"This Direct Hire Public Notice will be used to build
+        a list/inventory of applicants that may be referred as vacanciesbecome available.\nYou
+        must submit a complete online application including any required documents
+        prior to 11:59 pm Eastern Time on the closing date of the Announcement. Errors
+        or omissions may result in your not being considered for this vacancy. You
+        can modify/complete your application any time before the vacancy date/time
+        deadline. Simply return to USAJOBS, select the vacancy, and update your application.
+        For more detailed instructions on how to apply, read the Apply for a GSA Job
+        on the GSA website.To begin, click the Apply Online button on the vacancy
+        announcement. Sign in or register on USAJobs and select a resume and documents
+        to include in your application.\nOnce you have clicked Apply for this position
+        now, you will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this vacancy.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the announcement
+        closing.","WhatToExpectNext":"This Notice is issued under direct-hire authority
+        to recruit new talent to occupations for which there is a critical need of
+        candidates. We have a critical need of qualified applicants for our Project
+        Manager positions. To help us fill these jobs, we have been granted &ldquo;Direct
+        Hire Authority&rdquo; or DHA. This means that when we have a vacant job, we
+        can hire any qualified candidate, either from this notice or from any source.\nThe
+        benefit of applying to this notice is that your application may be shared
+        with a hiring manager, if they request resumes from this notice.\nThank you
+        for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are claiming veterans''
+        preference: Completed SF-15 form\nProof of your entitlement (refer to SF-15
+        for complete list).\nCopy of your Certificate of Release or Discharge From
+        Active Duty, DD-214 that shows the dates of your active duty service. If selected,
+        a DD-214 showing your type of discharge (member 4 copy) will be required prior
+        to appointment.\nIf you are claiming 10-point preference or derived preference
+        (a spouse, widow or widower, or parent of a deceased or disabled veteran),
+        submit both of the following in addition to the DD-214. If you are active
+        duty military- Certification on a letterhead from your military branch that
+        includes your rank, character of service (must be under honorable conditions)
+        &amp; military service dates including discharge/release date (must be no
+        later than 120 days after the date the certification is submitted).\nIf you
+        areICTAP/CTAPeligible-submit a, b, and c:(a)proof of eligibility including
+        agency notice;(b)SF-50, and(c)most recent performance appraisal.\nCollege
+        transcripts:If you are using some or all of your college education to meet
+        qualification requirements for this position, you must submit a photocopy
+        of your college transcript(s). If selected, an official transcript will be
+        required prior to appointment. For education completed outside the United
+        States, also submit a valid foreign credential evaluation that substantiates
+        possession of the required education.","Benefits":"You will have access to
+        many benefits including: Health insurance (choose from a wide range of plans)\nLife
+        insurance coverage with several options\nSick leave and vacation time, including
+        10 paid holidays per year\nThrift Savings Plan (similar to a 401(k) plan)\nFlexible
+        work schedules\nTransit and child care subsidies\nFlexible spending accounts\nLong-term
+        care insurance\nTraining and development","BenefitsUrl":"http://www.opm.gov/insure/federal_employ/index.asp","OtherInformation":"Bargaining
+        Unit status: Varies based on location\nTravel, transportation, and relocation
+        expenses may be paid when authorized and approved by appropriateagency officials
+        on a case by case basis.\nGSA may pay a recruitment incentive to a newly-appointed
+        employee; a relocation incentive to a currentemployee; or offer annual leave
+        service credit to an applicant with related non-federal or uniformed services
+        workexperience. Determinations to pay/allow incentives will be made on a case-by-case
+        basis, subject to fundingavailability and documentation that the position
+        is \"hard-to-fill\".\nSelected applicants may qualify for credit toward annual
+        leave accrual based on prior non-federal work experienceor uniformed service
+        experience.\nAdditional vacancies may be filled from this announcement as
+        needed. This vacancy announcement does notpreclude filling this position by
+        other means. Management also has the right not to fill the position.","KeyRequirements":["US
+        Citizens and National (Residents of American Samoa and Swains Island)","Meet
+        all eligibility criteria within 30 days of the closing date","Register with
+        Selective Service, if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"nrc@gsa.gov","AgencyContactPhone":"000-000-0000","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"585252200","MatchedObjectDescriptor":{"PositionID":"21NRCA008LB-DHA","PositionTitle":"Construction
+        Control Representative (Construction Manager)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/585252200","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/585252200?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Birmingham, Alabama","CountryCode":"United
+        States","CountrySubDivisionCode":"Alabama","CityName":"Birmingham, Alabama","Longitude":-86.8115,"Latitude":33.5203},{"LocationName":"Huntsville,
+        Alabama","CountryCode":"United States","CountrySubDivisionCode":"Alabama","CityName":"Huntsville,
+        Alabama","Longitude":-86.585,"Latitude":34.7291},{"LocationName":"Phoenix,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix,
+        Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"Tucson,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Tucson,
+        Arizona","Longitude":-110.96976,"Latitude":32.221554},{"LocationName":"Los
+        Angeles, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Los
+        Angeles, California","Longitude":-118.245,"Latitude":34.0535},{"LocationName":"Sacramento,
+        California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Sacramento,
+        California","Longitude":-121.491,"Latitude":38.57906},{"LocationName":"San
+        Diego, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Diego, California","Longitude":-117.162,"Latitude":32.7157},{"LocationName":"San
+        Francisco, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Lakewood,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Lakewood,
+        Colorado","Longitude":-105.08274,"Latitude":39.71095},{"LocationName":"Washington,
+        District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904},{"LocationName":"Fort
+        Lauderdale, Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Fort
+        Lauderdale, Florida","Longitude":-80.14356,"Latitude":26.12367},{"LocationName":"Miami,
+        Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Miami,
+        Florida","Longitude":-80.23742,"Latitude":25.728985},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Savannah,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Savannah,
+        Georgia","Longitude":-81.09072,"Latitude":32.08078},{"LocationName":"Honolulu,
+        Hawaii","CountryCode":"United States","CountrySubDivisionCode":"Hawaii","CityName":"Honolulu,
+        Hawaii","Longitude":-157.858,"Latitude":21.3047},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Louisville,
+        Kentucky","CountryCode":"United States","CountrySubDivisionCode":"Kentucky","CityName":"Louisville,
+        Kentucky","Longitude":-85.7664,"Latitude":38.25486},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Baltimore,
+        Maryland","CountryCode":"United States","CountrySubDivisionCode":"Maryland","CityName":"Baltimore,
+        Maryland","Longitude":-76.609604,"Latitude":39.290554},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Jackson,
+        Mississippi","CountryCode":"United States","CountrySubDivisionCode":"Mississippi","CityName":"Jackson,
+        Mississippi","Longitude":-90.18049,"Latitude":32.29869},{"LocationName":"Charlotte,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Charlotte, North Carolina","Longitude":-80.83754,"Latitude":35.2225},{"LocationName":"Raleigh,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Raleigh, North Carolina","Longitude":-78.64267,"Latitude":35.78551},{"LocationName":"Camden,
+        New Jersey","CountryCode":"United States","CountrySubDivisionCode":"New Jersey","CityName":"Camden,
+        New Jersey","Longitude":-75.1191,"Latitude":39.9453},{"LocationName":"Las
+        Vegas, Nevada","CountryCode":"United States","CountrySubDivisionCode":"Nevada","CityName":"Las
+        Vegas, Nevada","Longitude":-115.14,"Latitude":36.1719},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Philadelphia,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Philadelphia,
+        Pennsylvania","Longitude":-75.16237,"Latitude":39.95227},{"LocationName":"Pittsburgh,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Pittsburgh,
+        Pennsylvania","Longitude":-79.99746,"Latitude":40.43831},{"LocationName":"Columbia,
+        South Carolina","CountryCode":"United States","CountrySubDivisionCode":"South
+        Carolina","CityName":"Columbia, South Carolina","Longitude":-81.04525,"Latitude":33.99855},{"LocationName":"Memphis,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Memphis,
+        Tennessee","Longitude":-90.04893,"Latitude":35.14968},{"LocationName":"Nashville,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Nashville,
+        Tennessee","Longitude":-86.778366,"Latitude":36.16778},{"LocationName":"Fort
+        Worth, Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Fort
+        Worth, Texas","Longitude":-97.32925,"Latitude":32.74863},{"LocationName":"Norfolk,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Norfolk,
+        Virginia","Longitude":-76.28507,"Latitude":36.846825},{"LocationName":"Richmond,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Richmond,
+        Virginia","Longitude":-77.433655,"Latitude":37.5407},{"LocationName":"Roanoke,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Roanoke,
+        Virginia","Longitude":-79.9405,"Latitude":37.2715},{"LocationName":"Auburn,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Auburn,
+        Washington","Longitude":-122.23041,"Latitude":47.3074},{"LocationName":"Charleston,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Charleston, West Virginia","Longitude":-81.63893,"Latitude":38.350216},{"LocationName":"Martinsburg,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Martinsburg, West Virginia","Longitude":-77.96456,"Latitude":39.45637}],"OrganizationName":"General
+        Services Administration - Agency Wide","DepartmentName":"General Services
+        Administration","JobCategory":[{"Name":"Construction Control Technical","Code":"0809"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nStarting
+        Pay for all locations will be dependent upon the associated GS-Locality Pay
+        Table for that area.If you are a new federal employee, your starting salary
+        will likely be set at the Step 1 of the grade for which you are selected.
+        Depending on the locality pay of the duty location, the GS-12 salary range
+        starts as low as $76,721.00 and as high as $121,668.00 per year and the GS-13salary
+        range starts as low as $91,231.00 and as high as $144,676.00 per year.\nTo
+        qualify for the GS-12, you must have 1 year of specialized experienceequivalent
+        to at least GS-11.\nSpecialized experience is experience which included responsibility
+        for managing phases of a construction or alteration project. Such experience
+        must demonstrate experience defining requirements with customers; applying
+        construction and cost estimating methods and techniques; contract administration;
+        inspection and acceptance of materials and workmanship; and construction,
+        installation or repair of various types of systems used in public use buildings
+        (e.g., heating, air conditioning, fire safety, ventilation, plumbing).\nTo
+        qualify for the GS-13, you must have 1 year of specialized experienceequivalent
+        to at least GS-12.\nSpecialized experience isexperience which included responsibility
+        for developing and managing construction or alteration projects. Such experience
+        must demonstrate experience defining requirements with customers; applying
+        construction and cost estimating methods and techniques; contract administration;
+        inspection and acceptance of materials and workmanship; and construction,
+        installation or repair of various types of systems used in public use buildings
+        (e.g., heating, air conditioning, fire safety, ventilation, plumbing).","PositionRemuneration":[{"MinimumRange":"77488.0","MaximumRange":"146120.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2020-11-23","PositionEndDate":"2021-09-03","PublicationStartDate":"2020-11-23","ApplicationCloseDate":"2021-09-03","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"CLOSING
+        DATE CHANGED FROM 9/30 TO 9/3/21.\nTHIS IS A PUBLIC NOTICE: Please review
+        further information below regarding how this posting will be used.\nAs aConstruction
+        Control Representative (Construction Manager), you will be responsible for
+        complex, large, and politically sensitive prospectus projects.\nPositions
+        are in the Public Buildings Service (PBS). These positions are being filled
+        to directly support the Lease Cost Avoidance Program.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"12","HighGrade":"13","OrganizationCodes":"GS/GS00","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103252","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103252&S=1","MajorDuties":["We
+        are currently filling many vacancies in a variety of locations. This Notice
+        is issued under direct-hire authority to recruit new talent to occupations
+        for which there is a critical need of candidates. We have a critical need
+        of qualified applicants for our Construction Control Representative (Construction
+        Manager) positions. To help us fill these jobs, we have been granted &ldquo;Direct
+        Hire Authority&rdquo; or DHA. This means that when we have a vacant job, we
+        can hire any qualified candidate, either from this notice or from any source.
+        The benefit of applying to this notice is that your application may be shared
+        with a hiring manager if they request resumes from this notice.\nA few key
+        facts about this DHA notice: Many vacancies may be filled at the GS-12 or
+        13 levels.\nJobs may be located in any of the metropolitan areas listed.\nAvailability
+        of positions vary by location.\nCurrent civil service employees will receive
+        new appointments, if selected under this Direct Hire Authority. Each metropolitan
+        area will independently review applications and decide who to interview. For
+        questions specifically related to any individual location, please send an
+        inquiry (indicating the location of interest) to:pbsbvacancyinquiries@gsa.gov\nIf
+        you have general questions about this job posting, or are having difficulty
+        applying, contact us at 816-823-2006or nrc@gsa.gov.\nFor information on DHA,
+        please visit https://www.opm.gov/directhire/index.asp.\nDuties: Oversees construction
+        of lease and federal projects, either personally, or through contract construction
+        management firms.\nDevelops scopes of work, schedules, detailed fee estimates,
+        contract criteria, and other pertinent documentation if professional design
+        services from architecture and engineering (A/E) firms are required. Assists
+        Contracting Officer in negotiating contracts and design changes with A/E firms
+        in coordination with agency representatives and manages the overall planning
+        and design phase of projects.\nEvaluates and/or recommends the work of A/E
+        firms to ensure compliance with all regulations and design criteria. Administers
+        A/E contracts, as well as alteration and new construction contracts and recommends
+        approval or rejection of all or parts of the proposals.\nConducts or directs
+        contracted services (A/E firm) to conduct site investigations to determine
+        feasibility; topography; subsurface conditions; site configuration; or condition
+        of structure and essential data before initiating design.\nCoordinates with
+        others to assure that all technical areas are addressed, proper design consideration
+        is given and that the total project objectives and schedules are met. Prepares
+        and updates milestone schedules for project delivery, and reporting on project
+        status. Meets with local organizations to ensure that designs are compatible
+        with the adjacent built environment and to assess the availability of a construction
+        workforce.\nResolves or directs contracted services (A/E firm) to resolve
+        design problems. Prepares or directs contracted services"],"Education":"Note:
+        If you are using foreign education to meet qualification requirements, you
+        must send a Certificate of Foreign Equivalency with your transcript in order
+        to receive credit for that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position\nYou
+        may be required to participate in the Region''s Continuity of Operations Plan
+        (COOP), representing the Service and/or GSA as a whole. This may involve participating
+        in COOP meetings and planning activities;performing mission-critical work
+        at a designated location other than the traditional GSA office site (whichmay
+        be outside of the commuting area); and ensuring that GSA''s needs are still
+        being met in the event ofan emergency, disaster or otherwise unforeseen circumstance
+        disrupting traditional office operations.","Evaluations":"Applications will
+        be evaluated against the basic qualifications. Qualified candidates will be
+        considered inaccordance with the Office of Personnel Management Direct Hire
+        Guidelines. Veterans'' Preference does not applyto the direct hire recruitment
+        procedures. Certain selections made under this notice will be processed as
+        newappointments to the civil service. Current civil service employees might
+        be given new appointments to the civilservice. You may not be considered for
+        the position, if any part of the application is incomplete or missing therequired
+        supporting documentation. Falsifying your background, education and/or experience
+        is cause for nothiring you or dismissing you if hired.\nIf you are an Interagency
+        Career Transition Assistance Plan eligible or a GSA Career Transition Assistanceeligible,
+        you must be considered well qualified to receive priority(ICTAP/CTAP). Well
+        qualified is defined aspossession of the majority of competencies or knowledge,
+        skills and abilities required for the position and will be determined, based
+        upon a reviewof your resume against the following: Mastery of construction
+        administration and inspection methods, principles and practices.\nComprehensive
+        knowledge of the mechanical, electrical, structural, and/or architectural
+        aspects of large and complex projects, identify problems, determine solutions,
+        make decisions and commit to a course of action.\nKnowledge of Project Management,
+        Architecture, Construction, and Engineering concepts, principles, and practices
+        sufficient to permit the incumbent to serve as the Senior Construction Manager
+        concerned with the repair, alteration, preservation, restoration, rehabilitation,
+        and/or new construction of various building projects from the preliminary
+        planning stage through the design, construction, and commissioning stages
+        to the point of occupancy.\nKnowledge and skills sufficient to read and interpret
+        plans and specifications, interpret consultation practices and procedures,
+        provide quality assurance or required inspection for materials, workmanship
+        and installation of various systems, as wells as monitor and advise on safety
+        and environmental practices.\nKnowledge of interpersonal skills necessary
+        to build, lead, and maintain a diverse team through a long and complex process,
+        resulting in all team members and stakeholders participating efficiently and
+        effectively to achieve the common goal of completing a successful project.\nKnowledge
+        of related disciplines such as architecture, landscape architecture, and mechanical,
+        electrical, civil, and structural engineering. To preview questions please
+        click here.","HowToApply":"This Direct Hire Public Notice will be used to
+        build a list/inventory of applicants that may be referred as vacanciesbecome
+        available.\nYou must submit a complete online application including any required
+        documents prior to 11:59 pm Eastern Time on the closing date of the Announcement.
+        Errors or omissions may result in your not being considered for this vacancy.
+        You can modify/complete your application any time before the vacancy date/time
+        deadline. Simply return to USAJOBS, select the vacancy, and update your application.
+        For more detailed instructions on how to apply, read the Apply for a GSA Job
+        on the GSA website.To begin, click the Apply Online button on the vacancy
+        announcement. Sign in or register on USAJobs and select a resume and documents
+        to include in your application.\nOnce you have clicked Apply for this position
+        now, you will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this vacancy.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the announcement
+        closing.","WhatToExpectNext":"This Notice is issued under direct-hire authority
+        to recruit new talent to occupations for which there is a critical need of
+        candidates. We have a critical need of qualified applicants for our Construction
+        Control Representative (Construction Manager) positions. To help us fill these
+        jobs, we have been granted &ldquo;Direct Hire Authority&rdquo; or DHA. This
+        means that when we have a vacant job, we can hire any qualified candidate,
+        either from this notice or from any source.\nThe benefit of applying to this
+        notice is that your application may be shared with a hiring manager if they
+        request resumes from this notice.\nThank you for your interest in working
+        for U.S. General Services Administration!","RequiredDocuments":"ALL required
+        documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are claiming veterans''
+        preference: Completed SF-15 form\nProof of your entitlement (refer to SF-15
+        for complete list).\nCopy of your Certificate of Release or Discharge From
+        Active Duty, DD-214 that shows the dates of your active duty service. If selected,
+        a DD-214 showing your type of discharge (member 4 copy) will be required prior
+        to appointment.\nIf you are claiming 10-point preference or derived preference
+        (a spouse, widow or widower, or parent of a deceased or disabled veteran),
+        submit both of the following in addition to the DD-214. If you are active
+        duty military- Certification on a letterhead from your military branch that
+        includes your rank, character of service (must be under honorable conditions)
+        &amp; military service dates including discharge/release date (must be no
+        later than 120 days after the date the certification is submitted).\nIf you
+        areICTAP/CTAPeligible-submit a, b, and c:(a)proof of eligibility including
+        agency notice;(b)SF-50, and(c)most recent performance appraisal.\nCollege
+        transcripts:If you are using some or all of your college education to meet
+        qualification requirements for this position, you must submit a photocopy
+        of your college transcript(s). If selected, an official transcript will be
+        required prior to appointment. For education completed outside the United
+        States, also submit a valid foreign credential evaluation that substantiates
+        possession of the required education.","Benefits":"You will have access to
+        many benefits including: Health insurance (choose from a wide range of plans)\nLife
+        insurance coverage with several options\nSick leave and vacation time, including
+        10 paid holidays per year\nThrift Savings Plan (similar to a 401(k) plan)\nFlexible
+        work schedules\nTransit and child care subsidies\nFlexible spending accounts\nLong-term
+        care insurance\nTraining and development","BenefitsUrl":"http://www.opm.gov/insure/federal_employ/index.asp","OtherInformation":"Bargaining
+        Unit status: Varies based on location\nTravel, transportation, and relocation
+        expenses may be paid when authorized and approved by appropriateagency officials
+        on a case by case basis.\nGSA may pay a recruitment incentive to a newly-appointed
+        employee; a relocation incentive to a currentemployee; or offer annual leave
+        service credit to an applicant with related non-federal or uniformed services
+        workexperience. Determinations to pay/allow incentives will be made on a case-by-case
+        basis, subject to fundingavailability and documentation that the position
+        is \"hard-to-fill\".\nSelected applicants may qualify for credit toward annual
+        leave accrual based on prior non-federal work experienceor uniformed service
+        experience.\nAdditional vacancies may be filled from this announcement as
+        needed. This vacancy announcement does notpreclude filling this position by
+        other means. Management also has the right not to fill the position.","KeyRequirements":["US
+        Citizens and National (Residents of American Samoa and Swains Island)","Meet
+        all eligibility criteria within 30 days of the closing date","Register with
+        Selective Service, if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"nrc@gsa.gov","AgencyContactPhone":"000-000-0000","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"585252700","MatchedObjectDescriptor":{"PositionID":"21NRCA007LB-DHA","PositionTitle":"Construction
+        Analyst (Cost Estimator)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/585252700","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/585252700?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Birmingham, Alabama","CountryCode":"United
+        States","CountrySubDivisionCode":"Alabama","CityName":"Birmingham, Alabama","Longitude":-86.8115,"Latitude":33.5203},{"LocationName":"Huntsville,
+        Alabama","CountryCode":"United States","CountrySubDivisionCode":"Alabama","CityName":"Huntsville,
+        Alabama","Longitude":-86.585,"Latitude":34.7291},{"LocationName":"Phoenix,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix,
+        Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"Tucson,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Tucson,
+        Arizona","Longitude":-110.96976,"Latitude":32.221554},{"LocationName":"Los
+        Angeles, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Los
+        Angeles, California","Longitude":-118.245,"Latitude":34.0535},{"LocationName":"Sacramento,
+        California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Sacramento,
+        California","Longitude":-121.491,"Latitude":38.57906},{"LocationName":"San
+        Diego, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Diego, California","Longitude":-117.162,"Latitude":32.7157},{"LocationName":"San
+        Francisco, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Lakewood,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Lakewood,
+        Colorado","Longitude":-105.08274,"Latitude":39.71095},{"LocationName":"District
+        of Columbia, District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"District of Columbia, District of Columbia","Longitude":-77.03196,"Latitude":38.89037},{"LocationName":"Fort
+        Lauderdale, Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Fort
+        Lauderdale, Florida","Longitude":-80.14356,"Latitude":26.12367},{"LocationName":"Miami,
+        Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Miami,
+        Florida","Longitude":-80.23742,"Latitude":25.728985},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Savannah,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Savannah,
+        Georgia","Longitude":-81.09072,"Latitude":32.08078},{"LocationName":"Honolulu,
+        Hawaii","CountryCode":"United States","CountrySubDivisionCode":"Hawaii","CityName":"Honolulu,
+        Hawaii","Longitude":-157.858,"Latitude":21.3047},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Louisville,
+        Kentucky","CountryCode":"United States","CountrySubDivisionCode":"Kentucky","CityName":"Louisville,
+        Kentucky","Longitude":-85.7664,"Latitude":38.25486},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Baltimore,
+        Maryland","CountryCode":"United States","CountrySubDivisionCode":"Maryland","CityName":"Baltimore,
+        Maryland","Longitude":-76.609604,"Latitude":39.290554},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Jackson,
+        Mississippi","CountryCode":"United States","CountrySubDivisionCode":"Mississippi","CityName":"Jackson,
+        Mississippi","Longitude":-90.18049,"Latitude":32.29869},{"LocationName":"Charlotte,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Charlotte, North Carolina","Longitude":-80.83754,"Latitude":35.2225},{"LocationName":"Raleigh,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Raleigh, North Carolina","Longitude":-78.64267,"Latitude":35.78551},{"LocationName":"Camden,
+        New Jersey","CountryCode":"United States","CountrySubDivisionCode":"New Jersey","CityName":"Camden,
+        New Jersey","Longitude":-75.1191,"Latitude":39.9453},{"LocationName":"Las
+        Vegas, Nevada","CountryCode":"United States","CountrySubDivisionCode":"Nevada","CityName":"Las
+        Vegas, Nevada","Longitude":-115.14,"Latitude":36.1719},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Philadelphia,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Philadelphia,
+        Pennsylvania","Longitude":-75.16237,"Latitude":39.95227},{"LocationName":"Pittsburgh,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Pittsburgh,
+        Pennsylvania","Longitude":-79.99746,"Latitude":40.43831},{"LocationName":"Columbia,
+        South Carolina","CountryCode":"United States","CountrySubDivisionCode":"South
+        Carolina","CityName":"Columbia, South Carolina","Longitude":-81.04525,"Latitude":33.99855},{"LocationName":"Memphis,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Memphis,
+        Tennessee","Longitude":-90.04893,"Latitude":35.14968},{"LocationName":"Nashville,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Nashville,
+        Tennessee","Longitude":-86.778366,"Latitude":36.16778},{"LocationName":"Fort
+        Worth, Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Fort
+        Worth, Texas","Longitude":-97.32925,"Latitude":32.74863},{"LocationName":"Norfolk,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Norfolk,
+        Virginia","Longitude":-76.28507,"Latitude":36.846825},{"LocationName":"Richmond,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Richmond,
+        Virginia","Longitude":-77.433655,"Latitude":37.5407},{"LocationName":"Roanoke,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Roanoke,
+        Virginia","Longitude":-79.9405,"Latitude":37.2715},{"LocationName":"Auburn,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Auburn,
+        Washington","Longitude":-122.23041,"Latitude":47.3074},{"LocationName":"Charleston,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Charleston, West Virginia","Longitude":-81.63893,"Latitude":38.350216},{"LocationName":"Martinsburg,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Martinsburg, West Virginia","Longitude":-77.96456,"Latitude":39.45637}],"OrganizationName":"General
+        Services Administration - Agency Wide","DepartmentName":"General Services
+        Administration","JobCategory":[{"Name":"Construction Analyst","Code":"0828"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nStarting
+        Pay for all locations will be dependent upon the associated GS-Locality Pay
+        Table for that area.If you are a new federal employee, your starting salary
+        will likely be set at the Step 1 of the grade for which you are selected.
+        Depending on the locality pay of the duty location, the GS-12 salary range
+        starts as low as $76,721.00 and as high as $121,668 and the GS-13salary range
+        starts as low as $91,231.00 and as high as $144,676.00 per year.\nTo qualify
+        for the GS-12, you must have 1 year of specialized experienceequivalent to
+        at least GS-11.\nSpecialized experience is the preparation of plans, specifications
+        and estimates of materials and costs for the construction, extension, alteration,
+        or repair of government, institutional or commercial buildings.\nTo qualify
+        for the GS-13, you must have 1 year of specialized experienceequivalent to
+        at least GS-12.\nSpecialized experience isthe preparation of plans, specifications
+        and estimates of materials and costs for the construction, extension, alteration,
+        or repair of commercial buildings for multi-million dollar government, institutional
+        or commercial projects.","PositionRemuneration":[{"MinimumRange":"77488.0","MaximumRange":"146120.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2020-11-23","PositionEndDate":"2021-09-03","PublicationStartDate":"2020-11-23","ApplicationCloseDate":"2021-09-03","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"THIS
+        IS A PUBLIC NOTICE: Please review further information below regarding how
+        this posting will be used.\nAs aConstruction Analyst (Cost Estimator), you
+        will serve as an Estimator and Scheduler for all types of projects, from prospectus
+        level to small program level projects, and serve as the cost manager advocate
+        for the Division.\nPositions are in the Public Buildings Service (PBS). These
+        positions are being filled to directly support the Lease Cost Avoidance Program.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"12","HighGrade":"13","OrganizationCodes":"GS/GS00","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103251","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103251&S=1","MajorDuties":["CLOSING
+        DATE CHANGED FROM 9/30 TO 9/3/21.\nWe are currently filling many vacancies
+        in a variety of locations. This Notice is issued under direct-hire authority
+        to recruit new talent to occupations for which there is a critical need of
+        candidates. We have a critical need of qualified applicants for our Construction
+        Analyst (Cost Estimator) positions. To help us fill these jobs, we have been
+        granted &ldquo;Direct Hire Authority&rdquo; or DHA. This means that when we
+        have a vacant job, we can hire any qualified candidate, either from this notice
+        or from any source. The benefit of applying to this notice is that your application
+        may be shared with a hiring manager if they request resumes from this notice.\nA
+        few key facts about this DHA notice: Many vacancies may be filled at the GS-12
+        and 13 levels.\nJobs may be located in any of the metropolitan areas listed.\nAvailability
+        of positions vary by location.\nCurrent civil service employees will receive
+        new appointment, if selected under this Direct Hire Authority. Each metropolitan
+        area will independently review applications and decide who to interview. For
+        questions specifically related to any individual location, please send an
+        inquiry (indicating the location of interest) to:pbsbvacancyinquiries@gsa.gov\nIf
+        you have general questions about this job posting, or are having difficulty
+        applying, contact us at 816-823-2006or nrc@gsa.gov.\nFor information on DHA,
+        please visit https://www.opm.gov/directhire/index.asp.\nDuties: Prepares cost
+        estimates with bid level detail for new construction, modernization, lease
+        construction,renovation, repair and lease alteration projectsand provides
+        expertise and guidance to project managers on cost, pricing, market, and related
+        items.\nReviews and verifies A/E cost estimates for major systems, large buildings
+        and provides consultation with A/E estimators and Project Managers.\nReviews,
+        verifies, and identifies cost negotiation items within the tenant improvement
+        cost summary from the lessor.\nProvides consultation and review services for
+        costs and technical review to design teams to ensure projects are designed
+        within budget.\nDevelops, prepares, and analyzes detailed construction schedules
+        for new, repair and alterations prospectus level design and construction projects
+        for the region as needed, including major multi&shy;-year projects for new
+        Federal construction involving estimates of hundreds of millions of dollars.\nSupports
+        or represents lease contracting officers in negotiation with construction
+        company representatives and attorneys to settle significant or controversial
+        claim issues involving estimated costs and payments.\nImplements cost management
+        quality control procedures, including maintaining common project phase checkpoints
+        for cost and budget checks."],"Education":"Note: If you are using foreign
+        education to meet qualification requirements, you must send a Certificate
+        of Foreign Equivalency with your transcript in order to receive credit for
+        that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position\nYou
+        may be required to participate in the Region''s Continuity of Operations Plan
+        (COOP), representing the Service and/or GSA as a whole. This may involve participating
+        in COOP meetings and planning activities;performing mission-critical work
+        at a designated location other than the traditional GSA office site (whichmay
+        be outside of the commuting area); and ensuring that GSA''s needs are still
+        being met in the event ofan emergency, disaster or otherwise unforeseen circumstance
+        disrupting traditional office operations.","Evaluations":"Applications will
+        be evaluated against the basic qualifications. Qualified candidates will be
+        considered inaccordance with the Office of Personnel Management Direct Hire
+        Guidelines. Veterans'' Preference does not applyto the direct hire recruitment
+        procedures. Certain selections made under this notice will be processed as
+        newappointments to the civil service. Current civil service employees might
+        be given new appointments to the civilservice. You may not be considered for
+        the position, if any part of the application is incomplete or missing therequired
+        supporting documentation. Falsifying your background, education and/or experience
+        is cause for nothiring you or dismissing you if hired.\nIf you are an Interagency
+        Career Transition Assistance Plan eligible or a GSA Career Transition Assistanceeligible,
+        you must be considered well qualified to receive priority(ICTAP/CTAP). Well
+        qualified is defined aspossession of the majority of competencies or knowledge,
+        skills and abilities required for the position and will be determined, based
+        upon a reviewof your resume against the following: Mastery knowledge of the
+        different technical methods and techniques for cost estimating and scheduling,
+        acquired by extensive experience in the design and construction industry.\nAbility
+        to accomplish a full range of duties associated with cost estimating complex,
+        multi-&shy;year Government building projects.\nTechnical knowledge of mechanical,
+        electrical, structural, architecture including finishes and special construction
+        to provide cost estimates for these projects.\nAbility to conduct market research
+        on construction activities and identify construction labor and material costs
+        trends in upcoming GSA project locations\nUse judgment and initiative in applying
+        and adapting cost engineering where significant departures from established
+        practices and precedents result from factors such as unusual local conditions,
+        complex or unforeseen environmental or site issues, or other state of the
+        art project matters which substantially impact cost considerations.\nTechnical
+        knowledge of construction methods, cost estimating and scheduling principles
+        for the Design and Construction industry.\nKnowledge and skill to evaluate
+        and incorporate new developments and exercise judgment to solve a variety
+        of complex problems.\nInterprets policy and requirements in terms of established
+        objectives\nAbility to implement a Quality Control program for Cost Estimating\nAbility
+        to coordinate the work with other technical specialists or staff from other
+        divisions as necessary\nAbility to advise regional program managers, project
+        managers, architects, engineers, other estimating personnel, schedulers, subject
+        matter experts, and construction representatives on a diverse range of issues,
+        projects, and concerns.\nAbility to effectively communicate technical issues
+        orally and in writing.\nAbility to coordinate work efforts with other GSA
+        architects and engineers; to exchange information; and to jointly discuss
+        possible resolutions to technical and cost problems. To preview questions
+        please click here.","HowToApply":"This Direct Hire Public Notice will be used
+        to build a list/inventory of applicants that may be referred as vacanciesbecome
+        available.\nYou must submit a complete online application including any required
+        documents prior to 11:59 pm Eastern Time on the closing date of the Announcement.
+        Errors or omissions may result in your not being considered for this vacancy.
+        You can modify/complete your application any time before the vacancy date/time
+        deadline. Simply return to USAJOBS, select the vacancy, and update your application.
+        For more detailed instructions on how to apply, read the Apply for a GSA Job
+        on the GSA website.To begin, click the Apply Online button on the vacancy
+        announcement. Sign in or register on USAJobs and select a resume and documents
+        to include in your application.\nOnce you have clicked Apply for this position
+        now, you will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this vacancy.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the announcement
+        closing.","WhatToExpectNext":"This Notice is issued under direct-hire authority
+        to recruit new talent to occupations for which there is a critical need of
+        candidates. We have a critical need of qualified applicants for our Construction
+        Analyst (Cost Estimator) positions. To help us fill these jobs, we have been
+        granted &ldquo;Direct Hire Authority&rdquo; or DHA. This means that when we
+        have a vacant job, we can hire any qualified candidate, either from this notice
+        or from any source.\nThe benefit of applying to this notice is that your application
+        may be shared with a hiring manager, if they request resumes from this notice.\nThank
+        you for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are claiming veterans''
+        preference: Completed SF-15 form\nProof of your entitlement (refer to SF-15
+        for complete list).\nCopy of your Certificate of Release or Discharge From
+        Active Duty, DD-214 that shows the dates of your active duty service. If selected,
+        a DD-214 showing your type of discharge (member 4 copy) will be required prior
+        to appointment.\nIf you are claiming 10-point preference or derived preference
+        (a spouse, widow or widower, or parent of a deceased or disabled veteran),
+        submit both of the following in addition to the DD-214. If you are active
+        duty military- Certification on a letterhead from your military branch that
+        includes your rank, character of service (must be under honorable conditions)
+        &amp; military service dates including discharge/release date (must be no
+        later than 120 days after the date the certification is submitted).\nIf you
+        areICTAP/CTAPeligible-submit a, b, and c:(a)proof of eligibility including
+        agency notice;(b)SF-50, and(c)most recent performance appraisal.\nCollege
+        transcripts:If you are using some or all of your college education to meet
+        qualification requirements for this position, you must submit a photocopy
+        of your college transcript(s). If selected, an official transcript will be
+        required prior to appointment. For education completed outside the United
+        States, also submit a valid foreign credential evaluation that substantiates
+        possession of the required education.","Benefits":"You will have access to
+        many benefits including: Health insurance (choose from a wide range of plans)\nLife
+        insurance coverage with several options\nSick leave and vacation time, including
+        10 paid holidays per year\nThrift Savings Plan (similar to a 401(k) plan)\nFlexible
+        work schedules\nTransit and child care subsidies\nFlexible spending accounts\nLong-term
+        care insurance\nTraining and development","BenefitsUrl":"http://www.opm.gov/insure/federal_employ/index.asp","OtherInformation":"Bargaining
+        Unit status: Varies based on location\nTravel, transportation, and relocation
+        expenses may be paid when authorized and approved by appropriateagency officials
+        on a case by case basis.\nGSA may pay a recruitment incentive to a newly-appointed
+        employee; a relocation incentive to a currentemployee; or offer annual leave
+        service credit to an applicant with related non-federal or uniformed services
+        workexperience. Determinations to pay/allow incentives will be made on a case-by-case
+        basis, subject to fundingavailability and documentation that the position
+        is \"hard-to-fill\".\nSelected applicants may qualify for credit toward annual
+        leave accrual based on prior non-federal work experienceor uniformed service
+        experience.\nAdditional vacancies may be filled from this announcement as
+        needed. This vacancy announcement does notpreclude filling this position by
+        other means. Management also has the right not to fill the position.","KeyRequirements":["US
+        Citizens and National (Residents of American Samoa and Swains Island)","Meet
+        all eligibility criteria within 30 days of the closing date","Register with
+        Selective Service, if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"nrc@gsa.gov","AgencyContactPhone":"000-000-0000","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"585255200","MatchedObjectDescriptor":{"PositionID":"21NRCA005LB-DHA","PositionTitle":"Realty
+        Specialist (Lease Contracting Officer)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/585255200","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/585255200?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Birmingham, Alabama","CountryCode":"United
+        States","CountrySubDivisionCode":"Alabama","CityName":"Birmingham, Alabama","Longitude":-86.8115,"Latitude":33.5203},{"LocationName":"Huntsville,
+        Alabama","CountryCode":"United States","CountrySubDivisionCode":"Alabama","CityName":"Huntsville,
+        Alabama","Longitude":-86.585,"Latitude":34.7291},{"LocationName":"Phoenix,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix,
+        Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"Tucson,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Tucson,
+        Arizona","Longitude":-110.96976,"Latitude":32.221554},{"LocationName":"Los
+        Angeles, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Los
+        Angeles, California","Longitude":-118.245,"Latitude":34.0535},{"LocationName":"Sacramento,
+        California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Sacramento,
+        California","Longitude":-121.491,"Latitude":38.57906},{"LocationName":"San
+        Diego, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Diego, California","Longitude":-117.162,"Latitude":32.7157},{"LocationName":"San
+        Francisco County, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco County, California","Longitude":-122.42905,"Latitude":37.77986},{"LocationName":"Lakewood,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Lakewood,
+        Colorado","Longitude":-105.08274,"Latitude":39.71095},{"LocationName":"District
+        of Columbia, District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"District of Columbia, District of Columbia","Longitude":-77.03196,"Latitude":38.89037},{"LocationName":"Fort
+        Lauderdale, Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Fort
+        Lauderdale, Florida","Longitude":-80.14356,"Latitude":26.12367},{"LocationName":"Miami,
+        Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Miami,
+        Florida","Longitude":-80.23742,"Latitude":25.728985},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Savannah,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Savannah,
+        Georgia","Longitude":-81.09072,"Latitude":32.08078},{"LocationName":"Honolulu,
+        Hawaii","CountryCode":"United States","CountrySubDivisionCode":"Hawaii","CityName":"Honolulu,
+        Hawaii","Longitude":-157.858,"Latitude":21.3047},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Louisville,
+        Kentucky","CountryCode":"United States","CountrySubDivisionCode":"Kentucky","CityName":"Louisville,
+        Kentucky","Longitude":-85.7664,"Latitude":38.25486},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Baltimore,
+        Maryland","CountryCode":"United States","CountrySubDivisionCode":"Maryland","CityName":"Baltimore,
+        Maryland","Longitude":-76.609604,"Latitude":39.290554},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Jackson,
+        Mississippi","CountryCode":"United States","CountrySubDivisionCode":"Mississippi","CityName":"Jackson,
+        Mississippi","Longitude":-90.18049,"Latitude":32.29869},{"LocationName":"Charlotte,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Charlotte, North Carolina","Longitude":-80.83754,"Latitude":35.2225},{"LocationName":"Raleigh,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Raleigh, North Carolina","Longitude":-78.64267,"Latitude":35.78551},{"LocationName":"Camden,
+        New Jersey","CountryCode":"United States","CountrySubDivisionCode":"New Jersey","CityName":"Camden,
+        New Jersey","Longitude":-75.1191,"Latitude":39.9453},{"LocationName":"Las
+        Vegas, Nevada","CountryCode":"United States","CountrySubDivisionCode":"Nevada","CityName":"Las
+        Vegas, Nevada","Longitude":-115.14,"Latitude":36.1719},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Philadelphia,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Philadelphia,
+        Pennsylvania","Longitude":-75.16237,"Latitude":39.95227},{"LocationName":"Pittsburgh,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Pittsburgh,
+        Pennsylvania","Longitude":-79.99746,"Latitude":40.43831},{"LocationName":"Columbia,
+        South Carolina","CountryCode":"United States","CountrySubDivisionCode":"South
+        Carolina","CityName":"Columbia, South Carolina","Longitude":-81.04525,"Latitude":33.99855},{"LocationName":"Memphis,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Memphis,
+        Tennessee","Longitude":-90.04893,"Latitude":35.14968},{"LocationName":"Nashville,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Nashville,
+        Tennessee","Longitude":-86.778366,"Latitude":36.16778},{"LocationName":"Fort
+        Worth, Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Fort
+        Worth, Texas","Longitude":-97.32925,"Latitude":32.74863},{"LocationName":"Norfolk,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Norfolk,
+        Virginia","Longitude":-76.28507,"Latitude":36.846825},{"LocationName":"Richmond,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Richmond,
+        Virginia","Longitude":-77.433655,"Latitude":37.5407},{"LocationName":"Roanoke,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Roanoke,
+        Virginia","Longitude":-79.9405,"Latitude":37.2715},{"LocationName":"Auburn,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Auburn,
+        Washington","Longitude":-122.23041,"Latitude":47.3074},{"LocationName":"Charleston,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Charleston, West Virginia","Longitude":-81.63893,"Latitude":38.350216},{"LocationName":"Martinsburg,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Martinsburg, West Virginia","Longitude":-77.96456,"Latitude":39.45637}],"OrganizationName":"General
+        Services Administration - Agency Wide","DepartmentName":"General Services
+        Administration","JobCategory":[{"Name":"Realty","Code":"1170"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nStarting
+        Pay for all locations will be dependent upon the associated GS-Locality Pay
+        Table for that area.If you are a new federal employee, your starting salary
+        will likely be set at the Step 1 of the grade for which you are selected.
+        The GS-12salary range starts as low as $76,721.00 and as high as $121,668.00
+        per year depending on the locality pay of the duty location.The GS-13salary
+        range starts as low as $91,231.00 and as high as $144,676.00 per year depending
+        on the locality pay of the duty location.\nTo qualify for the GS-12, you must
+        have 1 year of specialized experienceequivalent to at least GS-11.\nSpecialized
+        experience ismanaging real estatetransactions for commercial office space
+        by researching, interpreting and applying real estate laws, regulations, and
+        practices. This experience must include performing the following: Lease acquisition
+        including negotiating, preparing and executing real estate contracts;\nConducting
+        market surveys and real estate site inspections;\nPerforming real estate project
+        management using project management tools to manage projects from inception
+        to closeout\nConducting cost analyses for real estate transactions to provide
+        recommendations and;\nManaging lease transactions and documents to ensure
+        procurement and financial accuracy To qualify for the GS-13, you must have
+        1 year of specialized experienceequivalent to at least GS-12.\nSpecialized
+        experience ismanaging a wide range of large scale, complex, and/or high visibility
+        real estate transactions for commercial office space by researching, interpreting,
+        and applying knowledge of real estate laws, regulations, and practices. This
+        experience must include performing the following: Lease acquisition including
+        negotiating, preparing and executing real estate contracts;\nConducting market
+        surveys and real estate site inspections;\nPerforming real estate project
+        management using project management tools to manage projects from inception
+        to closeout;\nConducting cost analyses for real estate transactions;Monitoring
+        lease transactions and documents for procurement and financial accuracy; and,\nAnalyzing
+        and providing technical advice and direction in the development and implementation
+        of real estate policy. Preferred Qualifications and Skillsfor BOTH GRADES\nIt
+        is preferred that you have: completed bachelor''s degree\nor completion of
+        at least 24 semester hours (or equivalent) of business coursework.","PositionRemuneration":[{"MinimumRange":"77488.0","MaximumRange":"146120.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2020-11-23","PositionEndDate":"2021-09-03","PublicationStartDate":"2020-11-23","ApplicationCloseDate":"2021-09-03","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"CLOSING
+        DATE CHANGED FROM 9/30 TO 9/3/21.\nTHIS IS A PUBLIC NOTICE: Please review
+        further information below regarding how this posting will be used.\nAs aRealty
+        Specialist (Lease Contract Officer), you will provide leased space for all
+        gov''t agencies, performing long/short range planning, space acquisition,
+        assignment, lease admin and utilization work.\nPositions are in the Public
+        Buildings Service (PBS). These positions are being filled to directly support
+        the Lease Cost Avoidance Program.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"12","HighGrade":"13","OrganizationCodes":"GS/GS00","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103245","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103245&S=1","MajorDuties":["This
+        Notice is issued under DHA to recruit new talent to occupations for which
+        there is a critical need of candidates. We have a critical need of qualified
+        applicants for our Realty Specialist (Lease Contracting Officer). To help
+        us fill these jobs, we have been granted &ldquo;Direct Hire Authority&rdquo;
+        or DHA. This means that when we have a vacant job, we can hire any qualified
+        candidate, either from this notice or from any source. The benefit of applying
+        to this notice is that your application may be shared with a hiring manager
+        if they request resumes from this notice.\nA few key facts about this DHA
+        notice: Many vacancies may be filled at the GS-12 or GS-13 levels.\nJobs have
+        varying opportunities for advancement (promotion potential).\nJobs may be
+        located in any of the metropolitan areas listed.\nAvailability of positions
+        and grade levels vary by location.\nCurrent civil service employees will receive
+        new appointments, if selected under this DHA. Each metropolitan area will
+        independently review applications and decide who to interview. For questions
+        specifically related to any individual location, please send an inquiry (indicating
+        the location of interest) to:pbsbvacancyinquiries@gsa.gov\nIf you have general
+        questions about this job posting or have difficulty applying, contact us at
+        816-823-2006 or nrc@gsa.gov.For information on DHA, visit https://www.opm.gov/directhire/index.asp.\nDuties:\nAcquisition
+        Management: Prepares and maintains current acquisition plans, strategies,
+        as well as appropriate milestone charts and schedules. Identifies customer
+        space requirements. Performs comprehensive market surveys and building inspections.\nAcquires
+        leasehold interests in space for assigned customers with complex space requirements;
+        solicits offers; develops, defines and negotiates lease terms and conditions;
+        performs cost and price analyses of offers; incorporates complex modifications
+        of terms and conditions into lease; and prepares and/or signs approval documents
+        necessary to award the lease. Makes final award determinations and verifies
+        the existence of necessary approvals for funding availability, and awards
+        and executes lease.\nOversees and enforces leases, modifying complex space
+        provisions to reflect changes in ownership, the amount and configuration of
+        space, and types of service received.\nResponsible for data input into several
+        systems to track and administer procurement and billing information (such
+        as GREX, REXUS, OA Tool and others).\nEnsures contractual documents/leasing
+        information and final decisions are properly documented and input into the
+        appropriate system. Project Management: May serve as project manager for designatedcomplex
+        realty projects or lead an interdisciplinary team from GSA (architects, engineers,
+        property managers, and attorneys) and from outside the Agency (lessors, developers,
+        contractors, tenant agency personnel, or other technical personnel), to take
+        the space need from planning and project execution through space delivery.
+        Performsthe full rangeof project management duties, using project management
+        principles andpractices and established tools and technology toperform the
+        full range of activitiessuch asproject identification, initiation, planning,
+        execution and closeout. Space Management: Analyzes the existing space inventory
+        for available Government-controlled space in satisfying the space requirements
+        customers. Consults and advises the customer in regard to the release and
+        reduction of space.\nReviews space requests; develops housing strategies,
+        and consults with agencies on their requirements (amount, type, layout and
+        location of space). Works with customers in developing their space specifications.\nCoordinates
+        efficient space design and layout through oversight of construction activities
+        related to a customer&rsquo;s initial space alterations or post-occupancy
+        space alterations. Communication: Serves as the primary contact and technical
+        representative for complex realty projects and realty matters often coordinating
+        input from other personnel within and outside of GSA.\nConducts/manages necessary
+        interactions with internal and external stakeholders to develop, oversee,
+        and/or execute solutions for varied customer business and diverse workspace
+        needs.\nPrepares, reviews and approves required legal and contractual documentation
+        as appropriate and authorized."],"Education":"Note: If you are using foreign
+        education to meet qualification requirements, you must send a Certificate
+        of Foreign Equivalency with your transcript in order to receive credit for
+        that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position\nYou
+        may be required to participate in the Region''s Continuity of Operations Plan
+        (COOP), representing the Service and/or GSA as a whole. This may involve participating
+        in COOP meetings and planning activities;performing mission-critical work
+        at a designated location other than the traditional GSA office site (whichmay
+        be outside of the commuting area); and ensuring that GSA''s needs are still
+        being met in the event ofan emergency, disaster or otherwise unforeseen circumstance
+        disrupting traditional office operations.","Evaluations":"Applications will
+        be evaluated against the basic qualifications. Qualified candidates will be
+        considered inaccordance with the Office of Personnel Management Direct Hire
+        Guidelines. Veterans'' Preference does not applyto the direct hire recruitment
+        procedures. Certain selections made under this notice will be processed as
+        newappointments to the civil service. Current civil service employees might
+        be given new appointments to the civilservice. You may not be considered for
+        the position, if any part of the application is incomplete or missing therequired
+        supporting documentation. Falsifying your background, education and/or experience
+        is cause for nothiring you or dismissing you if hired.\nIf you are an Interagency
+        Career Transition Assistance Plan eligible or a GSA Career Transition Assistanceeligible,
+        you must be considered well qualified to receive priority(ICTAP/CTAP). Well
+        qualified is defined aspossession of the majority of competencies or knowledge,
+        skills and abilities required for the position and will be determined, based
+        upon a reviewof your resume against the following: Ability to acquire and
+        maintain a leasing warrant as well as complete all requirements for the appropriate
+        GSA Leasing Certification Program which includes formal training, experience
+        and completion of either a bachelor''s degree or completion of at least 24
+        semester hours (or equivalent) of business coursework.\nKnowledge of real
+        estate guidelines concerning lease scoring and issues surrounding capital
+        lease vs. operating leases; knowledge of broker services contracts, technical
+        services contracts, and how the services are ordered, administered and paid;
+        knowledge of contract administration techniques to evaluate contractor proposals
+        and prepare pre-negotiation strategies.\nAdvanced negotiating skills to plan
+        and contract for complex acquisitions involving numerous issues and concerns.\nKnowledge
+        of a wide range of real estate principles, concepts and practices and market
+        conditions and industry standards to acquire and manage space and provide
+        guidance to customers on realty matters to acquire space and/or oversee broker-handled
+        realty actions.\nKnowledge of acquisition manuals, regulation guides, and
+        documents involved in planning and managing complex realty projects and/or
+        highly specialized leases.\nKnowledge of cost and price analysis to forecast
+        costs and evaluate prices; determine best business strategies; and to perform
+        negotiations involving complex financial arrangements or conditions.\nAbility
+        to plan, schedule, and balance all technical aspects of multiple complex projects
+        with a wide range of variables and independently determine and execute the
+        appropriate sequence of required tasks to fulfill customer agency needs.\nSkill
+        in performing extensive coordination for matters involving sensitive issues,
+        special and diverse customer needs, frequently changing requirements or unanticipated
+        changes in requirements.\nKnowledge of space management principles, techniques,
+        and regulations to monitor agencies&rsquo; use of space and/or manage federal
+        space, analyze space needs, and plan major space reorganization and alterations
+        to accommodate changing tenant requirements.\nSkill in applying quantitative
+        and qualitative analysis in order to create solutions to solve complex real
+        estate management problems.&ensp;\nSkill in communicating effectively orally
+        and in writing concerning a wide range of complex realty matters. To preview
+        questions please click here.","HowToApply":"This Direct Hire Public Notice
+        will be used to build a list/inventory of applicants that may be referred
+        as vacanciesbecome available.\nYou must submit a complete online application
+        including any required documents prior to 11:59 pm Eastern Time on the closing
+        date of the Announcement. Errors or omissions may result in your not being
+        considered for this vacancy. You can modify/complete your application any
+        time before the vacancy date/time deadline. Simply return to USAJOBS, select
+        the vacancy, and update your application. For more detailed instructions on
+        how to apply, read the Apply for a GSA Job on the GSA website.To begin, click
+        the Apply Online button on the vacancy announcement. Sign in or register on
+        USAJobs and select a resume and documents to include in your application.\nOnce
+        you have clicked Apply for this position now, you will be taken to the GSA
+        site to complete the application process.\nClick the Apply To This Vacancy
+        and complete all steps in the application process until the Confirmation indicates
+        your application is complete. If you click Return to USAJobs or get timed
+        out prior to receiving confirmation, your application will not be submitted
+        and cannot be considered for this vacancy.\nNote: Review the REQUIRED DOCUMENTS
+        section of this announcement to determine which apply to you and must be submitted
+        online. You may choose one or more of the following options to submit your
+        document(s): Upload (from your computer); USAJOBS (click the \"USAJOBS\" link
+        to complete the transfer process) or FAX (read the &ldquo;Fax instructions&rdquo;
+        provided prior to printing the Fax Cover Sheet and faxing your information).
+        Need Assistance in Applying? Contact the HR representative listed on the announcement
+        prior to the application deadline. We are available to assist you Monday-Friday
+        during normal business hours. You must receive HR approval before deviating
+        from these instructions. Be sure to APPLY EARLY as most assessments must be
+        completed fully and submitted before the announcement closing.","WhatToExpectNext":"This
+        Notice is issued under DHA to recruit new talent to occupations for which
+        there is a critical need of candidates. We have a critical need of qualified
+        applicants for our Realty Specialist (Lease Contracting Officer) positions.
+        To help us fill these jobs, we have been granted &ldquo;Direct Hire Authority&rdquo;
+        or DHA. This means that when we have a vacant job, we can hire any qualified
+        candidate, either from this notice or from any source.\nThe benefit of applying
+        to this notice is that your application may be shared with a hiring manager,
+        if they request resumes from this notice.\nThank you for your interest in
+        working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are claiming veterans''
+        preference: Completed SF-15 form\nProof of your entitlement (refer to SF-15
+        for complete list).\nCopy of your Certificate of Release or Discharge From
+        Active Duty, DD-214 that shows the dates of your active duty service. If selected,
+        a DD-214 showing your type of discharge (member 4 copy) will be required prior
+        to appointment.\nIf you are claiming 10-point preference or derived preference
+        (a spouse, widow or widower, or parent of a deceased or disabled veteran),
+        submit both of the following in addition to the DD-214. If you are active
+        duty military- Certification on a letterhead from your military branch that
+        includes your rank, character of service (must be under honorable conditions)
+        &amp; military service dates including discharge/release date (must be no
+        later than 120 days after the date the certification is submitted).\nIf you
+        areICTAP/CTAPeligible-submit a, b, and c:(a)proof of eligibility including
+        agency notice;(b)SF-50, and(c)most recent performance appraisal.\nCollege
+        transcripts:If you are using some or all of your college education to meet
+        qualification requirements for this position, you must submit a photocopy
+        of your college transcript(s). If selected, an official transcript will be
+        required prior to appointment. For education completed outside the United
+        States, also submit a valid foreign credential evaluation that substantiates
+        possession of the required education.","Benefits":"You will have access to
+        many benefits including: Health insurance (choose from a wide range of plans)\nLife
+        insurance coverage with several options\nSick leave and vacation time, including
+        10 paid holidays per year\nThrift Savings Plan (similar to a 401(k) plan)\nFlexible
+        work schedules\nTransit and child care subsidies\nFlexible spending accounts\nLong-term
+        care insurance\nTraining and development","BenefitsUrl":"http://www.opm.gov/insure/federal_employ/index.asp","OtherInformation":"Bargaining
+        Unit status: Varies based on job and location\nIf you are selected for this
+        position at a grade lower than the full performance level, you may be promoted
+        up tothat grade level without further competition in accordance with all applicable
+        regulations. However, promotions are not guaranteed and are dependent on performance.\nTravel,
+        transportation, and relocation expenses may be paid when authorized and approved
+        by appropriateagency officials on a case by case basis.\nGSA may pay a recruitment
+        incentive to a newly-appointed employee; a relocation incentive to a currentemployee;
+        or offer annual leave service credit to an applicant with related non-federal
+        or uniformed services workexperience. Determinations to pay/allow incentives
+        will be made on a case-by-case basis, subject to fundingavailability and documentation
+        that the position is \"hard-to-fill\".\nSelected applicants may qualify for
+        credit toward annual leave accrual based on prior non-federal work experienceor
+        uniformed service experience.\nAdditional vacancies may be filled from this
+        announcement as needed. This vacancy announcement does notpreclude filling
+        this position by other means. Management also has the right not to fill the
+        position.","KeyRequirements":["US Citizens and National (Residents of American
+        Samoa and Swains Island)","Meet all eligibility criteria within 30 days of
+        the closing date","Register with Selective Service, if you are a male born
+        after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"nrc@gsa.gov","AgencyContactPhone":"000-000-0000","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"585267700","MatchedObjectDescriptor":{"PositionID":"21NRCA006LB-DHA","PositionTitle":"Realty
+        Specialist (Lease Contracting Officer)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/585267700","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/585267700?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Birmingham, Alabama","CountryCode":"United
+        States","CountrySubDivisionCode":"Alabama","CityName":"Birmingham, Alabama","Longitude":-86.8115,"Latitude":33.5203},{"LocationName":"Huntsville,
+        Alabama","CountryCode":"United States","CountrySubDivisionCode":"Alabama","CityName":"Huntsville,
+        Alabama","Longitude":-86.585,"Latitude":34.7291},{"LocationName":"Phoenix,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix,
+        Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"Tucson,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Tucson,
+        Arizona","Longitude":-110.96976,"Latitude":32.221554},{"LocationName":"Los
+        Angeles, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Los
+        Angeles, California","Longitude":-118.245,"Latitude":34.0535},{"LocationName":"Sacramento,
+        California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Sacramento,
+        California","Longitude":-121.491,"Latitude":38.57906},{"LocationName":"San
+        Diego, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Diego, California","Longitude":-117.162,"Latitude":32.7157},{"LocationName":"San
+        Francisco, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Lakewood,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Lakewood,
+        Colorado","Longitude":-105.08274,"Latitude":39.71095},{"LocationName":"Washington,
+        District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904},{"LocationName":"Fort
+        Lauderdale, Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Fort
+        Lauderdale, Florida","Longitude":-80.14356,"Latitude":26.12367},{"LocationName":"Miami,
+        Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Miami,
+        Florida","Longitude":-80.23742,"Latitude":25.728985},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Savannah,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Savannah,
+        Georgia","Longitude":-81.09072,"Latitude":32.08078},{"LocationName":"Honolulu,
+        Hawaii","CountryCode":"United States","CountrySubDivisionCode":"Hawaii","CityName":"Honolulu,
+        Hawaii","Longitude":-157.858,"Latitude":21.3047},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Louisville,
+        Kentucky","CountryCode":"United States","CountrySubDivisionCode":"Kentucky","CityName":"Louisville,
+        Kentucky","Longitude":-85.7664,"Latitude":38.25486},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Baltimore,
+        Maryland","CountryCode":"United States","CountrySubDivisionCode":"Maryland","CityName":"Baltimore,
+        Maryland","Longitude":-76.609604,"Latitude":39.290554},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Jackson,
+        Mississippi","CountryCode":"United States","CountrySubDivisionCode":"Mississippi","CityName":"Jackson,
+        Mississippi","Longitude":-90.18049,"Latitude":32.29869},{"LocationName":"Charlotte,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Charlotte, North Carolina","Longitude":-80.83754,"Latitude":35.2225},{"LocationName":"Raleigh,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Raleigh, North Carolina","Longitude":-78.64267,"Latitude":35.78551},{"LocationName":"Camden,
+        New Jersey","CountryCode":"United States","CountrySubDivisionCode":"New Jersey","CityName":"Camden,
+        New Jersey","Longitude":-75.1191,"Latitude":39.9453},{"LocationName":"Las
+        Vegas, Nevada","CountryCode":"United States","CountrySubDivisionCode":"Nevada","CityName":"Las
+        Vegas, Nevada","Longitude":-115.14,"Latitude":36.1719},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Philadelphia,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Philadelphia,
+        Pennsylvania","Longitude":-75.16237,"Latitude":39.95227},{"LocationName":"Pittsburgh,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Pittsburgh,
+        Pennsylvania","Longitude":-79.99746,"Latitude":40.43831},{"LocationName":"Columbia,
+        South Carolina","CountryCode":"United States","CountrySubDivisionCode":"South
+        Carolina","CityName":"Columbia, South Carolina","Longitude":-81.04525,"Latitude":33.99855},{"LocationName":"Nashville,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Nashville,
+        Tennessee","Longitude":-86.778366,"Latitude":36.16778},{"LocationName":"Fort
+        Worth, Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Fort
+        Worth, Texas","Longitude":-97.32925,"Latitude":32.74863},{"LocationName":"Memphis,
+        Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Memphis,
+        Texas","Longitude":-100.5343,"Latitude":34.7241},{"LocationName":"Norfolk,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Norfolk,
+        Virginia","Longitude":-76.28507,"Latitude":36.846825},{"LocationName":"Richmond,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Richmond,
+        Virginia","Longitude":-77.433655,"Latitude":37.5407},{"LocationName":"Roanoke,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Roanoke,
+        Virginia","Longitude":-79.9405,"Latitude":37.2715},{"LocationName":"Auburn,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Auburn,
+        Washington","Longitude":-122.23041,"Latitude":47.3074},{"LocationName":"Charleston,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Charleston, West Virginia","Longitude":-81.63893,"Latitude":38.350216},{"LocationName":"Martinsburg,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Martinsburg, West Virginia","Longitude":-77.96456,"Latitude":39.45637}],"OrganizationName":"General
+        Services Administration - Agency Wide","DepartmentName":"General Services
+        Administration","JobCategory":[{"Name":"Realty","Code":"1170"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nStarting
+        Pay for all locations will be dependent upon the associated GS-Locality Pay
+        Table for that area.If you are a new federal employee, your starting salary
+        will likely be set at the Step 1 of the grade for which you are selected.
+        The GS-14 salary range starts as low as $108,904.00 and as high as $170,800.00
+        per year depending on the locality pay of the duty location.\nTo qualify for
+        the GS-14, you must have 1 year of specialized experienceequivalent to at
+        least GS-13.\nSpecialized experience isdefined as experience in both (a) planning
+        the scope and direction of lease acquisition programs and (b) performing the
+        full range of real estate functions including lease acquisition, lease policy
+        development, lease process improvement,lease project management, and lease
+        systems implementation.","PositionRemuneration":[{"MinimumRange":"108885.0","MaximumRange":"172500.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2020-11-23","PositionEndDate":"2021-09-03","PublicationStartDate":"2020-11-23","ApplicationCloseDate":"2021-09-03","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"THIS
+        IS A PUBLIC NOTICE: Please review further information below regarding how
+        this posting will be used.\nAs aRealty Specialist (Lease Contract Officer),
+        you willexecute or oversee execution of realty projects and acquisition of
+        leasehold interests in real property for a wide range of highly complex or
+        highly sensitive acquisitions and projects.\nPositions are in the Public Buildings
+        Service (PBS). These positions are being filled to directly support the Lease
+        Cost Avoidance Program.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"14","HighGrade":"14","OrganizationCodes":"GS/GS00","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103250","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103250&S=1","MajorDuties":["CLOSING
+        DATE CHANGED FROM 9/30 TO 9/3/21.\nWe are currently filling many vacancies
+        in a variety of locations. This Notice is issued under direct-hire authority
+        to recruit new talent to occupations for which there is a critical need of
+        candidates. We have a critical need of qualified, GS-14, applicants for our
+        Realty Specialist (Lease Contracting Officer) positions. To help us fill these
+        jobs, we have been granted &ldquo;Direct Hire Authority&rdquo; or DHA. This
+        means that when we have a vacant job, we can hire any qualified candidate,
+        either from this notice or from any source. The benefit of applying to this
+        notice is that your application may be shared with a hiring manager if they
+        request resumes from this notice.\nA few key facts about this DHA notice:
+        Many vacancies may be filled at the GS-14 level.\nJobs may be located in any
+        of the metropolitan areas listed.\nAvailability of positions vary by location.\nCurrent
+        civil service employees will receive new appointments, if selected under this
+        Direct Hire Authority. Each metropolitan area will independently review applications
+        and decide who to interview.\nFor questions specifically related to any individual
+        location, please send an inquiry (indicating the location of interest) to:pbsbvacancyinquiries@gsa.gov\nIf
+        you have general questions about this job posting, or are having difficulty
+        applying, contact us at 816-823-2006or nrc@gsa.gov.\nFor information on DHA,
+        please visit https://www.opm.gov/directhire/index.asp.\nDuties:\nAs a Realty
+        Specialist (Lease Contract Officer), you will: Conduct/manage interactions
+        with real estate industry professionals to develop, oversee, and/or execute
+        the most complex and highly sensitive realty projects within the region/assigned
+        organization.\nDevelop acquisition strategies for complex and/or unusual extraordinary
+        customer procurementneeds and advise the Division Director, on matters of
+        policy, as an expert in the acquisition of leasehold interests in Real Property.\nOversee
+        other leasing personnel, projectstakeholders and contractors in their performanceof
+        all phases and steps of lease acquisition, leaseadministration and project
+        management frominitiation phases to project closeout.\nNegotiate extensively
+        to manage conflicts andcontroversial transactions between clients andState
+        and/or local or Federal authorities.\nDevelop creative approaches to manage
+        realtyprojects and provide analytical, technical,consultative, and/or strategic
+        business support toPBS customers during project planning andthroughout the
+        lease acquisition and spacedelivery process ensuring that lease projectscomply
+        with all applicable policy and regulatoryrequirements.\nManage financial risk
+        and maintain sophisticated market knowledge to deliver highlycost effective
+        Realty solutions, and significantcost avoidance to the government by Conducting:market
+        surveys, market rent analyses and buildinginspections&#894; draft solicitations
+        for offer, all aspectsof cost and price analyses, financial evaluation ofoffers,
+        lease documents and requiredaccompanying documentation for real estatetransactions."],"Education":"Note:
+        If you are using foreign education to meet qualification requirements, you
+        must send a Certificate of Foreign Equivalency with your transcript in order
+        to receive credit for that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position\nYou
+        may be required to participate in the Region''s Continuity of Operations Plan
+        (COOP), representing the Service and/or GSA as a whole. This may involve participating
+        in COOP meetings and planning activities;performing mission-critical work
+        at a designated location other than the traditional GSA office site (whichmay
+        be outside of the commuting area); and ensuring that GSA''s needs are still
+        being met in the event ofan emergency, disaster or otherwise unforeseen circumstance
+        disrupting traditional office operations.","Evaluations":"Applications will
+        be evaluated against the basic qualifications. Qualified candidates will be
+        considered inaccordance with the Office of Personnel Management Direct Hire
+        Guidelines. Veterans'' Preference does not applyto the direct hire recruitment
+        procedures. Certain selections made under this notice will be processed as
+        newappointments to the civil service. Current civil service employees might
+        be given new appointments to the civilservice. You may not be considered for
+        the position, if any part of the application is incomplete or missing therequired
+        supporting documentation. Falsifying your background, education and/or experience
+        is cause for nothiring you or dismissing you if hired.\nIf you are an Interagency
+        Career Transition Assistance Plan eligible or a GSA Career Transition Assistanceeligible,
+        you must be considered well qualified to receive priority(ICTAP/CTAP). Well
+        qualified is defined aspossession of the majority of competencies or knowledge,
+        skills and abilities required for the position and will be determined, based
+        upon a reviewof your resume against the following: Mastery of real estate
+        principles, policies,methodologies, concepts and practices,as well as an expert
+        understanding of thereal estate market conditions and industryoperations to
+        serve as the RealtySpecialist, managing project teamstasked to acquire and
+        deliver highlycomplex space (including sites, buildings,easements, out-leases
+        and/or a variety ofoffice and special space categories)&#894; tomanage related
+        moves from leased and/orFederally-&shy;owned inventory&#894; and/or providetechnical
+        guidance (including reviewand/or support of assigned realtytransactions) to
+        brokers and otherstakeholders involved in the acquisition ofspace for GSA
+        and/or its customeragencies.\nComprehensive knowledge of contracting rules,
+        regulations andprocedures relating to the acquisition ofgoods and services,
+        including constructionof new buildings, leasehold agreements,sites and/or
+        out-leases.\nAbility to plan and carry out assignments;resolve conflicts that
+        arise; coordinate thework with others; and interpret policy.Ability to respond
+        to changing programrequirements.\nAbility to communicate effectively orallyand
+        in writing concerning realty matters.\nAbility to manage extremely complex
+        andhigh risk projects utilizing expertknowledge of project managementprinciples
+        and tools. Expert ability tocollaborate with others to perform workefficiently;
+        Ability to establish, build, andmaintain relationships in order to identifyand
+        resolve complex and unusualproblems involving conflictingrequirements.\nIn-depth
+        knowledge of cost and priceanalyses to forecast costs and evaluateprices/offers
+        to determine acquisitionstrategies and plans and to guidecustomer understanding
+        of options andobtain customer buy-in torecommendations made. To preview questions
+        please click here.","HowToApply":"This Direct Hire Public Notice will be used
+        to build a list/inventory of applicants that may be referred as vacanciesbecome
+        available.\nYou must submit a complete online application including any required
+        documents prior to 11:59 pm Eastern Time on the closing date of the Announcement.
+        Errors or omissions may result in your not being considered for this vacancy.
+        You can modify/complete your application any time before the vacancy date/time
+        deadline. Simply return to USAJOBS, select the vacancy, and update your application.
+        For more detailed instructions on how to apply, read the Apply for a GSA Job
+        on the GSA website.To begin, click the Apply Online button on the vacancy
+        announcement. Sign in or register on USAJobs and select a resume and documents
+        to include in your application.\nOnce you have clicked Apply for this position
+        now, you will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this vacancy.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the announcement
+        closing.","WhatToExpectNext":"This Notice is issued under direct-hire authority
+        to recruit new talent to occupations for which there is a critical need of
+        candidates. We have a critical need of qualified, GS-14, applicants for our
+        Realty Specialist (Lease Contracting Officer) positions. To help us fill these
+        jobs, we have been granted &ldquo;Direct Hire Authority&rdquo; or DHA. This
+        means that when we have a vacant job, we can hire any qualified candidate,
+        either from this notice or from any source.\nThe benefit of applying to this
+        notice is that your application may be shared with a hiring manager, if they
+        request resumes from this notice.\nThank you for your interest in working
+        for U.S. General Services Administration!","RequiredDocuments":"ALL required
+        documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are claiming veterans''
+        preference: Completed SF-15 form\nProof of your entitlement (refer to SF-15
+        for complete list).\nCopy of your Certificate of Release or Discharge From
+        Active Duty, DD-214 that shows the dates of your active duty service. If selected,
+        a DD-214 showing your type of discharge (member 4 copy) will be required prior
+        to appointment.\nIf you are claiming 10-point preference or derived preference
+        (a spouse, widow or widower, or parent of a deceased or disabled veteran),
+        submit both of the following in addition to the DD-214. If you are active
+        duty military- Certification on a letterhead from your military branch that
+        includes your rank, character of service (must be under honorable conditions)
+        &amp; military service dates including discharge/release date (must be no
+        later than 120 days after the date the certification is submitted).\nIf you
+        areICTAP/CTAPeligible-submit a, b, and c:(a)proof of eligibility including
+        agency notice;(b)SF-50, and(c)most recent performance appraisal.\nCollege
+        transcripts:If you are using some or all of your college education to meet
+        qualification requirements for this position, you must submit a photocopy
+        of your college transcript(s). If selected, an official transcript will be
+        required prior to appointment. For education completed outside the United
+        States, also submit a valid foreign credential evaluation that substantiates
+        possession of the required education.","Benefits":"You will have access to
+        many benefits including: Health insurance (choose from a wide range of plans)\nLife
+        insurance coverage with several options\nSick leave and vacation time, including
+        10 paid holidays per year\nThrift Savings Plan (similar to a 401(k) plan)\nFlexible
+        work schedules\nTransit and child care subsidies\nFlexible spending accounts\nLong-term
+        care insurance\nTraining and development","BenefitsUrl":"http://www.opm.gov/insure/federal_employ/index.asp","OtherInformation":"Bargaining
+        Unit status: Varies based on location\nTravel, transportation, and relocation
+        expenses may be paid when authorized and approved by appropriateagency officials
+        on a case by case basis.\nGSA may pay a recruitment incentive to a newly-appointed
+        employee; a relocation incentive to a currentemployee; or offer annual leave
+        service credit to an applicant with related non-federal or uniformed services
+        workexperience. Determinations to pay/allow incentives will be made on a case-by-case
+        basis, subject to fundingavailability and documentation that the position
+        is \"hard-to-fill\".\nSelected applicants may qualify for credit toward annual
+        leave accrual based on prior non-federal work experienceor uniformed service
+        experience.\nAdditional vacancies may be filled from this announcement as
+        needed. This vacancy announcement does notpreclude filling this position by
+        other means. Management also has the right not to fill the position.","KeyRequirements":["US
+        Citizens and National (Residents of American Samoa and Swains Island)","Meet
+        all eligibility criteria within 30 days of the closing date","Register with
+        Selective Service, if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"nrc@gsa.gov","AgencyContactPhone":"000-000-0000","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"590685600","MatchedObjectDescriptor":{"PositionID":"21NRCA029LB-DHA","PositionTitle":"Contract
+        Spec/Administrator/Negotiator, Procurement Analyst (Supvy/Non/Lead)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/590685600","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/590685600?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Anchorage, Alaska","CountryCode":"United
+        States","CountrySubDivisionCode":"Alaska","CityName":"Anchorage, Alaska","Longitude":-149.85774,"Latitude":61.21756},{"LocationName":"Birmingham,
+        Alabama","CountryCode":"United States","CountrySubDivisionCode":"Alabama","CityName":"Birmingham,
+        Alabama","Longitude":-86.8115,"Latitude":33.5203},{"LocationName":"Huntsville,
+        Alabama","CountryCode":"United States","CountrySubDivisionCode":"Alabama","CityName":"Huntsville,
+        Alabama","Longitude":-86.585,"Latitude":34.7291},{"LocationName":"Montgomery,
+        Alabama","CountryCode":"United States","CountrySubDivisionCode":"Alabama","CityName":"Montgomery,
+        Alabama","Longitude":-86.3006,"Latitude":32.3801},{"LocationName":"Fayetteville,
+        Arkansas","CountryCode":"United States","CountrySubDivisionCode":"Arkansas","CityName":"Fayetteville,
+        Arkansas","Longitude":-94.1579,"Latitude":36.0632},{"LocationName":"Little
+        Rock, Arkansas","CountryCode":"United States","CountrySubDivisionCode":"Arkansas","CityName":"Little
+        Rock, Arkansas","Longitude":-92.2745,"Latitude":34.7487},{"LocationName":"Phoenix,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix,
+        Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"Laguna
+        Niguel, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Laguna
+        Niguel, California","Longitude":-117.708374,"Latitude":33.559406},{"LocationName":"Los
+        Angeles, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Los
+        Angeles, California","Longitude":-118.245,"Latitude":34.0535},{"LocationName":"Sacramento,
+        California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Sacramento,
+        California","Longitude":-121.491,"Latitude":38.57906},{"LocationName":"San
+        Diego, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Diego, California","Longitude":-117.162,"Latitude":32.7157},{"LocationName":"San
+        Francisco, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Denver,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Denver,
+        Colorado","Longitude":-104.992256,"Latitude":39.74001},{"LocationName":"Lakewood,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Lakewood,
+        Colorado","Longitude":-105.08274,"Latitude":39.71095},{"LocationName":"District
+        of Columbia, District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"District of Columbia, District of Columbia","Longitude":-77.03196,"Latitude":38.89037},{"LocationName":"Fort
+        Walton Beach, Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Fort
+        Walton Beach, Florida","Longitude":-86.61467,"Latitude":30.4042},{"LocationName":"Panama
+        City, Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Panama
+        City, Florida","Longitude":-85.66033,"Latitude":30.15987},{"LocationName":"Tampa,
+        Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Tampa,
+        Florida","Longitude":-82.45927,"Latitude":27.94653},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Macon,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Macon,
+        Georgia","Longitude":-83.62758,"Latitude":32.839684},{"LocationName":"Warner
+        Robins, Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Warner
+        Robins, Georgia","Longitude":-83.60687,"Latitude":32.620834},{"LocationName":"Des
+        Moines, Iowa","CountryCode":"United States","CountrySubDivisionCode":"Iowa","CityName":"Des
+        Moines, Iowa","Longitude":-93.61568,"Latitude":41.589787},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"O''Fallon,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"O''Fallon,
+        Illinois","Longitude":-89.910866,"Latitude":38.59064},{"LocationName":"Indianapolis,
+        Indiana","CountryCode":"United States","CountrySubDivisionCode":"Indiana","CityName":"Indianapolis,
+        Indiana","Longitude":-86.14996,"Latitude":39.76691},{"LocationName":"Topeka,
+        Kansas","CountryCode":"United States","CountrySubDivisionCode":"Kansas","CityName":"Topeka,
+        Kansas","Longitude":-95.6775,"Latitude":39.0567},{"LocationName":"New Orleans,
+        Louisiana","CountryCode":"United States","CountrySubDivisionCode":"Louisiana","CityName":"New
+        Orleans, Louisiana","Longitude":-90.07771,"Latitude":29.95369},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Baltimore,
+        Maryland","CountryCode":"United States","CountrySubDivisionCode":"Maryland","CityName":"Baltimore,
+        Maryland","Longitude":-76.609604,"Latitude":39.290554},{"LocationName":"Detroit,
+        Michigan","CountryCode":"United States","CountrySubDivisionCode":"Michigan","CityName":"Detroit,
+        Michigan","Longitude":-83.0479,"Latitude":42.3317},{"LocationName":"Fort Snelling,
+        Minnesota","CountryCode":"United States","CountrySubDivisionCode":"Minnesota","CityName":"Fort
+        Snelling, Minnesota","Longitude":-93.18056,"Latitude":44.892776},{"LocationName":"Minneapolis,
+        Minnesota","CountryCode":"United States","CountrySubDivisionCode":"Minnesota","CityName":"Minneapolis,
+        Minnesota","Longitude":-93.26493,"Latitude":44.979034},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Saint
+        Louis, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Saint
+        Louis, Missouri","Longitude":-90.19952,"Latitude":38.62774},{"LocationName":"Helena,
+        Montana","CountryCode":"United States","CountrySubDivisionCode":"Montana","CityName":"Helena,
+        Montana","Longitude":-112.0212,"Latitude":46.58976},{"LocationName":"Charlotte,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Charlotte, North Carolina","Longitude":-80.83754,"Latitude":35.2225},{"LocationName":"Bismarck,
+        North Dakota","CountryCode":"United States","CountrySubDivisionCode":"North
+        Dakota","CityName":"Bismarck, North Dakota","Longitude":-100.77932,"Latitude":46.80537},{"LocationName":"Fargo,
+        North Dakota","CountryCode":"United States","CountrySubDivisionCode":"North
+        Dakota","CityName":"Fargo, North Dakota","Longitude":-96.78177,"Latitude":46.87591},{"LocationName":"Omaha,
+        Nebraska","CountryCode":"United States","CountrySubDivisionCode":"Nebraska","CityName":"Omaha,
+        Nebraska","Longitude":-95.94007,"Latitude":41.26067},{"LocationName":"Newark,
+        New Jersey","CountryCode":"United States","CountrySubDivisionCode":"New Jersey","CityName":"Newark,
+        New Jersey","Longitude":-74.17419,"Latitude":40.73197},{"LocationName":"Albuquerque,
+        New Mexico","CountryCode":"United States","CountrySubDivisionCode":"New Mexico","CityName":"Albuquerque,
+        New Mexico","Longitude":-106.649,"Latitude":35.0842},{"LocationName":"Central
+        Islip, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"Central Islip, New York","Longitude":-73.21191,"Latitude":40.80207},{"LocationName":"Kings,
+        New York","CountryCode":"United States","CountrySubDivisionCode":"New York","CityName":"Kings,
+        New York","Longitude":-73.959496,"Latitude":40.652878},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Syracuse,
+        New York","CountryCode":"United States","CountrySubDivisionCode":"New York","CityName":"Syracuse,
+        New York","Longitude":-76.14739,"Latitude":43.04999},{"LocationName":"Cincinnati,
+        Ohio","CountryCode":"United States","CountrySubDivisionCode":"Ohio","CityName":"Cincinnati,
+        Ohio","Longitude":-84.5041,"Latitude":39.1071},{"LocationName":"Cleveland,
+        Ohio","CountryCode":"United States","CountrySubDivisionCode":"Ohio","CityName":"Cleveland,
+        Ohio","Longitude":-81.690575,"Latitude":41.504494},{"LocationName":"Columbus,
+        Ohio","CountryCode":"United States","CountrySubDivisionCode":"Ohio","CityName":"Columbus,
+        Ohio","Longitude":-83.00301,"Latitude":39.962},{"LocationName":"Fairborn,
+        Ohio","CountryCode":"United States","CountrySubDivisionCode":"Ohio","CityName":"Fairborn,
+        Ohio","Longitude":-84.0221,"Latitude":39.8271},{"LocationName":"Oklahoma City,
+        Oklahoma","CountryCode":"United States","CountrySubDivisionCode":"Oklahoma","CityName":"Oklahoma
+        City, Oklahoma","Longitude":-97.52033,"Latitude":35.472004},{"LocationName":"Portland,
+        Oregon","CountryCode":"United States","CountrySubDivisionCode":"Oregon","CityName":"Portland,
+        Oregon","Longitude":-122.67563,"Latitude":45.511795},{"LocationName":"Philadelphia,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Philadelphia,
+        Pennsylvania","Longitude":-75.16237,"Latitude":39.95227},{"LocationName":"Aberdeen,
+        South Dakota","CountryCode":"United States","CountrySubDivisionCode":"South
+        Dakota","CityName":"Aberdeen, South Dakota","Longitude":-98.48733,"Latitude":45.45909},{"LocationName":"Rapid
+        City, South Dakota","CountryCode":"United States","CountrySubDivisionCode":"South
+        Dakota","CityName":"Rapid City, South Dakota","Longitude":-103.23089,"Latitude":44.081165},{"LocationName":"Nashville,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Nashville,
+        Tennessee","Longitude":-86.778366,"Latitude":36.16778},{"LocationName":"Austin,
+        Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Austin,
+        Texas","Longitude":-97.743,"Latitude":30.2676},{"LocationName":"Dallas, Texas","CountryCode":"United
+        States","CountrySubDivisionCode":"Texas","CityName":"Dallas, Texas","Longitude":-96.7954,"Latitude":32.778156},{"LocationName":"Fort
+        Worth, Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Fort
+        Worth, Texas","Longitude":-97.32925,"Latitude":32.74863},{"LocationName":"Houston,
+        Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Houston,
+        Texas","Longitude":-95.36978,"Latitude":29.76045},{"LocationName":"McAllen,
+        Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"McAllen,
+        Texas","Longitude":-98.2294,"Latitude":26.2074},{"LocationName":"San Antonio,
+        Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"San
+        Antonio, Texas","Longitude":-98.49462,"Latitude":29.42449},{"LocationName":"Ogden,
+        Utah","CountryCode":"United States","CountrySubDivisionCode":"Utah","CityName":"Ogden,
+        Utah","Longitude":-111.97046,"Latitude":41.222366},{"LocationName":"Salt Lake
+        City, Utah","CountryCode":"United States","CountrySubDivisionCode":"Utah","CityName":"Salt
+        Lake City, Utah","Longitude":-111.88823,"Latitude":40.75952},{"LocationName":"Auburn,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Auburn,
+        Washington","Longitude":-122.23041,"Latitude":47.3074},{"LocationName":"Seattle,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Seattle,
+        Washington","Longitude":-122.32945,"Latitude":47.60358},{"LocationName":"Spokane,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Spokane,
+        Washington","Longitude":-117.41228,"Latitude":47.65726},{"LocationName":"Milwaukee,
+        Wisconsin","CountryCode":"United States","CountrySubDivisionCode":"Wisconsin","CityName":"Milwaukee,
+        Wisconsin","Longitude":-87.906845,"Latitude":43.04181},{"LocationName":"Casper,
+        Wyoming","CountryCode":"United States","CountrySubDivisionCode":"Wyoming","CityName":"Casper,
+        Wyoming","Longitude":-106.3277,"Latitude":42.8501}],"OrganizationName":"General
+        Services Administration - Agency Wide","DepartmentName":"General Services
+        Administration","JobCategory":[{"Name":"Contracting","Code":"1102"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nStarting
+        Pay for all locations will be dependent upon the associated GS-Locality Pay
+        Table for that area.\n1102 Qualifications GS-12 &amp; below:\nBASIC REQUIREMENTS:
+        A 4-year course of study leading to a bachelor''s degree with a major in any
+        field; or atleast 24 semester hours in any combination of the following fields:
+        accounting, business, finance, law, contracts, purchasing, economics, industrial
+        management, marketing, quantitative methods, or organization andmanagement.\nSPECIALIZED
+        EXPERIENCE: In addition to the basic requirement stated above, you must have
+        one year ofspecialized experience at or equivalent to work at the next lower
+        grade level of the position to be filled.\nGS-11: Specialized experience is
+        experience that provided knowledge of formal advertising and negotiated procurement
+        procedures sufficient to develop solicitations, evaluate offers, negotiate
+        prices and terms and recommend award of contracts for a range of standard
+        or specialized supplies or services; or knowledge of contracting principles
+        and procedures sufficient to administer contracts for a range of standard
+        or specialized supplies or services.\nGS-12: Specialized experience is progressively
+        responsible experience that provided knowledge of contractingprocedures, methods,
+        a variety of contract types and use of special provisions and incentives to
+        plan and carry out pre-award and/or post-award contract assignments for the
+        acquisition of products, professional or non-professionalservices, or construction;
+        or experience which required a sufficient knowledge of contract regulations,
+        policies, and procedures and an organization''s technical and program requirements
+        in order to participate in planning,improving, or carrying out the organization''s
+        procurement program.\nSUBSTITUTION OF EDUCATION FOR SPECIALIZED EXPERIENCE:
+        If you do not have the specialized experience described above, you may qualify
+        if you have graduate education as noted below if it is in one or a combination
+        of the following fields: accounting, business, finance, law, contracts, purchasing,
+        economics, industrial management, marketing, quantitative methods, or organization
+        and management.\nGS-11 level: a Ph.D. or equivalent doctoral degree; OR three
+        full years of progressively higher level related graduate level education
+        leading to such a degree; OR a LL.M.\nThis position has a positive education
+        requirement: Applicants must submit a copy of their college or university
+        transcript(s) and certificates to verify qualifications. If selected, an official
+        transcript will be required prior to appointment.\n1102 Qualifications GS-13
+        &amp; above:You must meetthe requirements in 1, 2, or 3 below: All of the
+        following: (a) Completion of Training listed in Level I &amp; II of FAC-C
+        Course Requirements;or FAC-CLevel II or III,or a DAWIA level II or III certification.
+        If your certification is over 2 years old, 80 hours of Continuous Learning
+        Points are required to maintain certification. (b) At least 4 years of experience
+        in contracting or related positions including 1 year of specialized experience
+        at or equivalent to work at the level described below; and (c) Completion
+        of a 4-year course of study leading to a bachelor''s degree that included
+        or was supplemented by at least 24 semester hours in any combination of the
+        following fields: accounting, business, finance, law, contracts, purchasing,
+        economics, industrial management, marketing, quantitative methods, or organization
+        and management.\nException: If you were in a GS-1102 position on January 1,
+        2000, you will be exempt from meeting the educational requirements for the
+        grade level of that position. However, to be promoted you will have to meet
+        Option 1 or 3. Waiver: GSA''s senior procurement executive has the discretion
+        to waive any or all of the requirements in 1 above. SPECIALIZED EXPERIENCE:
+        In addition to the basic requirement stated above, you must have one year
+        ofspecialized experience at or equivalent to work at the next lower grade
+        level of the position to be filled.\nGS-13: Experience in performing the full
+        range of pre-award and/or post-award activities utilizing various types ofcontracts
+        such as fixed price, various cost types, requirements, performance based and
+        multiple award schedules,and evidence of professional potential, business
+        acumen, and drive for results, relationship building, and self motivation
+        in order to procure a variety of complex or specialized products and/or services;
+        OR experience requiring sufficient knowledge of contracting regulations, policies,
+        and procedures and an organization''s programand technical requirements in
+        order to conduct reviews of contracts or contracting actions, recommend or
+        planimprovements to an organization''s procurement program.\nGS-14: Experience
+        in evaluating or implementing contracting programs; OR leading or supervising
+        contractingprofessionals providing contracting services for the acquisition
+        of a wide range of supplies, services (professionaland non-professional),
+        and/or construction; OR contracting experience that demonstrated the ability
+        to perform thefull range of highly complex pre-award and post-award activities
+        utilizing a variety of types of contracts andevidence of professional potential,
+        business acumen, drive for results, relationship building, and self-motivation
+        inorder to procure supplies, services, or construction associated with an
+        organization.\nGS-15: Experience that includes planning and evaluating programs
+        and operations; overseeing the organization''stechnical and managerial activities
+        relating to the contracting function; or ensuring that agency regulation andguidance
+        implement statutory requirements and sound policies across the entire spectrum
+        of procurement;overseeing the development, implementation, and communication
+        of policies that directly affect the terms andconditions in contracts, and
+        providing the competencies necessary to perform the full range of highly complex
+        pre-awardand post award activities utilizing a variety of types of contracts
+        and evidence of professional potential,business acumen, drive for results,
+        relationship building, and self-motivation in order to procure supplies, services,or
+        construction associated with an organization.\nThis position has a positive
+        education requirement: Applicants must submit a copy of their college or university
+        transcript(s) and certificates to verify qualifications. If selected, an official
+        transcript will be required prior to appointment.","PositionRemuneration":[{"MinimumRange":"64649.0","MaximumRange":"172500.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-02-03","PositionEndDate":"2022-02-02","PublicationStartDate":"2021-02-03","ApplicationCloseDate":"2022-02-02","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"THIS
+        IS A PUBLIC NOTICE: Please review further information below regarding how
+        this posting will be used.\nAs a contracting professional, you will be responsible
+        for the procurement of highly specialized equipment,components and systems
+        for high-rise buildings and their operating systems, the construction of specializedequipment
+        or special purpose buildings, information technology equipment and systems,
+        professional or technicalservices, and/or a variety of supplies.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"11","HighGrade":"15","OrganizationCodes":"GS/GS00","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103707","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=103707&S=1","MajorDuties":["This
+        Notice is issued under direct-hire authority to recruit new talent to occupations
+        for which there is a severe shortage of candidates. We have a severe shortage
+        of qualified applicants for our Contract Specialist positions. To help us
+        fill these jobs, we have been granted &ldquo;Direct Hire Authority&rdquo;
+        or DHA. This means that when we have a vacant job, we can hire any qualified
+        candidate, either from this notice or from any source. The benefit of applying
+        to this notice is that your application may be shared with a hiring manager
+        if they request resumes from this notice.\nA few key facts about this DHA
+        notice: Many vacancies may be filled at the GS-11 through GS-15 levels\nJobs
+        have varying opportunities for advancement (promotion potential)\nSupervisory
+        and non-supervisory opportunities will vary\nJobs may be located in any of
+        the metropolitan areas listed.\nAvailability of positions and grade levels
+        vary by location. Promotion potential varies by position.\nCurrent civil service
+        employees will receive new appointments if selected under this Direct Hire
+        Authority. Each metropolitan area will independently review applications and
+        decide who to interview. For questions aboutthe selection process, contact
+        the following: Greater Southeast Region - AL, FL, GA, KY, MS, NC, SC, TN:404-331-3186\nNew
+        England Region - CT, ME, MA, NH, RI, VT: HRBoston@gsa.gov\nGreat Lakes Region
+        - IL, IN, OH, MI, MN, WI: 312-353-5547\nRocky Mountain Region - CO, MT, ND,
+        SD, UT, WY: vacancy.inquiries@gsa.gov\nGreater Southwest Region - AR, LA,
+        NM, OK, TX:vacancy.inquiries@gsa.gov\nHeartland Region -IA, KS, MO, NE: 816-926-8395\nNortheast
+        &amp; Caribbean Region - NJ, NY, VI, PR: 212-264-5557\nMid-Atlantic Region
+        - DE, MD, PA, VA, WV: 215-446-4973\nPacific Rim Region - AZ, CA, NV, HI:vacancy.inquiries@gsa.gov\nNorthwest
+        Arctic Region - AK, ID, OR, WA:vacancy.inquiries@gsa.gov or 253-931-7742\nWashington,
+        DC (Central Office/National Capital Region):-Public Buildings Service: Kevin
+        Towe, 202-341-6663-Federal Acquisition Service: Amina Hamilton, 202-969-5593-Staff
+        offices: Susan Lewis, 202-316-9547-Office of Technology Transformation Service:
+        Stephanie Bernstein, 215-446-4691 If you have general questions about this
+        job posting, or are having difficulty applying, contact us at 816-823-2006,or
+        nrc@gsa.gov.\nFor information on DHA, please visit https://www.opm.gov/directhire/index.asp.\nDuties:As
+        a contracting professional, you will be responsible for the procurement of
+        highly specialized equipment,components and systems for high-rise buildings
+        and their operating systems, the construction of specializedequipment or special
+        purpose buildings, information technology equipment and systems, professional
+        or technicalservices, and/or a variety of supplies.\nYour duties at the GS-11
+        and GS-12 may also include: Pre/post-award and termination activities, such
+        as: analyzing requirements, recommending revisions to statements of work/specifications,
+        determining the appropriate type of contract, establishing milestones, procurement
+        planning, conducting post-award and contractual terminations, initiating briefings
+        with contractors to ensure full understanding of terms, handling modifications,
+        resolution of issues related to non-compliance, and the termination process.\nDeveloping,
+        implementing and analyzing data requirements for planning and measurement
+        systems\nAnalyzing performance of procurement activities against various procurement
+        indicators and goals\nAnalyzing data to determine trends\nAssistance in tracking/monitoring
+        contract actions to ensure compliance with GSA policy, administrative procedures,
+        regulations, and statutes Your duties at the GS-13, GS-14 and GS-15 may also
+        include: Pre/Post Award contracting functions that help clients achieve results
+        and meet their mission.\nIdentifying procurement objectives and methodologies;
+        developing statements of work; performing analyses of elements of cost; making
+        competitive range determinations; conducting pre-proposal conferences; planning
+        comprehensive negotiation strategy; coordinating with technical experts, leading
+        negotiations and awarding contracts\nDeveloping, coordinating, and revising
+        a wide variety of Government-wide procurement policies, reviewingproposed
+        changes to existing regulations and determining whether they should be addressed\nProviding
+        principal policy advice, analyzing comments and proposed legislative changes\nDeveloping
+        and presenting presentations and defending complex and often controversial
+        positions whichare subject to considerable Congressional scrutiny and preparing
+        expert response to Congressional correspondence\nIdentifying and analyzing
+        acquisition process problems, trends, and emerging needs. Formulating and
+        justifying new statutory initiatives to address unique problems, to meet newly
+        emerging acquisition needs, and to resolve critical procurement process problems"],"Education":"Note:
+        If you are using foreign education to meet qualification requirements, you
+        must send a Certificate of Foreign Equivalency with your transcript in order
+        to receive credit for that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position\nServe
+        a one year supervisory or managerial probationary period, if required\nYou
+        may be required to participate in the Region''s Continuity of Operations Plan
+        (COOP), representing the Service and/or GSA as a whole. This may involve participating
+        in COOP meetings and planning activities;performing mission-critical work
+        at a designated location other than the traditional GSA office site (whichmay
+        be outside of the commuting area); and ensuring that GSA''s needs are still
+        being met in the event ofan emergency, disaster or otherwise unforeseen circumstance
+        disrupting traditional office operations. EXPIRATION OF YOUR APPLICATION:
+        Please be advised that although this posting is active for one year, all applications
+        will have a 120 day expiration. If you are still interested in being considered
+        after your 120 days are up, you must extend your application PRIOR to that
+        date. To extend, please return to the Applicant Dashboard on your USAJOBS
+        account, select the vacancy, and update your application.","Evaluations":"Applications
+        will be evaluated against the basic qualifications. Qualified candidates will
+        be considered inaccordance with the Office of Personnel Management Direct
+        Hire Guidelines. Veterans'' Preference does not applyto the direct hire recruitment
+        procedures. Certain selections made under this notice will be processed as
+        newappointments to the civil service. Current civil service employees might
+        be given new appointments to the civilservice. You may not be considered for
+        the position, if any part of the application is incomplete or missing therequired
+        supporting documentation. Falsifying your background, education and/or experience
+        is cause for nothiring you or dismissing you if hired.\nIf you are an Interagency
+        Career Transition Assistance Plan eligible or a GSA Career Transition Assistanceeligible,
+        you must be considered well qualified to receive priority (ICTAP/CTAP). Well
+        qualified is defined aspossession of the majority of competencies required
+        for the position and will be determined, based upon a reviewof your resume
+        against the competencies required for the position being filled. To preview
+        questions please click here.","HowToApply":"This Direct Hire Public Notice
+        will be used to build a list/inventory of applicants that may be referred
+        as vacanciesbecome available.\nYou must submit a complete online application,
+        including any required documents, before your eligibility can be confirmed.
+        Errors or omissions may result in your not being considered for this vacancy.
+        You can modify/complete your application any time before the vacancy date/time
+        deadline. Simply return to USAJOBS, select the vacancy, and update your application.
+        For more detailed instructions on how to apply, read the Apply for a GSA Job
+        on the GSA website.\nTo begin, click the Apply Online button on the vacancy
+        announcement. Sign in or register on USAJOBS and select a resume and documents
+        to include in your application.\nOnce you have clicked Apply for this position
+        now, you will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJOBSor get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this job.\nNote: Review
+        the REQUIRED DOCUMENTS section of this posting to determine which apply to
+        you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the posting prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the posting
+        closes.","WhatToExpectNext":"This Notice is issued under direct-hire authority
+        to recruit new talent to occupations for which there is a severe shortage
+        of candidates. We have a severe shortage of qualified applicants for our Contract
+        Specialist positions. To help us fill these jobs, we have been granted &ldquo;Direct
+        Hire Authority&rdquo; or DHA. This means that when we have a vacant job, we
+        can hire any qualified candidate, either from this notice or from any source.
+        The benefit of applying to this notice is that your application may be shared
+        with a hiring manager if they request resumes from this notice.\nThank you
+        for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted. Review the following list to determine
+        what you need to submit. If you are claiming veterans&rsquo; preference: (a)
+        Copy of your Certificate of Release or Discharge From Active Duty, DD-214
+        that shows the dates of your active duty service. If selected, a DD-214 showing
+        your type of discharge (member 4 copy) will be required prior to appointment.
+        (b) If you are claiming 10-point preference or derived preference (a spouse,
+        widow or widower, or parent of a deceased or disabled veteran), submit both
+        of the following in addition to the DD-214: (1) completedSF-15form; and (2)
+        proof of your entitlement (refer to SF-15 for complete list).\nIf you are
+        active duty military- Certification on a letterhead from your military branch
+        that includes your rank, character of service (must be under honorable conditions)
+        &amp; military service dates including discharge/release date (must be no
+        later than 120 days after the date the certification is submitted).\nIf you
+        are ICTAP/CTAPeligible - submit a, b, and c: (a) proof of eligibility including
+        agency notice; (b) SF-50, and (c) most recent performance appraisal.\nCurrent
+        or Former Political Appointees: Submit SF-50.\nCollege transcripts:You must
+        submit a photocopy of your college transcript(s). If selected, an official
+        transcript will be required prior to appointment. For education completed
+        outside the United States, also submit a valid foreign credential evaluation
+        that substantiates possession of the required education.\nContracting Documentation:
+        Submit A or B:\n(A) List of completed courses as described in the requirements
+        section of this announcement. The list must include: official course title,
+        course number, training provider, training hours completed, and the date completed\n(B)
+        Proof of contracting certification: FAC-C or DAWIA Level II or higher certification
+        (copy of certificate)\nIf certification is over 2 years old, also submit (a)
+        or (b) below: Continuous Learning Points (CLPs) history identifying the completion
+        of 80 CLPs every two years. The 80 CLPs every two years must be from the issuance
+        date of certification to the current period.\nIf you are a FAITAS member,
+        you may submit your Continuous Learning Achievement Certificate from FAITAS.
+        On your \"My Continuous Learning\" page, click on the \"approved\" link under
+        Achievement Status to print a copy of your most recent certificate.","Benefits":"You
+        will have access to many benefits including: Health insurance (choose from
+        a wide range of plans)\nLife insurance coverage with several options\nSick
+        leave and vacation time, including 10 paid holidays per year\nThrift Savings
+        Plan (similar to a 401(k) plan)\nFlexible work schedules\nTransit and child
+        care subsidies\nFlexible spending accounts\nLong-term care insurance\nTraining
+        and development","BenefitsUrl":"http://www.opm.gov/insure/federal_employ/index.asp","OtherInformation":"Bargaining
+        Unit status: Varies based on job and location\nIf you are selected for this
+        position at a grade lower than the full performance level, you may be promoted
+        up tothat grade level without further competition in accordance with all applicable
+        regulations. However, promotions are not guaranteed and are dependent on performance.\nTravel,
+        transportation, and relocation expenses may be paid when authorized and approved
+        by appropriateagency officials on a case by case basis.\nGSA may pay a recruitment
+        incentive to a newly-appointed employee; a relocation incentive to a currentemployee;
+        or offer annual leave service credit to an applicant with related non-federal
+        or uniformed services workexperience. Determinations to pay/allow incentives
+        will be made on a case-by-case basis, subject to fundingavailability and documentation
+        that the position is \"hard-to-fill\".\nSelected applicants may qualify for
+        credit toward annual leave accrual based on prior non-federal work experienceor
+        uniformed service experience.\nAdditional vacancies may be filled from this
+        announcement as needed. This vacancy announcement does notpreclude filling
+        this position by other means. Management also has the right not to fill the
+        position. EXPIRATION OF YOUR APPLICATION: Please be advised that although
+        this posting is active for one year, all applications will have a 120 day
+        expiration. If you are still interested in being considered after your 120
+        days are up, you must extend your application PRIOR to that date. To extend,
+        please return to the Applicant Dashboard on your USAJOBS account, select the
+        vacancy, and update your application.","KeyRequirements":["US Citizens and
+        National (Residents of American Samoa and Swains Island)","Meet all eligibility
+        criteria within 30 days of the closing date","Register with Selective Service,
+        if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"nrc@gsa.gov","AgencyContactPhone":"000-000-0000","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"595608600","MatchedObjectDescriptor":{"PositionID":"21NRCA062LB-DHA","PositionTitle":"Interdisciplinary
+        General Engineer / Civil Engineer (Supervisory/Non-Supervisory)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/595608600","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/595608600?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Birmingham, Alabama","CountryCode":"United
+        States","CountrySubDivisionCode":"Alabama","CityName":"Birmingham, Alabama","Longitude":-86.8115,"Latitude":33.5203},{"LocationName":"Phoenix,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix,
+        Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"Tucson,
+        Arizona","CountryCode":"United States","CountrySubDivisionCode":"Arizona","CityName":"Tucson,
+        Arizona","Longitude":-110.96976,"Latitude":32.221554},{"LocationName":"Fresno,
+        California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Fresno,
+        California","Longitude":-119.78568,"Latitude":36.740616},{"LocationName":"Laguna
+        Niguel, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Laguna
+        Niguel, California","Longitude":-117.708374,"Latitude":33.559406},{"LocationName":"Los
+        Angeles, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Los
+        Angeles, California","Longitude":-118.245,"Latitude":34.0535},{"LocationName":"Oakland,
+        California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Oakland,
+        California","Longitude":-122.273026,"Latitude":37.805065},{"LocationName":"Pasadena,
+        California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Pasadena,
+        California","Longitude":-118.144264,"Latitude":34.147236},{"LocationName":"Sacramento,
+        California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Sacramento,
+        California","Longitude":-121.491,"Latitude":38.57906},{"LocationName":"San
+        Diego, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Diego, California","Longitude":-117.162,"Latitude":32.7157},{"LocationName":"San
+        Francisco County, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco County, California","Longitude":-122.42905,"Latitude":37.77986},{"LocationName":"San
+        Jose, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Jose, California","Longitude":-121.885796,"Latitude":37.338474},{"LocationName":"Lakewood,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Lakewood,
+        Colorado","Longitude":-105.08274,"Latitude":39.71095},{"LocationName":"Washington,
+        District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904},{"LocationName":"Miami,
+        Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Miami,
+        Florida","Longitude":-80.23742,"Latitude":25.728985},{"LocationName":"Tampa,
+        Florida","CountryCode":"United States","CountrySubDivisionCode":"Florida","CityName":"Tampa,
+        Florida","Longitude":-82.45927,"Latitude":27.94653},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Savannah,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Savannah,
+        Georgia","Longitude":-81.09072,"Latitude":32.08078},{"LocationName":"Honolulu,
+        Hawaii","CountryCode":"United States","CountrySubDivisionCode":"Hawaii","CityName":"Honolulu,
+        Hawaii","Longitude":-157.858,"Latitude":21.3047},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Springfield,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Springfield,
+        Illinois","Longitude":-89.64361,"Latitude":39.801056},{"LocationName":"Indianapolis,
+        Indiana","CountryCode":"United States","CountrySubDivisionCode":"Indiana","CityName":"Indianapolis,
+        Indiana","Longitude":-86.14996,"Latitude":39.76691},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Baltimore,
+        Maryland","CountryCode":"United States","CountrySubDivisionCode":"Maryland","CityName":"Baltimore,
+        Maryland","Longitude":-76.609604,"Latitude":39.290554},{"LocationName":"Detroit,
+        Michigan","CountryCode":"United States","CountrySubDivisionCode":"Michigan","CityName":"Detroit,
+        Michigan","Longitude":-83.0479,"Latitude":42.3317},{"LocationName":"Grand
+        Rapids, Michigan","CountryCode":"United States","CountrySubDivisionCode":"Michigan","CityName":"Grand
+        Rapids, Michigan","Longitude":-85.67118,"Latitude":42.96641},{"LocationName":"Minneapolis,
+        Minnesota","CountryCode":"United States","CountrySubDivisionCode":"Minnesota","CityName":"Minneapolis,
+        Minnesota","Longitude":-93.26493,"Latitude":44.979034},{"LocationName":"Saint
+        Paul, Minnesota","CountryCode":"United States","CountrySubDivisionCode":"Minnesota","CityName":"Saint
+        Paul, Minnesota","Longitude":-93.09333,"Latitude":44.94383},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Jackson,
+        Mississippi","CountryCode":"United States","CountrySubDivisionCode":"Mississippi","CityName":"Jackson,
+        Mississippi","Longitude":-90.18049,"Latitude":32.29869},{"LocationName":"Oxford,
+        Mississippi","CountryCode":"United States","CountrySubDivisionCode":"Mississippi","CityName":"Oxford,
+        Mississippi","Longitude":-89.518776,"Latitude":34.364014},{"LocationName":"Butte,
+        Montana","CountryCode":"United States","CountrySubDivisionCode":"Montana","CityName":"Butte,
+        Montana","Longitude":-112.52089,"Latitude":46.001755},{"LocationName":"Helena,
+        Montana","CountryCode":"United States","CountrySubDivisionCode":"Montana","CityName":"Helena,
+        Montana","Longitude":-112.0212,"Latitude":46.58976},{"LocationName":"Charlotte,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Charlotte, North Carolina","Longitude":-80.83754,"Latitude":35.2225},{"LocationName":"Raleigh,
+        North Carolina","CountryCode":"United States","CountrySubDivisionCode":"North
+        Carolina","CityName":"Raleigh, North Carolina","Longitude":-78.64267,"Latitude":35.78551},{"LocationName":"Bismarck,
+        North Dakota","CountryCode":"United States","CountrySubDivisionCode":"North
+        Dakota","CityName":"Bismarck, North Dakota","Longitude":-100.77932,"Latitude":46.80537},{"LocationName":"Fargo,
+        North Dakota","CountryCode":"United States","CountrySubDivisionCode":"North
+        Dakota","CityName":"Fargo, North Dakota","Longitude":-96.78177,"Latitude":46.87591},{"LocationName":"Newark,
+        New Jersey","CountryCode":"United States","CountrySubDivisionCode":"New Jersey","CityName":"Newark,
+        New Jersey","Longitude":-74.17419,"Latitude":40.73197},{"LocationName":"Las
+        Vegas, Nevada","CountryCode":"United States","CountrySubDivisionCode":"Nevada","CityName":"Las
+        Vegas, Nevada","Longitude":-115.14,"Latitude":36.1719},{"LocationName":"Reno,
+        Nevada","CountryCode":"United States","CountrySubDivisionCode":"Nevada","CityName":"Reno,
+        Nevada","Longitude":-119.813,"Latitude":39.5274},{"LocationName":"Brooklyn,
+        New York","CountryCode":"United States","CountrySubDivisionCode":"New York","CityName":"Brooklyn,
+        New York","Longitude":-73.9494,"Latitude":40.6452},{"LocationName":"New York,
+        New York","CountryCode":"United States","CountrySubDivisionCode":"New York","CityName":"New
+        York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Syracuse,
+        New York","CountryCode":"United States","CountrySubDivisionCode":"New York","CityName":"Syracuse,
+        New York","Longitude":-76.14739,"Latitude":43.04999},{"LocationName":"Cincinnati,
+        Ohio","CountryCode":"United States","CountrySubDivisionCode":"Ohio","CityName":"Cincinnati,
+        Ohio","Longitude":-84.5041,"Latitude":39.1071},{"LocationName":"Cleveland,
+        Ohio","CountryCode":"United States","CountrySubDivisionCode":"Ohio","CityName":"Cleveland,
+        Ohio","Longitude":-81.690575,"Latitude":41.504494},{"LocationName":"Columbus,
+        Ohio","CountryCode":"United States","CountrySubDivisionCode":"Ohio","CityName":"Columbus,
+        Ohio","Longitude":-83.00301,"Latitude":39.962},{"LocationName":"Philadelphia,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Philadelphia,
+        Pennsylvania","Longitude":-75.16237,"Latitude":39.95227},{"LocationName":"Pittsburgh,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Pittsburgh,
+        Pennsylvania","Longitude":-79.99746,"Latitude":40.43831},{"LocationName":"Hato
+        Rey, Puerto Rico","CountryCode":"United States","CountrySubDivisionCode":"Puerto
+        Rico","CityName":"Hato Rey, Puerto Rico","Longitude":-66.05612,"Latitude":18.42488},{"LocationName":"Rapid
+        City, South Dakota","CountryCode":"United States","CountrySubDivisionCode":"South
+        Dakota","CityName":"Rapid City, South Dakota","Longitude":-103.23089,"Latitude":44.081165},{"LocationName":"Nashville,
+        Tennessee","CountryCode":"United States","CountrySubDivisionCode":"Tennessee","CityName":"Nashville,
+        Tennessee","Longitude":-86.778366,"Latitude":36.16778},{"LocationName":"Austin,
+        Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Austin,
+        Texas","Longitude":-97.743,"Latitude":30.2676},{"LocationName":"Fort Worth,
+        Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Fort
+        Worth, Texas","Longitude":-97.32925,"Latitude":32.74863},{"LocationName":"Salt
+        Lake City, Utah","CountryCode":"United States","CountrySubDivisionCode":"Utah","CityName":"Salt
+        Lake City, Utah","Longitude":-111.88823,"Latitude":40.75952},{"LocationName":"Norfolk,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Norfolk,
+        Virginia","Longitude":-76.28507,"Latitude":36.846825},{"LocationName":"Richmond,
+        Virginia","CountryCode":"United States","CountrySubDivisionCode":"Virginia","CityName":"Richmond,
+        Virginia","Longitude":-77.433655,"Latitude":37.5407},{"LocationName":"Auburn,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Auburn,
+        Washington","Longitude":-122.23041,"Latitude":47.3074},{"LocationName":"Milwaukee,
+        Wisconsin","CountryCode":"United States","CountrySubDivisionCode":"Wisconsin","CityName":"Milwaukee,
+        Wisconsin","Longitude":-87.906845,"Latitude":43.04181},{"LocationName":"Charleston,
+        West Virginia","CountryCode":"United States","CountrySubDivisionCode":"West
+        Virginia","CityName":"Charleston, West Virginia","Longitude":-81.63893,"Latitude":38.350216}],"OrganizationName":"General
+        Services Administration - Agency Wide","DepartmentName":"General Services
+        Administration","JobCategory":[{"Name":"General Engineering","Code":"0801"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nStarting
+        Pay for all locations will be dependent upon the associated GS-Locality Pay
+        Table for that area.\nBASIC REQUIREMENTS FOR ENGINEERS: A Degree in professional
+        engineering OR a combination ofcollege-level education, training, and/or technical
+        experience. For specifics on qualifying education and/orexperience - use the
+        following link: Basic Requirements for Engineer Positions.\nSPECIALIZED EXPERIENCE:
+        In addition to the basic requirement stated above, you must have one year
+        ofspecialized experience at or equivalent to work at the next lower grade
+        level of the position to be filled. Read each grade level below carefully.\nGS-11:Applicant
+        must have one year of specialized experience equivalent to the GS-9 in the
+        federal service. Specialized experience is experience applying professional
+        engineering principles, concepts, and practices in the design of construction
+        or alteration projects involving large and moderately complex buildings or
+        major building systems; or the coordination of the activities of architects,
+        engineers, tenants and construction contractors on such projects. Such experience
+        must also include having assisted in managing projects and/or large portions
+        of projects (balance scope/quality, schedule and budget) requiring the services
+        of multiple disciplines from project initiation phase through project closeout.OR\nSubstitution
+        of Education for Specialized Experience: Applicant must have three years of
+        progressively higher level graduate education leading to a PhD. degree, or
+        a PhD, or equivalent doctoral degree that is directly related to the position.OR\nCombination
+        of Education and Specialized Experience: Applicants must havea combination
+        of graduate level education and appropriate experience that together meet
+        the qualification requirements of this position.\nGS-12: Applicant must have
+        one year of specialized experience equivalent to the GS-11 in the federal
+        service. Specialized experience is applying professional engineering principles,
+        concepts, and practices in the design of construction or alteration projects
+        involving large and complex buildings or major building systems; or the coordination
+        of the activities of architects, engineers, tenants and construction contractors
+        on such projects. Such experience must also include having independently managed
+        projects and/or large portions of projects (balance scope/quality, schedule
+        and budget) requiring the services of multiple disciplines from project initiation
+        phase through project closeout.\nGS-13:Applicant must have one year of specialized
+        experience equivalent to the GS-12 in the federal service.Specialized experience
+        is applying professional engineering principles, concepts, and practices in
+        the design of construction or alteration projects involving large and complex
+        buildings or major building systems; and the coordination of the activities
+        of architects, engineers, tenants and construction contractors on such projects.
+        Such experience must also include having independently managed projects (balance
+        scope/quality, schedule and budget) requiring the services of multiple disciplines
+        from project initiation phase through project closeout.\nThis position has
+        a positive education requirement. Applicants MUST submit a copy of their college
+        or university transcript(s) and certificates to verify qualifications. If
+        selected, an official transcript will be required prior to appointment.","PositionRemuneration":[{"MinimumRange":"64649.0","MaximumRange":"146120.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-03-21","PositionEndDate":"2022-03-20","PublicationStartDate":"2021-03-21","ApplicationCloseDate":"2022-03-20","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"THIS
+        IS A PUBLIC NOTICE: Please review further information below regarding how
+        this posting will be used.\nAs a General Engineer/Civil Engineer, you will
+        beresponsible for the performance of all aspects of the project management
+        of Prospectus Level and non-prospectus level projects. Oversees and/or is
+        involved in the business management of building and/or leasing projects from
+        the preliminary identification stage through initiation, planning, execution
+        and project closeout stages.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"11","HighGrade":"13","OrganizationCodes":"GS/GS00","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104060","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104060&S=1","MajorDuties":["This
+        Notice is issued under direct-hire authority to recruit new talent to occupations
+        for which there is a severe shortage of candidates. We have a severe shortage
+        of qualified applicants for our General Engineer / Civil Engineer positions.
+        To help us fill these jobs, we have been granted &ldquo;Direct Hire Authority&rdquo;
+        or DHA. This means that when we have a vacant job, we can hire any qualified
+        candidate, either from this notice or from any source. The benefit of applying
+        to this notice is that your application may be shared with a hiring manager
+        if they request resumes from this notice.\nA few key facts about this DHA
+        notice: Many vacancies may be filled at the GS-11 through GS-13 levels.\nJobs
+        have varying opportunities for advancement (promotion potential).\nSupervisory
+        and non-supervisory opportunities will vary.\nJobs may be located in any of
+        the metropolitan areas listed.\nAvailability of positions and grade levels
+        vary by location. Promotion potential varies by position.\nCurrent civil service
+        employees will receive new appointments, if selected under this Direct Hire
+        Authority. Each metropolitan area will independently review applications and
+        decide who to interview.\nFor questions specifically related to any individual
+        location, please send an inquiry (indicating the location of interest) to:pbsbvacancyinquiries@gsa.gov\nIf
+        you have general questions about this job posting, or are having difficulty
+        applying, contact us at 816-823-2006,or nrc@gsa.gov.\nFor information on DHA,
+        please visit https://www.opm.gov/directhire/index.asp.\nDuties:\nAs a General/Civil
+        Engineer you will be responsible responsible for the performance of all aspects
+        of the project management of Prospectus and non-prospectus level projects.
+        Oversees and/or is involved in the business management of building and/or
+        leasing projects from the preliminary identification stage through initiation,
+        planning, execution and project closeout stages.Assignments encompass a broad
+        range of responsibilities including planning, organizing, controlling, coordinating,
+        reviewing, and approving design, construction, and related work performed
+        by other GSA organizations.\nYour duties may also include: Professional Engineering
+        - Conducting site surveys to determine condition of structures and systems,
+        evaluates requirements and recommends incorporation, modification or exclusion
+        of various project features to best meet long-term needs of the government
+        in consideration of such factors as urgency of needed repairs or redesign,
+        useful life of building components and systems, and cost/benefits involved.
+        Reviewing engineering problems and provides recommendations to GSA management.
+        Preparing technical reports on engineering matters that influence current
+        and future regional programs.\nProject Management - Range of responsibilities
+        leading to the successful initiation, planning, execution, and closure of
+        leasing, design, or construction projects, including prospectus level and
+        non-prospectus level projects, which comprise the most major, politically
+        sensitive, and complex initiatives.\nContracting Officer''s Representative
+        - Represents GSA and the Contracting Officer (CO) on Architecture/Engineering,
+        Construction Management, lease and Construction contracts as the Contracting
+        Officer&rsquo;s Representative (COR) and exercises delegated authority from
+        the CO reviewing, inspecting, and directing work as it proceeds in compliance
+        with contract requirements. Recommends payment for services received or appropriate
+        action where non-conformance with the contract is discovered.\nCustomer Service
+        -Serving as the primary point of contact for a variety of customers both internal
+        and external to the organization."],"Education":"Note: If you are using foreign
+        education to meet qualification requirements, you must send a Certificate
+        of Foreign Equivalency with your transcript in order to receive credit for
+        that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nServe a one year
+        supervisory or managerial probationary period, if required.\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position\nYou
+        may be required to participate in the Region''s Continuity of Operations Plan
+        (COOP), representing the Service and/or GSA as a whole. This may involve participating
+        in COOP meetings and planning activities;performing mission-critical work
+        at a designated location other than the traditional GSA office site (whichmay
+        be outside of the commuting area); and ensuring that GSA''s needs are still
+        being met in the event ofan emergency, disaster or otherwise unforeseen circumstance
+        disrupting traditional office operations.","Evaluations":"Applications will
+        be evaluated against the basic qualifications. Qualified candidates will be
+        considered inaccordance with the Office of Personnel Management Direct Hire
+        Guidelines. Veterans'' Preference does NOT applyto the direct hire recruitment
+        procedures. Certain selections made under this notice will be processed as
+        newappointments to the civil service. Current civil service employees might
+        be given new appointments to the civilservice. You may not be considered for
+        the position, if any part of the application is incomplete or missing therequired
+        supporting documentation. Falsifying your background, education and/or experience
+        is cause for nothiring you or dismissing you if hired.\nIf you are an Interagency
+        Career Transition Assistance Plan eligible or a GSA Career Transition Assistanceeligible,
+        you must be considered well qualified to receive priority. ICTAP/CTAP. Well
+        qualified is defined aspossession of the majority of competencies required
+        for the position and will be determined, based upon a reviewof your resume
+        against the competencies required for the position being filled. To preview
+        questions please click here.","HowToApply":"This Direct Hire Public Notice
+        will be used to build a list/inventory of applicants that may be referred
+        as vacanciesbecome available.\nYou must submit a complete online application
+        including any required documents prior to 11:59 pm Eastern Time on the closing
+        date of the Announcement. Errors or omissions may result in your not being
+        considered for this vacancy. You can modify/complete your application any
+        time before the vacancy date/time deadline. Simply return to USAJOBS, select
+        the vacancy, and update your application. For more detailed instructions on
+        how to apply, read the Apply for a GSA Job on the GSA website.To begin, click
+        the Apply Online button on the vacancy announcement. Sign in or register on
+        USAJobs and select a resume and documents to include in your application.\nOnce
+        you have clicked Apply for this position now, you will be taken to the GSA
+        site to complete the application process.\nClick the Apply To This Vacancy
+        and complete all steps in the application process until the Confirmation indicates
+        your application is complete. If you click Return to USAJobs or get timed
+        out prior to receiving confirmation, your application will not be submitted
+        and cannot be considered for this vacancy.\nNote: Review the REQUIRED DOCUMENTS
+        section of this announcement to determine which apply to you and must be submitted
+        online. You may choose one or more of the following options to submit your
+        document(s): Upload (from your computer); USAJOBS (click the \"USAJOBS\" link
+        to complete the transfer process) or FAX (read the &ldquo;Fax instructions&rdquo;
+        provided prior to printing the Fax Cover Sheet and faxing your information).
+        Need Assistance in Applying? Contact the HR representative listed on the announcement
+        prior to the application deadline. We are available to assist you Monday-Friday
+        during normal business hours. You must receive HR approval before deviating
+        from these instructions. Be sure to APPLY EARLY as most assessments must be
+        completed fully and submitted before the announcement closing.","WhatToExpectNext":"This
+        Notice is issued under direct-hire authority to recruit new talent to occupations
+        for which there is a severe shortage of candidates. We have a severe shortage
+        of qualified applicants for our General Engineer / Civil Engineer positions.
+        To help us fill these jobs, we have been granted &ldquo;Direct Hire Authority&rdquo;
+        or DHA. This means that when we have a vacant job, we can hire any qualified
+        candidate, either from this notice or from any source. The benefit of applying
+        to this notice is that your application may be shared with a hiring manager
+        if they request resumes from this notice.\nThank you for your interest in
+        working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are claiming veterans&rsquo;
+        preference: (a) Copy of your Certificate of Release or Discharge From Active
+        Duty, DD-214 that shows the dates of your active duty service. If selected,
+        a DD-214 showing your type of discharge (member 4 copy) will be required prior
+        to appointment. (b) If you are claiming 10-point preference or derived preference
+        (a spouse, widow or widower, or parent of a deceased or disabled veteran),
+        submit both of the following in addition to the DD-214: (1) completedSF-15form;
+        and (2) proof of your entitlement (refer to SF-15 for complete list).\nIf
+        you are active duty military-Certification on a letterhead from your military
+        branch that includes your rank, character of service (must be under honorable
+        conditions) &amp; military service dates including discharge/release date
+        (must be no later than 120 days after the date the certification is submitted).\nIf
+        you are ICTAP/CTAPeligible - submit a, b, and c: (a) proof of eligibility
+        including agency notice; (b) SF-50, and (c) most recent performance appraisal.\nCurrent
+        or Former Political Appointees: Submit SF-50.\nCollege transcripts:This position
+        has a positive education requirement. Applicants MUST submit a copy of their
+        college or university transcript(s) and certificates to verify qualifications.
+        If selected, an official transcript will be required prior to appointment.For
+        education completed outside the United States, also submit a valid foreign
+        credential evaluation that substantiates possession of the required education.","Benefits":"You
+        will have access to many benefits including: Health insurance (choose from
+        a wide range of plans)\nLife insurance coverage with several options\nSick
+        leave and vacation time, including 10 paid holidays per year\nThrift Savings
+        Plan (similar to a 401(k) plan)\nFlexible work schedules\nTransit and child
+        care subsidies\nFlexible spending accounts\nLong-term care insurance\nTraining
+        and development","BenefitsUrl":"http://www.opm.gov/insure/federal_employ/index.asp","OtherInformation":"Bargaining
+        Unit status: Varies based on job and location\nIf you are selected for this
+        position at a grade lower than the full performance level, you may be promoted
+        up tothat grade level without further competition in accordance with all applicable
+        regulations. However, promotions are not guaranteed and are dependent on performance.\nTravel,
+        transportation, and relocation expenses may be paid when authorized and approved
+        by appropriateagency officials on a case by case basis.\nGSA may pay a recruitment
+        incentive to a newly-appointed employee; a relocation incentive to a currentemployee;
+        or offer annual leave service credit to an applicant with related non-federal
+        or uniformed services workexperience. Determinations to pay/allow incentives
+        will be made on a case-by-case basis, subject to fundingavailability and documentation
+        that the position is \"hard-to-fill\".\nSelected applicants may qualify for
+        credit toward annual leave accrual based on prior non-federal work experienceor
+        uniformed service experience.\nAdditional vacancies may be filled from this
+        announcement as needed. This vacancy announcement does notpreclude filling
+        this position by other means. Management also has the right not to fill the
+        position. EXPIRATION OF YOUR APPLICATION: Please be advised that although
+        this posting is active for one year, all applications will have a 120 day
+        expiration.If you are still interested in being considered after your 120
+        days are up, you must extend your application PRIOR to that date. To extend,
+        please return to the Applicant Dashboard on your USAJOBS account, select the
+        vacancy, and update your application.","KeyRequirements":["US Citizens and
+        National (Residents of American Samoa and Swains Island)","Meet all eligibility
+        criteria within 30 days of the closing date","Register with Selective Service,
+        if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"nrc@gsa.gov","AgencyContactPhone":"000-000-0000","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"598454000","MatchedObjectDescriptor":{"PositionID":"21PBSA350RGDE","PositionTitle":"Electrical
+        Engineer","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/598454000","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/598454000?PostingChannelID="],"PositionLocationDisplay":"Auburn,
+        Washington","PositionLocation":[{"LocationName":"Auburn, Washington","CountryCode":"United
+        States","CountrySubDivisionCode":"Washington","CityName":"Auburn, Washington","Longitude":-122.23041,"Latitude":47.3074}],"OrganizationName":"Public
+        Buildings Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Electrical
+        Engineering","Code":"0850"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nThe
+        GS-13 salary range starts at $100,940 per year. If you are a new federal employee,
+        your starting salary will likely be set at the Step 1 of the grade for which
+        you are selected.BASIC REQUIREMENTS FOR ENGINEERS: A Degree in professional
+        engineering OR a combination of college-level education, training, and/or
+        technical experience. For specifics on qualifying education and/or experience
+        - use the following link: Basic Requirements for Engineer Positions. SPECIALIZED
+        EXPERIENCE:In addition to the Basic Requirements listed above, you must have
+        one year of specialized experience equivalent to the GS-12in the Federal service.
+        Specialized experience isapplying professional electrical engineering principles,concepts,
+        and practices in the design of construction or alteration projects involving
+        large and complex buildings or major buildingsystems; and the coordination
+        of the activities of architects, engineers, tenants and construction contractors
+        on such projects. Suchexperience must also include having independently managed
+        projects (balance scope/quality, schedule and budget) requiring the servicesof
+        multiple disciplines from project initiation phase through project closeout.\nIn
+        addition, to qualify for the GS-13, you must be a registered professional
+        engineer in the United States or its territories. A COPY OF YOUR PROFESSIONAL
+        REGISTRATION MUST BE INCLUDED IN YOUR APPLICATION.","PositionRemuneration":[{"MinimumRange":"100940.0","MaximumRange":"131223.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-04-14","PositionEndDate":"2021-05-28","PublicationStartDate":"2021-04-14","ApplicationCloseDate":"2021-05-28","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"As
+        an Electrical Engineer, performs all aspects of the project management of
+        Prospectus Level and non-prospectus level projects, which comprise the most
+        major, politically sensitive, and complex initiatives.Location of position:Public
+        Building Service, Design and Construction Division,Auburn, Washington.We are
+        currently filling one vacancy, but additional vacancies may be filled as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"13","HighGrade":"13","OrganizationCodes":"GS/GS03","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104179","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104179&S=1","MajorDuties":["Overall
+        responsibility for the successful initiation, planning, execution, and closure
+        of leasing, design, construction and alteration projects, including prospectus
+        level and non-prospectus level projects, which comprise the most major, politically
+        sensitive, and complex initiatives.\nRepresents GSA and the Contracting Officer
+        (CO) on A/E, Construction Management, lease and Construction contracts as
+        the Contracting Officer&rsquo;s Representative (COR). Exercises full delegated
+        authority from the Contracting Officer, reviewing, inspecting and directing
+        the work as it proceeds in compliance with contract requirements.\nReviews
+        complex electrical engineering problems and provides recommendations to GSA
+        management. Conducts site surveys to determine condition of structures and
+        systems, evaluates requirements and recommends incorporation, modification
+        or exclusion of various project features to best meet long-term needs of the
+        government in consideration of such factors as urgency of needed repairs or
+        redesign, useful life of building components and systems, and cost/benefits
+        involved.\nMaintains liaison with representative of PBS, other agencies, contract
+        architects and engineers, contractors and occasionally with state and local
+        government authorities and with material suppliers and manufacturers."],"Education":"Note:
+        If you are using foreign education to meet qualification requirements, you
+        must send a Certificate of Foreign Equivalency with your transcript in order
+        to receive credit for that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nUndergo and pass
+        a background investigation (Tier 4 investigation level).\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position.","Evaluations":"We
+        will use a method called Category Rating to assess your application. Here&rsquo;s
+        how it will work:\nYou will be scored on the questions you answer during the
+        application process, which will measure your possession of the following competencies
+        or knowledge, skills, and abilities: Knowledge to manage prospectus level
+        projects impacted by multiple competing priorities and requirements and to
+        successfully integrate these requirements to meet the goals outlined for development
+        initiatives.\nKnowledge of Contracting Officer&rsquo;s Representative (COR)
+        duties and limitations as defined by the Federal Acquisition Regulations.\nKnowledge
+        of procurement principles and procedures and of different types of contracts.
+        Familiarity with contract monitoring and contract termination functions. Skill
+        in techniques to negotiate contract costs, prices, and terms to ensure the
+        successful completion of a project.\nKnowledge of professional electrical
+        engineering principles, concepts and practices applicable to a full range
+        of design, layout, construction, repair and/or alterations to a variety of
+        Prospectus Level/complex structures.\nSkill in communication necessary to
+        manage business relationships with both internal and external customers.\nExcellent
+        communication skills to interpret and explain highly complex and technical
+        information to a wide range of stakeholders. Your answers to the questions
+        will be used to place you in one of three categories: Best Qualified, Well
+        Qualified, or Qualified. We will verify your answers to the questions in your
+        resume. If your resume doesn&rsquo;t support your answers, we may lower your
+        score, which could place you in a lower category.\nWithin each category, veterans
+        will receive selection priority over non-veterans. Additional assessments
+        may be used, and, if so, you will be provided with further instructions.If
+        you are eligible under Interagency Career Transition Assistance Plan or GSA&rsquo;s
+        Career Transition Assistance Plan(ICTAP/CTAP), you must receive a score of
+        85 or higher to receive priority. To preview questions please click here.","HowToApply":"You
+        must submit a complete online application including any required documents
+        prior to 11:59 pm Eastern Time on the closing date of the Announcement. Errors
+        or omissions may result in your not being considered for this vacancy. You
+        can modify/complete your application any time before the vacancy date/time
+        deadline. Simply return to USAJOBS, select the vacancy, and update your application.
+        For more detailed instructions on how to apply, read the Apply for a GSA Job
+        on the GSA website.To begin, click the Apply Online button on the vacancy
+        announcement. Sign in or register on USAJobs and select a resume and documents
+        to include in your application.\nOnce you have clicked Apply for this position
+        now, you will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this vacancy.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the announcement
+        closing.","WhatToExpectNext":"After the closing date/deadline: ELIGIBILITY/QUALIFICATIONS:
+        Applicant eligibility and qualifications are reviewed.\nREFERRAL TO MANAGEMENT:
+        Eligible/Qualified applicants are referred to management for review and possible
+        interview.\nSELECTION/TENTATIVE JOB OFFER: If a selection is made, a Tentative
+        Offer is extended to the selectee and suitability and/or security background
+        investigation is conducted.\nFINAL JOB OFFER: A final job offer is made (typically
+        within 40 days after the closing date/deadline for applications).\nFINAL COMMUNICATION
+        TO APPLICANTS: Once the position is filled, we will notify you of your status.
+        You may also check your application status by logging into USAJOBS and clicking
+        &ldquo;Track this Application&rdquo; on theApplicant Dashboard. Thank you
+        for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit.If you are claiming veterans&rsquo;
+        preference:(a) Copy of your Certificate of Release or Discharge From Active
+        Duty, DD-214 that shows the dates of your active duty service. If selected,
+        a DD-214 showing your type of discharge (member 4 copy) will be required prior
+        to appointment. (b) If you are claiming 10-point preference or derived preference
+        (a spouse, widow or widower, or parent of a deceased or disabled veteran),
+        submit both of the following in addition to the DD-214: (1) completedSF-15form;
+        and(2) proof of your entitlement (refer to SF-15 for complete list).\nIf you
+        are active duty military - Certification on a letterhead from your military
+        branch that includes your rank, character of service (must be under honorable
+        conditions) &amp; military service dates including discharge/release date
+        (must be no later than 120 days after the date the certification is submitted).If
+        you are ICTAP/CTAPeligible - submit a, b, and c: (a) proof of eligibility
+        including agency notice; (b) SF-50, and (c) most recent performance appraisal.\nCurrent
+        or Former Political Appointees:Submit SF-50.College transcripts: If you are
+        using some or all of your college education to meet qualification requirements
+        for this position, you must submit a photocopy of your college transcript(s).
+        If selected, an official transcript will be required prior to appointment.
+        For education completed outside the United States, also submit a valid foreign
+        credential evaluation that substantiates possession of the required education.","Benefits":"You
+        will have access to many benefits including: Health insurance (choose from
+        a wide range of plans)\nLife insurance coverage with several options\nSick
+        leave and vacation time, including 10 paid holidays per year\nThrift Savings
+        Plan (similar to a 401(k) plan)\nFlexible work schedules\nTransit and child
+        care subsidies\nFlexible spending accounts\nLong-term care insurance\nTraining
+        and development","OtherInformation":"Bargaining Unit status: AFGE\nRelocation-related
+        expenses arenotapproved and will be your responsibility. On a case-by-case
+        basis, the following incentives may be approved:\n&middot; Recruitment incentive
+        if you are new to the federal government\n&middot; Relocation incentive if
+        you are a current federal employee\n&middot; Credit toward vacation leave
+        if you are new to the federal government\nAdditional vacancies may be filled
+        from this announcement as needed; through other means; or not at all. If you
+        are eligible under Merit Promotion, you may also apply under Vacancy Announcement
+        #21PBSA349RGMP. You must apply separately to each announcement to be considered
+        for both.","KeyRequirements":["US Citizens and National (Residents of American
+        Samoa and Swains Island)","Meet all eligibility criteria within 30 days of
+        the closing date","Register with Selective Service if you are a male born
+        after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","SecondAnnouncementUrl":"598454100","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"R10HumanReseources@gsa.gov","AgencyContactPhone":"253-931-7742","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"NCS/High
+        Risk","AdjudicationType":["Credentialing","Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"598454100","MatchedObjectDescriptor":{"PositionID":"21PBSA349RGMP","PositionTitle":"Electrical
+        Engineer","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/598454100","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/598454100?PostingChannelID="],"PositionLocationDisplay":"Auburn,
+        Washington","PositionLocation":[{"LocationName":"Auburn, Washington","CountryCode":"United
+        States","CountrySubDivisionCode":"Washington","CityName":"Auburn, Washington","Longitude":-122.23041,"Latitude":47.3074}],"OrganizationName":"Public
+        Buildings Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Electrical
+        Engineering","Code":"0850"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.The
+        GS-13 salary range starts at $100,940 per year. If you are a new federal employee,
+        your starting salary will likely be set at the Step 1 of the grade for which
+        you are selected.BASIC REQUIREMENTS FOR ENGINEERS: A Degree in professional
+        engineering OR a combination of college-level education, training, and/or
+        technical experience. For specifics on qualifying education and/or experience
+        - use the following link: Basic Requirements for Engineer Positions. SPECIALIZED
+        EXPERIENCE:In addition to the Basic Requirements listed above, you must have
+        one year of specialized experience equivalent to the GS-12in the Federal service.
+        Specialized experience isapplying professional electrical engineering principles,concepts,
+        and practices in the design of construction or alteration projects involving
+        large and complex buildings or major buildingsystems; and the coordination
+        of the activities of architects, engineers, tenants and construction contractors
+        on such projects. Suchexperience must also include having independently managed
+        projects (balance scope/quality, schedule and budget) requiring the servicesof
+        multiple disciplines from project initiation phase through project closeout.\nIn
+        addition, to qualify for the GS-13, you must be a registered professional
+        engineer in the United States or its territories. A COPY OF YOUR PROFESSIONAL
+        REGISTRATION MUST BE INCLUDED IN YOUR APPLICATION.","PositionRemuneration":[{"MinimumRange":"100940.0","MaximumRange":"131223.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-04-14","PositionEndDate":"2021-05-28","PublicationStartDate":"2021-04-14","ApplicationCloseDate":"2021-05-28","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"As
+        an Electrical Engineer, performs all aspects of the project management of
+        Prospectus Level and non-prospectus level projects, which comprise the most
+        major, politically sensitive, and complex initiatives.Location of position:Public
+        Building Service, Design and Construction Division,Auburn, Washington.We are
+        currently filling one vacancy, but additional vacancies may be filled as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"13","HighGrade":"13","OrganizationCodes":"GS/GS03","Relocation":"False","HiringPath":["disability","fed-competitive","fed-transition","land","mspouse","overseas","peace","special-authorities","vet"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104158","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104158&S=1","MajorDuties":["Overall
+        responsibility for the successful initiation, planning, execution, and closure
+        of leasing, design, construction and alteration projects, including prospectus
+        level and non-prospectus level projects, which comprise the most major, politically
+        sensitive, and complex initiatives.\nRepresents GSA and the Contracting Officer
+        (CO) on A/E, Construction Management, lease and Construction contracts as
+        the Contracting Officer&rsquo;s Representative (COR). Exercises full delegated
+        authority from the Contracting Officer, reviewing, inspecting and directing
+        the work as it proceeds in compliance with contract requirements.\nReviews
+        complex electrical engineering problems and provides recommendations to GSA
+        management. Conducts site surveys to determine condition of structures and
+        systems, evaluates requirements and recommends incorporation, modification
+        or exclusion of various project features to best meet long-term needs of the
+        government in consideration of such factors as urgency of needed repairs or
+        redesign, useful life of building components and systems, and cost/benefits
+        involved.\nMaintains liaison with representative of PBS, other agencies, contract
+        architects and engineers, contractors and occasionally with state and local
+        government authorities and with material suppliers and manufacturers."],"Education":"Note:If
+        you are using foreign education to meet qualification requirements, you must
+        send a Certificate of Foreign Equivalency with your transcript in order to
+        receive credit for that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nUndergo and pass
+        a background investigation (Tier 4 investigation level).\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position.","Evaluations":"You
+        will be evaluated on the questions you answer during the application process,
+        which will measure your overall possession of the following competencies or
+        knowledge, skills, and abilities. Your responses to these questions must be
+        supported by your resume or your score may be lowered. Knowledge to manage
+        prospectus level projects impacted by multiple competing priorities and requirements
+        and to successfully integrate these requirements to meet the goals outlined
+        for development initiatives.\nKnowledge of Contracting Officer&rsquo;s Representative
+        (COR) duties and limitations as defined by the Federal Acquisition Regulations.\nKnowledge
+        of procurement principles and procedures and of different types of contracts.
+        Familiarity with contract monitoring and contract termination functions. Skill
+        in techniques to negotiate contract costs, prices, and terms to ensure the
+        successful completion of a project.\nKnowledge of professional electrical
+        engineering principles, concepts and practices applicable to a full range
+        of design, layout, construction, repair and/or alterations to a variety of
+        Prospectus Level/complex structures.\nSkill in communication necessary to
+        manage business relationships with both internal and external customers.\nExcellent
+        communication skills to interpret and explain highly complex and technical
+        information to a wide range of stakeholders. Additional assessments may be
+        used, and, if so, you will be provided with further instructions.\nIf you
+        are eligible under Interagency Career Transition Assistance Plan or GSA&rsquo;s
+        Career Transition Assistance Plan(ICTAP/CTAP), you must receive a score of
+        85 or higher to receive priority. To preview questions please click here.","HowToApply":"Submit
+        a complete online application including any required documents prior to 11:59
+        pm Eastern Time on the closing date of the announcement. You can modify or
+        complete your application any time before the deadline. Simply return to USAJOBS,
+        select the vacancy, and update your application. For more detailed instructions
+        on how to apply, click here: Apply for a GSA Job.To begin, click the Apply
+        Online button on the vacancy announcement. Sign in or register on USAJobs
+        and select a resume and documents to include in your application.\nOnce you
+        have clicked Apply for this position now, you will be taken to the GSA site
+        to complete the application process.\nClick the Apply To This Vacancy and
+        complete all steps in the application process until the Confirmation indicates
+        your application is complete. If you click Return to USAJobs or get timed
+        out prior to receiving confirmation, your application will not be submitted
+        and cannot be considered for this job.\nNote: Review the REQUIRED DOCUMENTS
+        section of this announcement to determine which apply to you and must be submitted
+        online. You may choose one or more of the following options to submit your
+        document(s): Upload (from your computer); USAJOBS (click the \"USAJOBS\" link
+        to complete the transfer process) or FAX (read the &ldquo;Fax instructions&rdquo;
+        provided prior to printing the Fax Cover Sheet and faxing your information).
+        Need Assistance in Applying? Contact the HR representative listed on the announcement
+        prior to the application deadline. We are available to assist you Monday-Friday
+        during normal business hours. You must receive HR approval before deviating
+        from these instructions. Be sure to APPLY EARLY as most assessments must be
+        completed fully and submitted before the announcement closing.","WhatToExpectNext":"After
+        the closing date/deadline: ELIGIBILITY/QUALIFICATIONS: Your application will
+        be reviewed for all requirements.\nREFERRAL TO MANAGEMENT: If you meet all
+        the requirements, you may be referred to management for review and a possible
+        interview. SELECTION/TENTATIVE JOB OFFER: If you are selected, you will receive
+        a tentative offer and start the suitability and/or security background investigation
+        process.\nFINAL JOB OFFER:Once our security office determines you can come
+        on board, you will be given a final offer, which is typically 40 days after
+        the announcement closes.\nFINAL COMMUNICATION: Once the position is filled,
+        we will notify you of your status. You may also check your application status
+        by logging into USAJOBS and clicking &ldquo;Track this Application&rdquo;
+        on theApplicant Dashboard. Thank you for your interest in working for U.S.
+        General Services Administration!","RequiredDocuments":"ALL required documents
+        must be submitted before the closing date. Review the following list to determine
+        what you need to submit.Note: If required to submit an SF-50 (Notice of Personnel
+        Action), an equivalent agency Notice of Personnel Action form is acceptable.
+        Such document(s) must show all of the following: effective date, position,
+        title, series, grade, and rate of basic pay, tenure group 1 (career) or 2
+        (career-conditional), position occupied group, and name of agency. If you
+        are a GSA employee (except in the OIG), you are not required to submit an
+        SF-50.If you are a 30% or more disabled veteran, VEOA or VRA applicant or
+        qualified spouse, widow/widower, or parent:(a) Copy of your Certificate of
+        Release or Discharge From Active Duty, DD-214 that shows the dates of your
+        active duty service. If selected, a DD-214 showing your type of discharge
+        (member 4 copy) will be required prior to appointment.(b) If you are a disabled
+        veteran, or are applying under VRA or VEOA as a spouse, widow/widower, or
+        parent of a veteran, submit both of the following in addition to the DD-214:
+        (1)completed SF-15 form; and (2)proof of your entitlement (refer to SF-15
+        for complete list).\nIf you are active duty military- Certification on a letterhead
+        from your military branch that includes your rank, character of service (must
+        be under honorable conditions) &amp; military service dates including discharge/release
+        date (must be no later than 120 days after the date the certification is submitted).If
+        you are a current Federal employee or Reinstatement Eligible: Submit your
+        latest SF-50.If you are eligible under an Interchange Agreement: Submit your
+        latest SF-50.If you are a former Peace Corp or VISTA volunteer: Submit your
+        Description of Service.\nIf you are acurrent or former Land Management Agency
+        Employee- Submit a and b: (a) one or more SF-50s, including your most recent
+        one that shows you were on a competitive time-limited appointment(s) with
+        a Land Management Agencyand served on the appointment for a period(s) totaling
+        more than 24 months without a break of 2 or more years. (b) Copy of your agency&rsquo;s
+        annual performance appraisal(s) or written reference(s) from a supervisor
+        at the agency verifying satisfactory performance during your appointment(s).\nIf
+        you have a disability: Submit proof of eligibility. For information on eligibility
+        and required documentation, refer to USAJOBS&rsquo;s People With Disabilities
+        page.If you are applying under another special appointment authority: Submit
+        proof of your eligibility under the appropriate appointment authority. See
+        USAJOBS''s Resource Center for more information.If you areICTAP/CTAP eligible
+        - submit a, b, and c: (a) proof of eligibility including agency notice; (b)
+        SF-50, and (c) most recent performance appraisal.\nIf you are a current or
+        former political appointee: Submit your SF-50. College transcripts: If you
+        are using some or all of your college education to meet qualification requirements
+        for this position, you must submit a photocopy of your college transcript(s).
+        If selected, an official transcript will be required prior to appointment.
+        For education completed outside the United States, also submit a valid foreign
+        credential evaluation that substantiates possession of the required education.","Benefits":"You
+        will have access to many benefits including: Health insurance (choose from
+        a wide range of plans)\nLife insurance coverage with several options\nSick
+        leave and vacation time, including 10 paid holidays per year\nThrift Savings
+        Plan (similar to a 401(k) plan)\nFlexible work schedules\nTransit and child
+        care subsidies\nFlexible spending accounts\nLong-term care insurance\nTraining
+        and development","OtherInformation":"Bargaining Unit status: AFGE\nRelocation-related
+        expenses arenotapproved and will be your responsibility. On a case-by-case
+        basis, the following incentives may be approved:\n&middot; Recruitment incentive
+        if you are new to the federal government\n&middot; Relocation incentive if
+        you are a current federal employee\n&middot; Credit toward vacation leave
+        if you are new to the federal government\nAdditional vacancies may be filled
+        from this announcement as needed; through other means; or not at all. We are
+        also accepting applications from all U.S. Citizens and Nationals under Vacancy
+        Announcement #21PBSA350RGDE. You must apply separately to each announcement
+        to be considered for both.","KeyRequirements":["US Citizenship or National
+        (Residents of American Samoa and Swains Island)","Meet all eligibility criteria
+        within 30 days of the closing date","Meet time-in-grade within 30 days of
+        the closing date, if applicable","Register with Selective Service if you are
+        a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","SecondAnnouncementUrl":"598454000","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"R10HumanReseources@gsa.gov","AgencyContactPhone":"253-931-7742","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"NCS/High
+        Risk","AdjudicationType":["Credentialing","Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"598984700","MatchedObjectDescriptor":{"PositionID":"21FASA253MDOTR","PositionTitle":"Information
+        Technology Specialist (INFOSEC)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/598984700","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/598984700?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Phoenix, Arizona","CountryCode":"United
+        States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix, Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"San
+        Diego, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Diego, California","Longitude":-117.162,"Latitude":32.7157},{"LocationName":"San
+        Francisco, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Lakewood,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Lakewood,
+        Colorado","Longitude":-105.08274,"Latitude":39.71095},{"LocationName":"District
+        of Columbia, District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"District of Columbia, District of Columbia","Longitude":-77.03196,"Latitude":38.89037},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Manchester,
+        New Hampshire","CountryCode":"United States","CountrySubDivisionCode":"New
+        Hampshire","CityName":"Manchester, New Hampshire","Longitude":-71.46309,"Latitude":42.991177},{"LocationName":"Philadelphia,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Philadelphia,
+        Pennsylvania","Longitude":-75.16237,"Latitude":39.95227},{"LocationName":"Fort
+        Worth, Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Fort
+        Worth, Texas","Longitude":-97.32925,"Latitude":32.74863}],"OrganizationName":"Federal
+        Acquisition Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Information
+        Technology Management","Code":"2210"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nStarting
+        Pay for all locations will be dependent upon the associated GS-Locality Pay
+        Table for that area.\nIn addition to theSpecialized Experience described below,
+        you alsomust haveIT-related experience demonstrating EACH of the four competencies
+        as described below: Attention to Detail - This skill is generally demonstrated
+        by assignments where the applicant keeps abreast of latest technology, information,
+        research, etc., to maintain knowledge in field of expertise (for example,
+        reads trade journals, participates in professional/technical associations,
+        maintains credentials).\nCustomer Service - This skill is generally demonstrated
+        by assignments where the applicant promotes or develops and maintains good
+        working relationships with key individuals or groups.\nOral Communication
+        - This skill is generally demonstrated by assignments where the applicant
+        serves on panels, committees, or task forces as a representative for the organization
+        on technical or professional issues.\nProblem Solving - This skill is generally
+        demonstrated by assignments where the applicant monitors current trends or
+        events (for example, technological, economic, political, social, educational,
+        or employment trends or events) and applies the information as appropriate.
+        SPECIALIZED EXPERIENCE:\nTo qualify, you must have at least one year of specialized
+        experience equivalent to theGS-09 level or higher in the Federal service.\nGS-11\nSpecialized
+        experience is experience in working with computer networking concepts, protocols,
+        network security methodologies, risk management processes;conducting cyber
+        securitysystemsevaluations and reviews of policy enforcement practices to
+        ensure secure information systems reliability and accessibility; or evaluating
+        Automated Information System (AIS) security program(s) to protect AIS from
+        unauthorized access.\n~or~\nEDUCATION SUBSTITUTIONS: Ph.D. or equivalent doctoral
+        degree OR three (3) full years of progressively higher level graduate education
+        leading to a Ph.D. or equivalent doctoral degree. Degree must be in computer
+        science, engineering, information science, information systems management,
+        mathematics, operations research, statistics, or technology management or
+        degree that provided a minimum of 24 semester hours in one or more of the
+        fields identified above and required the development or adaptation of applications,
+        systems or networks.\nTo qualify, you must have at least one year of specialized
+        experience equivalent to theGS-11 level or higher in the Federal service.\nGS-12\nSpecialized
+        experience is experience in managing computer networking concepts, protocols,
+        network security methodologies, risk management processes;developing procedures
+        and conducting systems cyber security evaluations, audits and reviews of policy
+        enforcement practices to ensure secure information systems reliability and
+        accessibility; or developing Automated Information Systems (AIS) security
+        contingency plans and disaster recovery procedures as part of an organization.\nTo
+        qualify, you must have at least one year of specialized experience equivalent
+        to the GS-12level or higher in the Federal service.\nGS-13\nSpecialized experience
+        is experienceworking with computer networking concepts, protocols, network
+        security methodologies;identifying IT system control vulnerabilities, risks
+        and protection needs; resolving issues and problems involving IT systems security;
+        implementing information system security policies, standards and guidelines;
+        and, providing technical advice to management officials on security requirements.","PositionRemuneration":[{"MinimumRange":"65307.0","MaximumRange":"134798.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-04-20","PositionEndDate":"2021-09-30","PublicationStartDate":"2021-04-20","ApplicationCloseDate":"2021-09-30","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"THIS
+        IS A PUBLIC NOTICE: Please review further information below regarding how
+        this posting will be used.\nTo fill this job we have been granted &ldquo;Direct
+        Hire Authority&rdquo; or DHA. This means that we can hire any qualified candidate,
+        either from this notice or from any source.\nThis position is located in the
+        Federal Acquisition Service, General Services Administration,Information Technology
+        Category","WhoMayApply":{"Name":"","Code":""},"LowGrade":"11","HighGrade":"13","OrganizationCodes":"GS/GS30","Relocation":"False","HiringPath":["public"],"MCOTags":["01"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104194","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104194&S=1","MajorDuties":["We
+        are currently filling one vacancy, but additional vacancies may be filled
+        as needed.\nThis Notice is issued under direct-hire authority to recruit new
+        talent to occupations for which there is a severe shortage of candidates.
+        We have been granted &ldquo;Direct Hire Authority&rdquo; or DHA. This means
+        that when we have a vacant job, we can hire any qualified candidate, either
+        from this notice or from any source.\nA few key facts about this DHA notice:
+        All GSA employees may be considered for aDHAappointment.\nCurrent civil service
+        employees will receive a new appointment if selected underDHA. For information
+        on DHA, please visit https://www.opm.gov/directhire/index.asp.\nDuties may
+        include: (This is NOT an all-inclusive list) Assists in the development and
+        maintenance of supply chain, system, network, performance, and cybersecurity
+        requirements. Assists with drafting and publication of supply chain security
+        and risk management documents. Develops and documents supply chain risks for
+        critical system elements, as appropriate. Ensures that all acquisitions, procurements,
+        and outsourcing efforts address information security requirements consistent
+        with organizational goals. Ensures that supply chain, system, network, performance,
+        and cybersecurity requirements are included in contract language and delivered.
+        Provides direct support for acquisitions that use information technology (IT)
+        (including National Security Systems), applying IT-related laws and policies,
+        and provides IT-related guidance throughout the total acquisition life cycle.
+        Establishes/maintains communication channels with stakeholders. Reviews existing
+        and proposed policies with stakeholders. Develops/maintains long-range plans
+        for IT security systems for clients that anticipate, identify, evaluate, mitigate,
+        and minimize risks associated with IT system vulnerabilities. Participates
+        in systems security evaluations, audits, and reviews. Uses specific common
+        performance measures for service levels and costs."],"Education":"Note: If
+        you are using foreign education to meet qualification requirements, you must
+        send a Certificate of Foreign Equivalency with your transcript in order to
+        receive credit for that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Undergo and pass a background
+        investigation security clearance requirement but it can vary based on the
+        PD. This may include a Tier 5 investigation level and Candidates must be granted
+        this clearance before starting the job.\nReceive authorization from OPM on
+        any job offer you receive, if you are or were (within the last 5 years) a
+        political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nYou
+        may be required to participate in the Region''s Continuity of Operations Plan
+        (COOP), representing the Service and/or GSA as a whole. This may involve participating
+        in COOP meetings and planning activities;performing mission-critical work
+        at a designated location other than the traditional GSA office site (whichmay
+        be outside of the commuting area); and ensuring that GSA''s needs are still
+        being met in the event ofan emergency, disaster or otherwise unforeseen circumstance
+        disrupting traditional office operations.","Evaluations":"Applications will
+        be evaluated against the basic qualifications. Qualified candidates will be
+        considered inaccordance with the Office of Personnel Management Direct Hire
+        Guidelines. Veterans'' Preference does not applyto the direct hire recruitment
+        procedures. Certain selections made under this notice will be processed as
+        newappointments to the civil service. Current civil service employees might
+        be given new appointments to the civilservice. You may not be considered for
+        the position, if any part of the application is incomplete or missing therequired
+        supporting documentation. Falsifying your background, education and/or experience
+        is cause for nothiring you or dismissing you if hired.\nIf you are an Interagency
+        Career Transition Assistance Plan eligible or a GSA Career Transition Assistanceeligible,
+        you must be considered well qualified to receive priority (ICTAP/CTAP). Well
+        qualified is defined aspossession of the majority of competencies required
+        for the position and will be determined, based upon a reviewof your resume
+        against the competencies required for the position being filled. To preview
+        questions please click here.","HowToApply":"This Direct Hire Public Notice\nYou
+        must submit a complete online application, including any required documents,
+        before your eligibility can be confirmed. Errors or omissions may result in
+        your not being considered for this vacancy. You can modify/complete your application
+        any time before the vacancy date/time deadline. Simply return to USAJOBS,
+        select the vacancy, and update your application. For more detailed instructions
+        on how to apply, read the Apply for a GSA Job on the GSA website.\nStanding
+        Register As mentioned in the Other Information section, this announcement
+        will be used to fill positions on an ongoing basis as job openings occur.
+        Your application will only be reviewed after a cut-off date or after the vacancy
+        closing date if you have completed the application process described above.\nTo
+        begin, click the Apply Online button on the vacancy announcement. Sign in
+        or register on USAJOBS and select a resume and documents to include in your
+        application.\nOnce you have clicked Apply for this position now, you will
+        be taken to the GSA site to complete the application process.\nClick the Apply
+        To This Vacancy and complete all steps in the application process until the
+        Confirmation indicates your application is complete. If you click Return to
+        USAJOBSor get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this job.\nNote: Review
+        the REQUIRED DOCUMENTS section of this posting to determine which apply to
+        you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the posting prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the posting
+        closes.","WhatToExpectNext":"STANDING REGISTER The following process is used
+        if your application is complete and active as of the cut-off date deadline.
+        ELIGIBILITY/QUALIFICATIONS: Your application will be reviewed for all requirements.\nREFERRAL
+        TO MANAGEMENT: If you meet all the requirements, you may be referred to management
+        for review and a possible interview.\nSELECTION/TENTATIVE JOB OFFER: If you
+        are selected, you will receive a tentative offer and start the suitability
+        and/or security background investigation process.\nFINAL JOB OFFER: Once our
+        security office determines you can come on board, you will be given a final
+        offer, which is typically 40 days after the announcement closes. Thank you
+        for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. Veterans: Copy of your Certificate
+        of Release or Discharge From Active Duty, DD-214 that shows the dates of your
+        active duty service. If selected, a DD-214 showing your type of discharge
+        (member 4 copy) will be required prior to appointment.\nIf you are claiming
+        10-point preference or derived preference (a spouse, widow or widower, or
+        parent of a deceased or disabled veteran), submit both of the following in
+        addition to the DD-214: (1)completed SF-15 form; and (2) proof of your entitlement
+        (refer to SF-15 for complete list). If you are active duty military- Certification
+        on a letterhead from your military branch that includes your rank, character
+        of service (must be under honorable conditions) &amp; military service dates
+        including discharge/release date (must be no later than 120 days after the
+        date the certification is submitted).\nIf you are ICTAP/CTAP eligible - submit
+        a, b, and c: (a) proof of eligibility including agency notice; (b) SF-50,
+        and (c) most recent performance appraisal.\nCurrent or Former Political Appointees:
+        Submit SF-50.\nCollege transcripts: If you are using some or all of your college
+        education to meet qualification requirements for this position, you must submit
+        a photocopy of your college transcript(s). If selected, an official transcript
+        will be required prior to appointment. For education completed outside the
+        United States, also submit a valid foreign credential evaluation that substantiates
+        possession of the required education.","Benefits":"You will have access to
+        many benefits including: Health insurance (choose from a wide range of plans)\nLife
+        insurance coverage with several options\nSick leave and vacation time, including
+        10 paid holidays per year\nThrift Savings Plan (similar to a 401(k) plan)\nFlexible
+        work schedules\nTransit and child care subsidies\nFlexible spending accounts\nLong-term
+        care insurance\nTraining and development","BenefitsUrl":"http://www.opm.gov/insure/federal_employ/index.asp","OtherInformation":"Bargaining
+        Unit status:May vary based on the position description\nGSA may pay a recruitment
+        incentive to a newly-appointed employee; a relocation incentive to a currentemployee;
+        or offer annual leave service credit to an applicant with related non-federal
+        or uniformed services workexperience. Determinations to pay/allow incentives
+        will be made on a case-by-case basis, subject to fundingavailability and documentation
+        that the position is \"hard-to-fill\".\nSelected applicants may qualify for
+        credit toward annual leave accrual based on prior non-federal work experienceor
+        uniformed service experience.\nAdditional vacancies may be filled from this
+        announcement as needed. This vacancy announcement does notpreclude filling
+        this position by other means. Management also has the right not to fill the
+        position.","KeyRequirements":["US Citizens and National (Residents of American
+        Samoa and Swains Island)","Meet all eligibility criteria within 30 days of
+        the closing date","Register with Selective Service, if you are a male born
+        after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"marquis.sterling-davis@gsa.gov","AgencyContactPhone":"404.895.1622","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"600804400","MatchedObjectDescriptor":{"PositionID":"21NRCA073LBMP","PositionTitle":"Realty
+        Specialist","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/600804400","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/600804400?PostingChannelID="],"PositionLocationDisplay":"Washington,
+        District of Columbia","PositionLocation":[{"LocationName":"Washington, District
+        of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904}],"OrganizationName":"Public
+        Buildings Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Realty","Code":"1170"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace corps, Americorps), we encourage you to include this experience on your
+        resume.For a brief video on How to Create a Federal Resume, clickhere.The
+        GS-13 salary range starts at $103,690 per year.\nNOTE: Unlimited Contractor
+        Officers Warrant preferred. You will be required to obtain and maintain an
+        Unlimited Contracting Officers Warrant and FACCOR Level II Certification in
+        active status. The incumbent is also required to complete training andensure
+        applicable leasing certification program requirements at a Level III, with
+        additional training andfocus on Out leasing.Training must be kept current,
+        in accordance with leasing certification programguidelines. To qualify, you
+        must have at least one year of specialized experience equivalent to theGS-12level
+        in the Federal Service.\nSpecialized experience is experience in: providing
+        technical advice and guidance on commercial realty transactions in one or
+        more of the following: realty activities; site acquisition; or out-leasing;\nanalyzing
+        and evaluating commercial realty contracting issues;\nproviding input and
+        recommendations for the development of contracting policies and procedures
+        for a commercial realty program; and\nplanning, coordinating, and managing
+        lease construction projects and negotiating lease terms for lease acquisition
+        projects.","PositionRemuneration":[{"MinimumRange":"103690.0","MaximumRange":"134798.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-10","PositionEndDate":"2021-05-28","PublicationStartDate":"2021-05-10","ApplicationCloseDate":"2021-05-28","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"You
+        will serve as a senior Realty Specialist within the Public Buildings Service
+        (PBS) for the NCROut lease Program which includes the leasing or licensing
+        of vacant GSA owned or leased space, if nofederal tenants are available,to
+        commercial private sector tenants who provide retail services.\nLocation of
+        position:NCR/Public Buildings Service, 1800 F Street, Washington, DC\nWe are
+        currently filling one vacancy, but additional vacancies may be filled as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"13","HighGrade":"13","OrganizationCodes":"GS/GS03","Relocation":"False","HiringPath":["fed-internal-search","fed-transition"],"TotalOpenings":"FEW","AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"0","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104232","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104232&S=1","MajorDuties":["Your
+        major duties are as follows: Serve as a customer support specialist performing
+        work involving analytical and evaluative dutiesrelated to various wireless
+        telecommunications systems with knowledge requirements fortelecommunication
+        s systems.\nServe as the primary point ofcontact for all Retail and Wireless
+        Telecommunications (telecom) leases with primary responsibility fordeveloping
+        and negotiating leases with existing and potential customers to include business
+        terms andconditions and financial arrangements, consulting with other PBS
+        or GSA components as necessary,including at the regional and national levels.\nNegotiate
+        leaseterms and conditions, perform cost and price analyses of offers, incorporate
+        complex modifications ofterms and conditions into leases, and prepare approval
+        documents necessary to award the lease.\nIndependently determine actions to
+        be taken during the course of complex negotiations that ofteninvolve long-term
+        lease transactions with blocks of space and commitments for considerable sums
+        ofmoney.\nProvide advice and consultation on major projects dealing with complex
+        and controversial issues. Dealwith intensive controversies, such as defending
+        controversial decisions to the courts and GSA Board ofContract Appeals.\nFrom
+        market surveys and/orknowledge of available space, advise customers, make
+        recommendations, and suggestions onproperties from which to choose.\nPrepare
+        decision papers, detailed analyses, and fact sheets for higher level regional
+        and National Officemanagement officials, considering various alternatives
+        and recommend solutions.\nAssemble and/or participate on interdisciplinary
+        teams of design and constructionprofessionals, attorneys, lessor representatives,
+        developers, contractors, financial consultants, tenantagency personnel, or
+        other technical personnel, as appropriate.\nServe as a project manager for
+        major projects dealing with complex and controversial real propertyissues.\nEnsure
+        that payments of awarded leases are made in a timely and accurate fashion.\nPrepare
+        statements of work, determinations and findings, solicitation documents, and
+        detailedinstructions for guidance to architects and consulting engineers for
+        the out leasing components of theproject.\nPerform extensive enforcement surveys
+        to determine if lessee operations arein conformance with lease provisions.
+        Develop asset management strategies to maximize efficient useof lessee&rsquo;s
+        use of federal facilities."],"Education":"","Requirements":"If selected, you
+        must meet the following conditions: Receive authorization from OPM on any
+        job offer you receive, if you are or were (within the last 5 years) apoliticalSchedule
+        A, Schedule C or Non-Career SES employee in the Executive Branch.\nServe a
+        one year probationary period, if required.","Evaluations":"You will be scored
+        on the questions you answer during the application process, which will measure
+        your possession of the following competencies or knowledge, skills, and abilities.
+        Your responses to these questions must be supported by your resume or your
+        score may be lowered. Skill in techniques to negotiate contract costs, prices,
+        and terms to ensure the successful completion of aproject.\nKnowledge of managing
+        execution commencement packages and final lease documents.\nSkill in project
+        management to implement an end-to-end solution for strategic and highly complex
+        inbuilding project initiatives. Including requirements definition, evaluation,
+        goal setting, and management ofdeliverables and analysis of information.\nKnowledge
+        of Federal and agency policies, regulations, procedures and applicable Federalstatutes
+        with regard to real estate out leasing and site management.\nSkillof cost
+        and price analysis to forecast revenue and evaluate prices for which little
+        or nohistorical data exists and to determine complicated strategies and perform
+        complicated negotiationsinvolving financial arrangements, terms or conditions
+        that impose greater financial risk to the Governmentthan most real estate
+        projects.\nKnowledge of building operational requirements to understand the
+        feasibility and impact of tenantupgrades and alterations when complex needs
+        are involved.\nKnowledge of wireless telecommunications principles including
+        but not limited to cellular, PCS, data and twoway radio communications and
+        their applications serving the Federal community and related constructionpractices,
+        zoning issues and radio frequency (RF) safety guidelines.\nKnowledge of governmental
+        approvals and processes, such as NCPC, SHPO, CFA, etc. Additional assessments
+        may be used, and, if so, you will be provided with further instructions.\nIf
+        you are eligible under GSA&rsquo;s Career Transition Assistance Plan (CTAP),
+        you must receive a score of 85 or higher to receive priority. To preview questions
+        please click here.","HowToApply":"Submit a complete online application including
+        any required documents prior to 11:59 pm Eastern Time on the closing date
+        of the announcement. You can modify or complete your application any time
+        before the deadline. Simply return to USAJOBS, select the vacancy, and update
+        your application. For more detailed instructions on how to apply, click here:
+        Apply for a GSA Job. To begin, click the Apply Online button on the vacancy
+        announcement. Sign in or register on USAJobs and select a resume and documents
+        to include in your application.\nOnce you have clicked Apply for this position
+        now, you will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this job.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the announcement
+        closing.","WhatToExpectNext":"After the closing date/deadline: ELIGIBILITY/QUALIFICATIONS:Your
+        application will be reviewed for all requirements\nREFERRAL TO MANAGEMENT:If
+        you meet all the requirements, you may be referred to management for review
+        and a possible interview.\nSELECTION/TENTATIVE JOB OFFER:If you are selected,
+        you will receive a tentative offer and start the suitability and/or security
+        background investigation process.\nFINAL JOB OFFER:Once our security office
+        determines you can come onboard, you will be given a final offer, which is
+        typically within 40 days after the announcement closes.\nFINAL COMMUNICATION:Once
+        the position is filled, we will notify you of your status. You may also check
+        your status by logging into USAJOBS. Go to My USAJOBS and then to Applications.
+        Thank you for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. CTAP Eligible - Submit a, b, and
+        c: (a) proof of eligibility including agency notice; (b) SF-50, and (c)most
+        recent performance appraisal.\nCurrent or Former Political Appointees: Submit
+        SF-50.","Benefits":"You will have access to many benefits including: Health
+        insurance (choose from a wide range of plans)\nLife insurance coverage with
+        several options\nSick leave and vacation time, including 10 paid holidays
+        per year\nThrift Savings Plan (similar to a 401(k) plan)\nFlexible work schedules
+        and telework\nTransit and child care subsidies\nFlexible spending accounts\nLong-term
+        care insurance\nTraining and development","BenefitsUrl":"http://www.opm.gov/insure/federal_employ/index.asp","OtherInformation":"Bargaining
+        Unit status: NFFE\nRelocation-related expenses arenotapproved and will be
+        your responsibility. Additional vacancies may be filled from this announcement
+        as needed; through other means; or not at all.","KeyRequirements":["Meet all
+        eligibility criteria within 30 days of the closing date","Meet time-in-grade
+        within 30 days of the closing date, if applicable","US Citizenship or National
+        (Residents of American Samoa and Swains Island)"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"nrc@gsa.gov","AgencyContactPhone":"816-823-2006","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"Moderate
+        Risk (MR)","AdjudicationType":["Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"600946000","MatchedObjectDescriptor":{"PositionID":"21PBSB381MMMP","PositionTitle":"Building
+        Management Specialist","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/600946000","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/600946000?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Bangor, Maine","CountryCode":"United
+        States","CountrySubDivisionCode":"Maine","CityName":"Bangor, Maine","Longitude":-68.7708,"Latitude":44.8017},{"LocationName":"Van
+        Buren, Maine","CountryCode":"United States","CountrySubDivisionCode":"Maine","CityName":"Van
+        Buren, Maine","Longitude":-67.93658,"Latitude":47.157936}],"OrganizationName":"Public
+        Buildings Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Building
+        Management","Code":"1176"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume. For a brief video on creating a Federal resume, clickhere.
+        The GS-12 salary range starts at $77488 per year. If you are a new federal
+        employee, your starting salary will likely be set at the Step 1 of the grade
+        for which you are selected.\nTo qualify for the GS-12, you must have at least
+        one year of specialized experience equivalent to the GS-11 level or higher
+        in the Federal service.\nSpecialized experience is experience assisting in
+        the management of a multi-level commercial office building (or equivalent
+        non-housing high rise building) consisting of complex building mechanical
+        system (i.e., building automated systems, centralized HVAC, alarm systems,
+        elevators, etc): This experience typically includes: monitoring occupant space
+        utilization, energy and water conservation, sustainability and environmental
+        hazards programs;\ndirects and coordinates minor alteration and renovation
+        projects;\nmaintaining customer satisfaction programs including feedback mechanisms
+        used to evaluate the effectiveness of services provided; and\nmanaging or
+        monitoring real property budgetary and financial data.\ncontract administration
+        and oversight (i.e., janitorial, mechanical, elevator contracts)","PositionRemuneration":[{"MinimumRange":"77488.0","MaximumRange":"100739.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-11","PositionEndDate":"2021-06-07","PublicationStartDate":"2021-05-11","ApplicationCloseDate":"2021-06-07","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"As
+        a Building Management Specialist, you will provide property management services
+        in both federal and/or lease locations to ensure customer agencies are housed
+        in safe, secure, clean facilities.\nPosition is located in the Public Buildings
+        Service, Service Center Division, Van Buren, ME and Bangor, ME\nWe are currently
+        filling two vacancies, additional vacancies may be filled as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"12","HighGrade":"12","OrganizationCodes":"GS/GS03","Relocation":"False","HiringPath":["disability","fed-competitive","fed-transition","land","mspouse","overseas","peace","special-authorities","vet"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104279","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104279&S=1","MajorDuties":["The
+        incumbent will serve as the Assistant Building Manager and Contracting Officer&rsquo;s
+        Representative (COR). Assist the Building Manager in monitoring the building
+        operational trends, contract management and enforcement, and act as the customer
+        representative. Interact directly with building occupants and serve as the
+        first point of contact for customers in assigned buildings. Develop a professional
+        and respectful relationship with customers and Improve customer satisfaction
+        with building services and maintain and preserve real property assets.\nParticipate,
+        plan and assist in developing projects for facilities as well as operational
+        budgets. Understand and utilize agency business performance goals and objectives
+        in the operations of assigned facilities. Manage the lease administration
+        process (post occupancy) for on behalf of tenant agencies. Perform COR duties
+        to ensure the lease is in compliance and provide technical support the PBS
+        Leasing Division."],"Education":"","Requirements":"If selected, you must meet
+        the following conditions: Receive authorization from OPM on any job offer
+        you receive, if you are or were (within the last 5 years) a Schedule A, Schedule
+        C, or non-career SES political appointee\nServe a one year probationary period,
+        if required.\nUndergo and pass a background investigation (Tier 2 investigation
+        level).\nHave your identity and work status eligibility verified if you are
+        not a GSA employee. We will use the Department of Homeland Security&rsquo;s
+        e-Verify system for this. Any discrepancies must be resolved as a condition
+        of continued employment.\nComplete a financial disclosure report to verify
+        that no conflict, or an appearance of conflict, exists between your financial
+        interest and this position\nParticipate in the Continuity of Operations Plan
+        (COOP), which includes attending meetings and planning activities; and carrying
+        out mission-critical work at a designated location other than your primary
+        work site (which may be outside of your commuting area).\nWork is normally
+        performed in an office setting, however, incumbent is routinely required to
+        travel and may be exposed to slippery or uneven ground, failing objects, constructions
+        and site conditions, noise, dust and environment or other discomforts and
+        hazards, walking, climbing ladders, crawling under and over equipment, bending,
+        stooping and standing for long periods of time is required while inspecting
+        buildings during field evaluations.\nThe employee must travel to customer
+        offices and GSA sites; a valid driver&rsquo;s license is required.","Evaluations":"You
+        will be scored on the questions you answer during the application process,
+        which will measure your possession of the following competencies or knowledge,
+        skills, and abilities. Your responses to these questions must be supported
+        by your resume or your score may be lowered.\nKnowledge of qualitative and
+        quantitative techniques and statistical interpretation required to perform
+        extensive coordination and fact-finding in order to identify client agency
+        and building tenants&rsquo; facility needs in relation to customer satisfaction;
+        evaluate and interpret required customer survey responses and other similar
+        data; analyze the effectiveness and efficiency of property management programs
+        and building profitability initiatives; evaluate technical and program data,
+        and to make decisions or recommendations for action based on consideration
+        of all aspects of a problem.\nAdvanced skills in interpersonal relations and
+        in written and oral communications required to explain, evaluate and negotiate
+        client and technical operating requirements; coordinate work efforts and negotiate
+        resolutions to problems; present information and conduct town hall meetings,
+        tenant interviews and discussions in a concise and professional manner; knowledge
+        of customer relations and conflict resolution sufficient to develop and maintain
+        a high level of customer satisfaction in the building(s) managed.\nKnowledge
+        of quality assurance and quality control methods and standards, inspection
+        and evaluation procedures and issue resolution required to ensure optimal
+        contract performance.\nKnowledge of the property management industry, including
+        private sector leasing protocols and practices involving facility operations
+        and systems; comprehensive knowledge of technical operating and customer-focused
+        strategies required to create a facility environment that exceeds customer
+        expectations, within established operating and financial parameters contractually
+        determined by the lessor(s).\nTechnical knowledge of building operations and
+        maintenance, including Federal and industry operations and maintenance best
+        practices; major systems and equipment such as HVAC, controls, mechanical,
+        electrical, plumbing, roofing, structural, elevators, and renewable energy
+        systems and how they contribute to whole building energy and water use; programs
+        such as commissioning, building returning and continuous commissioning, energy
+        and water efficiency, sustainability, zero environmental footprint and related
+        energy goals, custodial, waste management and recycling; art and historic
+        preservation; space alterations; safety, emergency management, environmental
+        management and concessions. If you are eligible under Interagency Career Transition
+        Assistance Plan or GSA&rsquo;s Career Transition Assistance Plan (ICTAP/CTAP),
+        you must receive a score of 85 or higher to receive priority. To preview questions
+        please click here.","HowToApply":"Submit a complete online application including
+        any required documents prior to 11:59 pm Eastern Time on the closing date
+        of the announcement. You can modify or complete your application any time
+        before the deadline. Simply return to USAJOBS, select the vacancy, and update
+        your application. For more detailed instructions on how to apply, click here:
+        Apply for a GSA Job.To begin, click the Apply Online button on the vacancy
+        announcement. Sign in or register on USAJobs and select a resume and documents
+        to include in your application.\nOnce you have clicked Apply for this position
+        now, you will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this job.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the announcement
+        closing.","WhatToExpectNext":"After the closing date/deadline: ELIGIBILITY/QUALIFICATIONS:
+        Your application will be reviewed for all requirements.\nREFERRAL TO MANAGEMENT:
+        If you meet all the requirements, you may be referred to management for review
+        and a possible interview. SELECTION/TENTATIVE JOB OFFER: If you are selected,
+        you will receive a tentative offer and start the suitability and/or security
+        background investigation process.\nFINAL JOB OFFER:Once our security office
+        determines you can come on board, you will be given a final offer, which is
+        typically 40 days after the announcement closes.\nFINAL COMMUNICATION: Once
+        the position is filled, we will notify you of your status. You may also check
+        your status by logging into USAJOBS. Go to My USAJOBS and then to Applications.
+        Thank you for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit.Note: If required to submit an SF-50
+        (Notice of Personnel Action), an equivalent agency Notice of Personnel Action
+        form is acceptable. Such document(s) must show all of the following: effective
+        date, position, title, series, grade, and rate of basic pay, tenure group
+        1 (career) or 2 (career-conditional), position occupied group, and name of
+        agency. If you are a GSA employee (except in the OIG), you are not required
+        to submit an SF-50.If you are a 30% or more disabled veteran, VEOA or VRA
+        applicant or qualified spouse, widow/widower, or parent: (a) Copy of your
+        Certificate of Release or Discharge From Active Duty, DD-214 that shows the
+        dates of your active duty service. If selected, a DD-214 showing your type
+        of discharge (member 4 copy) will be required prior to appointment. (b) If
+        you are a disabled veteran, or are applying under VRA or VEOA as a spouse,
+        widow/widower, or parent of a veteran, submit both of the following in addition
+        to the DD-214: completed SF-15 form; and\nproof of your entitlement (refer
+        to SF-15 for complete list). If you are active duty military- Certification
+        on a letterhead from your military branch that includes your rank, character
+        of service (must be under honorable conditions) &amp; military service dates
+        including discharge/release date (must be no later than 120 days after the
+        date the certification is submitted).If you are a current Federal employee
+        or Reinstatement Eligible: Submit your latest SF-50.If you are eligible under
+        an Interchange Agreement: Submit your latest SF-50.If you are a former Peace
+        Corp or VISTA volunteer: Submit your Description of Service.\nIf you are acurrent
+        or former Land Management Agency Employee- Submit a and b: (a) one or more
+        SF-50s, including your most recent one that shows you were on a competitive
+        time-limited appointment(s) with a Land Management Agencyand served on the
+        appointment for a period(s) totaling more than 24 months without a break of
+        2 or more years. (b) Copy of your agency&rsquo;s annual performance appraisal(s)
+        or written reference(s) from a supervisor at the agency verifying satisfactory
+        performance during your appointment(s).\nIf you have a disability: Submit
+        proof of eligibility. For information on eligibility and required documentation,
+        refer to USAJOBS&rsquo;s People With Disabilities page.If you are applying
+        under another special appointment authority: Submit proof of your eligibility
+        under the appropriate appointment authority. See USAJOBS''s Resource Center
+        for more information.If you areICTAP/CTAP eligible - submit a, b, and c: (a)
+        proof of eligibility including agency notice; (b) SF-50, and (c) most recent
+        performance appraisal.College transcripts: If you are using some or all of
+        your college education to meet qualification requirements for this position,
+        you must submit a photocopy of your college transcript(s). If selected, an
+        official transcript will be required prior to appointment. For education completed
+        outside the United States, also submit a valid foreign credential evaluation
+        that substantiates possession of the required education.","Benefits":"You
+        will have access to many benefits including: Health insurance (choose from
+        a wide range of plans)\nLife insurance coverage with several options\nSick
+        leave and vacation time, including 10 paid holidays per year\nThrift Savings
+        Plan (similar to a 401(k) plan)\nFlexible work schedules and telework\nTransit
+        and child care subsidies\nFlexible spending accounts\nLong-term care insurance\nTraining
+        and development","OtherInformation":"Bargaining Unit status: AFGE\nRelocation-related
+        expenses arenotapproved and will be your responsibility.\nAdditional vacancies
+        may be filled from this announcement as needed; through other means; or not
+        at all.\nWe are also accepting applications from all U.S. Citizens and Nationals
+        under Vacancy Announcement # 21PBSB382MMDE. You must apply separately to each
+        announcement to be considered for both.","KeyRequirements":["US Citizenship
+        or National (Residents of American Samoa and Swains Island)","Meet all eligibility
+        criteria within 30 days of the closing date","Meet time-in-grade within 30
+        days of the closing date, if applicable","Register with Selective Service,
+        if you are a male born after 12/31/1959","Must have valid State Drivers License"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"maura.murphy@gsa.gov","AgencyContactPhone":"212-264-5557","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"600946200","MatchedObjectDescriptor":{"PositionID":"21PBSB382MMDE","PositionTitle":"Building
+        Management Specialist","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/600946200","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/600946200?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Bangor, Maine","CountryCode":"United
+        States","CountrySubDivisionCode":"Maine","CityName":"Bangor, Maine","Longitude":-68.7708,"Latitude":44.8017},{"LocationName":"Van
+        Buren, Maine","CountryCode":"United States","CountrySubDivisionCode":"Maine","CityName":"Van
+        Buren, Maine","Longitude":-67.93658,"Latitude":47.157936}],"OrganizationName":"Public
+        Buildings Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Building
+        Management","Code":"1176"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume. For a brief video on creating a Federal resume, clickhere.
+        The GS-12 salary range starts at $77488 per year. If you are a new federal
+        employee, your starting salary will likely be set at the Step 1 of the grade
+        for which you are selected.\nTo qualify for the GS-12, you must have at least
+        one year of specialized experience equivalent to the GS-11 level or higher
+        in the Federal service.\nSpecialized experience is experience assisting in
+        the management of a multi-level commercial office building (or equivalent
+        non-housing high rise building) consisting of complex building mechanical
+        system (i.e., building automated systems, centralized HVAC, alarm systems,
+        elevators, etc): This experience typically includes: monitoring occupant space
+        utilization, energy and water conservation, sustainability and environmental
+        hazards programs;\ndirects and coordinates minor alteration and renovation
+        projects;\nmaintaining customer satisfaction programs including feedback mechanisms
+        used to evaluate the effectiveness of services provided; and\nmanaging or
+        monitoring real property budgetary and financial data.\ncontract administration
+        and oversight (i.e., janitorial, mechanical, elevator contracts)","PositionRemuneration":[{"MinimumRange":"77488.0","MaximumRange":"100739.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-11","PositionEndDate":"2021-06-07","PublicationStartDate":"2021-05-11","ApplicationCloseDate":"2021-06-07","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"Building
+        Management Specialist, you will provide property management services in both
+        federal and/or lease locations to ensure customer agencies are housed in safe,
+        secure, clean facilities.\nPosition is located in the Public Buildings Service,
+        Service Center Division, Van Buren, ME and Bangor, ME.\nWe are currently filling
+        two vacancies, additional vacancies may be filled as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"12","HighGrade":"12","OrganizationCodes":"GS/GS03","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104280","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104280&S=1","MajorDuties":["The
+        incumbent will serve as the Assistant Building Manager and Contracting Officer&rsquo;s
+        Representative (COR). Assist the Building Manager in monitoring the building
+        operational trends, contract management and enforcement, and act as the customer
+        representative. Interact directly with building occupants and serve as the
+        first point of contact for customers in assigned buildings. Develop a professional
+        and respectful relationship with customers and Improve customer satisfaction
+        with building services and maintain and preserve real property assets.\nParticipate,
+        plan and assist in developing projects for facilities as well as operational
+        budgets. Understand and utilize agency business performance goals and objectives
+        in the operations of assigned facilities. Manage the lease administration
+        process (post occupancy) for on behalf of tenant agencies. Perform COR duties
+        to ensure the lease is in compliance and provide technical support the PBS
+        Leasing Division."],"Education":"","Requirements":"If selected, you must meet
+        the following conditions: Receive authorization from OPM on any job offer
+        you receive, if you are or were (within the last 5 years) a Schedule A, Schedule
+        C, or non-career SES political appointee\nServe a one year probationary period,
+        if required.\nUndergo and pass a background investigation (Tier 2 investigation
+        level).\nHave your identity and work status eligibility verified if you are
+        not a GSA employee. We will use the Department of Homeland Security&rsquo;s
+        e-Verify system for this. Any discrepancies must be resolved as a condition
+        of continued employment.\nComplete a financial disclosure report to verify
+        that no conflict, or an appearance of conflict, exists between your financial
+        interest and this position\nParticipate in the Continuity of Operations Plan
+        (COOP), which includes attending meetings and planning activities; and carrying
+        out mission-critical work at a designated location other than your primary
+        work site (which may be outside of your commuting area).\nWork is normally
+        performed in an office setting, however, incumbent is routinely required to
+        travel and may be exposed to slippery or uneven ground, failing objects, constructions
+        and site conditions, noise, dust and environment or other discomforts and
+        hazards, walking, climbing ladders, crawling under and over equipment, bending,
+        stooping and standing for long periods of time is required while inspecting
+        buildings during field evaluations.\nThe employee must travel to customer
+        offices and GSA sites; a valid driver&rsquo;s license is required.","Evaluations":"We
+        will use a method called Category Rating to assess your application. Here&rsquo;s
+        how it will work: You will be scored on the questions you answer during the
+        application process, which will measure your possession of the following competencies
+        or knowledge, skills, and abilities:\nKnowledge of qualitative and quantitative
+        techniques and statistical interpretation required to perform extensive coordination
+        and fact-finding in order to identify client agency and building tenants&rsquo;
+        facility needs in relation to customer satisfaction; evaluate and interpret
+        required customer survey responses and other similar data; analyze the effectiveness
+        and efficiency of property management programs and building profitability
+        initiatives; evaluate technical and program data, and to make decisions or
+        recommendations for action based on consideration of all aspects of a problem.\nAdvanced
+        skills in interpersonal relations and in written and oral communications required
+        to explain, evaluate and negotiate client and technical operating requirements;
+        coordinate work efforts and negotiate resolutions to problems; present information
+        and conduct town hall meetings, tenant interviews and discussions in a concise
+        and professional manner; knowledge of customer relations and conflict resolution
+        sufficient to develop and maintain a high level of customer satisfaction in
+        the building(s) managed.\nKnowledge of quality assurance and quality control
+        methods and standards, inspection and evaluation procedures and issue resolution
+        required to ensure optimal contract performance.\nKnowledge of the property
+        management industry, including private sector leasing protocols and practices
+        involving facility operations and systems; comprehensive knowledge of technical
+        operating and customer-focused strategies required to create a facility environment
+        that exceeds customer expectations, within established operating and financial
+        parameters contractually determined by the lessor(s).\nTechnical knowledge
+        of building operations and maintenance, including Federal and industry operations
+        and maintenance best practices; major systems and equipment such as HVAC,
+        controls, mechanical, electrical, plumbing, roofing, structural, elevators,
+        and renewable energy systems and how they contribute to whole building energy
+        and water use; programs such as commissioning, building returning and continuous
+        commissioning, energy and water efficiency, sustainability, zero environmental
+        footprint and related energy goals, custodial, waste management and recycling;
+        art and historic preservation; space alterations; safety, emergency management,
+        environmental management and concessions. Your answers to the questions will
+        be used to place you in one of three categories: Best Qualified, Well Qualified,
+        or Qualified.\nWe will verify your answers to the questions in your resume.
+        If your resume doesn&rsquo;t support your answers, we may lower your score,
+        which could place you in a lower category.\nWithin each category, veterans
+        will receive selection priority over non-veterans. Additional assessments
+        may be used, and, if so, you will be provided with further instructions. If
+        you are eligible under Interagency Career Transition Assistance Plan or GSA&rsquo;s
+        Career Transition Assistance Plan (ICTAP/CTAP), you must receive a score of
+        85 or higher to receive priority. To preview questions please click here.","HowToApply":"Submit
+        a complete online application including any required documents prior to 11:59
+        pm Eastern Time on the closing date of the announcement. You can modify or
+        complete your application any time before the deadline. Simply return to USAJOBS,
+        select the vacancy, and update your application. For more detailed instructions
+        on how to apply, click here: Apply for a GSA Job.To begin, click the Apply
+        Online button on the vacancy announcement. Sign in or register on USAJobs
+        and select a resume and documents to include in your application.\nOnce you
+        have clicked Apply for this position now, you will be taken to the GSA site
+        to complete the application process.\nClick the Apply To This Vacancy and
+        complete all steps in the application process until the Confirmation indicates
+        your application is complete. If you click Return to USAJobs or get timed
+        out prior to receiving confirmation, your application will not be submitted
+        and cannot be considered for this job.\nNote: Review the REQUIRED DOCUMENTS
+        section of this announcement to determine which apply to you and must be submitted
+        online. You may choose one or more of the following options to submit your
+        document(s): Upload (from your computer); USAJOBS (click the \"USAJOBS\" link
+        to complete the transfer process) or FAX (read the &ldquo;Fax instructions&rdquo;
+        provided prior to printing the Fax Cover Sheet and faxing your information).
+        Need Assistance in Applying? Contact the HR representative listed on the announcement
+        prior to the application deadline. We are available to assist you Monday-Friday
+        during normal business hours. You must receive HR approval before deviating
+        from these instructions. Be sure to APPLY EARLY as most assessments must be
+        completed fully and submitted before the announcement closing.","WhatToExpectNext":"After
+        the closing date/deadline: ELIGIBILITY/QUALIFICATIONS: Your application will
+        be reviewed for all requirements.\nREFERRAL TO MANAGEMENT: If you meet all
+        the requirements, you may be referred to management for review and a possible
+        interview. SELECTION/TENTATIVE JOB OFFER: If you are selected, you will receive
+        a tentative offer and start the suitability and/or security background investigation
+        process.\nFINAL JOB OFFER:Once our security office determines you can come
+        on board, you will be given a final offer, which is typically 40 days after
+        the announcement closes.\nFINAL COMMUNICATION: Once the position is filled,
+        we will notify you of your status. You may also check your status by logging
+        into USAJOBS. Go to My USAJOBS and then to Applications. Thank you for your
+        interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are claiming veterans''
+        preference: Copy of your Certificate of Release or Discharge From Active Duty,
+        DD-214 that shows the dates of your active duty service. If selected, a DD-214
+        showing your type of discharge (member 4 copy) will be required prior to appointment.\nIf
+        you are claiming 10-point preference or derived preference (a spouse, widow
+        or widower, or parent of a deceased or disabled veteran), submit both of the
+        following in addition to the DD-214: (1)completed SF-15 form; and (2) proof
+        of your entitlement (refer to SF-15 for complete list). If you are active
+        duty military- Certification on a letterhead from your military branch that
+        includes your rank, character of service (must be under honorable conditions)
+        &amp; military service dates including discharge/release date (must be no
+        later than 120 days after the date the certification is submitted).\nIf you
+        are ICTAP/CTAP eligible - submit a, b, and c: (a) proof of eligibility including
+        agency notice; (b) SF-50, and (c) most recent performance appraisal.\nCurrent
+        or Former Political Appointees: Submit SF-50.\nCollege transcripts: If you
+        are using some or all of your college education to meet qualification requirements
+        for this position, you must submit a photocopy of your college transcript(s).
+        If selected, an official transcript will be required prior to appointment.
+        For education completed outside the United States, also submit a valid foreign
+        credential evaluation that substantiates possession of the required education.","Benefits":"You
+        will have access to many benefits including: Health insurance (choose from
+        a wide range of plans)\nLife insurance coverage with several options\nSick
+        leave and vacation time, including 10 paid holidays per year\nThrift Savings
+        Plan (similar to a 401(k) plan)\nFlexible work schedules and telework\nTransit
+        and child care subsidies\nFlexible spending accounts\nLong-term care insurance\nTraining
+        and development","OtherInformation":"Bargaining Unit status: AFGE\nRelocation-related
+        expenses arenotapproved and will be your responsibility.\nAdditional vacancies
+        may be filled from this announcement as needed; through other means; or not
+        at all.\nIf you are eligible under Merit Promotion, you may also apply under
+        Vacancy Announcement #21PBSB382MMDE. You must apply separately to each announcement
+        to be considered for both.","KeyRequirements":["US Citizenship or National
+        (Residents of American Samoa and Swains Island)","Meet all eligibility criteria
+        within 30 days of the closing date","Register with Selective Service, if you
+        are a male born after 12/31/1959","Must have valid State Drivers License"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"maura.murphy@gsa.gov","AgencyContactPhone":"212-264-5557","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"601238500","MatchedObjectDescriptor":{"PositionID":"21PBSC399SLMP","PositionTitle":"Building
+        Management Specialist","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/601238500","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/601238500?PostingChannelID="],"PositionLocationDisplay":"District
+        of Columbia, District of Columbia","PositionLocation":[{"LocationName":"District
+        of Columbia, District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"District of Columbia, District of Columbia","Longitude":-77.03196,"Latitude":38.89037}],"OrganizationName":"Public
+        Buildings Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Building
+        Management","Code":"1176"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"TheGS-12
+        salary range starts at $87,198 per year, if you meet the following qualifications.
+        You must meet all qualification and eligibility requirements within 30 days
+        of the closing date of this announcement. To qualify, you must demonstrate
+        one year of specialized experience at the GS-11.Specialized experience is
+        experience managing large office buildings including buildings and space delegated
+        to other entities. Such experience must reflect responsibility for coordinating
+        tasks and assignments; improving customer and client satisfaction; preparing
+        service contracts, and/or the development of maintenance programs for buildings;
+        evaluating and monitoring building management operations including custodial,
+        recycling, energy and environmental management, and mechanical maintenance
+        programs; utilizing quantitative and qualitative techniques to gather, analyze
+        and report data to measure programs relating to facility operations.NOTE:
+        Qualifications are based on length and level of experience. Therefore, in
+        addition to describing duties performed, applicants must provide the exact
+        dates of each period of employment (from month/year to month/year) and the
+        number of hours per week if part time. Qualification determinations cannot
+        be made when resumes do not include the required information, so failure to
+        provide this information may result in disqualification. For a brief video
+        on How to Create a Federal Resume, clickhere.","PositionRemuneration":[{"MinimumRange":"87198.0","MaximumRange":"113362.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-12","PositionEndDate":"2021-06-01","PublicationStartDate":"2021-05-12","ApplicationCloseDate":"2021-06-01","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"As
+        a Building Management Specialist, you will be responsible for improving customer
+        and client agency satisfaction with building services.as well as providing
+        occupants of Federal Government buildings with safe, secure, clean, and sustainable
+        facilities in which to conduct agency business. Location of Position:National
+        Capital Region (NCR), Public Building Services (PBS), Office of Facilities
+        Management (OFM), Washington, D.C.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"12","HighGrade":"12","OrganizationCodes":"GS/GS03","Relocation":"False","HiringPath":["disability","fed-competitive","fed-transition","land","mspouse","overseas","special-authorities","vet"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104296","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104296&S=1","MajorDuties":["As
+        aBuilding Management Specialist, you will perform the following duties: Serve
+        as Assistant Building Manager and provides occupants of Federal Government
+        buildings with safe, secure, clean, and sustainable facilities in which to
+        conduct agency business, and may specialize in one or more program areas.\nServe
+        as a customer agency advocate and first point of contact with client agency
+        personnel in designated GSA owned, interacts extensively with building tenants
+        and client representatives on a recurring basis to assess their facility and
+        facility related needs, and to assure that the procedures used to obtain services
+        are responsive and customer friendly.\nAssist Building Manager with building
+        operations, maintenance, repair, alteration, historic preservation, recycling,
+        concessions, safety, environmental and security in GSA-owned and leased buildings
+        assigned.\nManage grounds and exteriors including parking structures and lots,
+        site utilities, landscaping and grounds, snow removal, and exterior building
+        maintenance; assesses the effect of climate and extreme environmental conditions
+        and evaluates the performance of grounds and exterior elements.\nWork with
+        tenant agencies, building occupants, contractors, appropriate GSA program
+        experts and other stakeholders to coordinate sustainability-related programs
+        as applicable. These include but are not limited to recycling, HAZMAT reduction,
+        green purchasing, alternative transportation and workplace strategy, energy
+        and water use awareness and conservation, grassroots efforts to enlist occupant
+        support of building sustainability goals. *This is NOT a full-time telework
+        position. The selectee is expected to work at the duty location listed in
+        the vacancy announcement.\n*Valid driver&rsquo;s license is required.\nAt
+        this time, we are only filling only 1 vacancy;however, additional vacancies
+        may be filled through this announcement or other GSA organizations within
+        the same commuting area."],"Education":"","Requirements":"If selected, you
+        must meet the following conditions: Current or Former Political Appointees:The
+        Office of Personnel Management (OPM) must authorize employment offers made
+        to current or former political appointees. If you are currently, or have been
+        within the last 5 years, a political Schedule A, Schedule C or Non-Career
+        SES employee in the Executive Branch, you must disclose this information to
+        the HR Office. Failure to disclose this information could result in disciplinary
+        action including removal from Federal Service.\nComplete a \"Declaration of
+        Federal Employment\" (OF-306) to determine suitability for Federal employment.\nUndergo
+        a background investigation and receive a favorable adjudication. This position
+        has been designated as a Moderate Risk position.\nIf you are not a current
+        GSA employee, you must complete the Department of Homeland Security (DHS)
+        Form I-9 to determine identity and employment (work status) eligibility. GSA
+        will verify the information through the DHS e-Verify automated system. Any
+        identified discrepancies must be resolved as a condition of continued employment.\nNon-GSA
+        employees must complete the Department of Homeland Security (DHS) Form I-9
+        to determine identity and employment (work status) eligibility. GSA will verify
+        the information through the DHS e-Verify automated system. Any identified
+        discrepancies must be resolved as a condition of continued employment.\nMay
+        complete an OGE Form 450, Confidential Financial Disclosure Report, and obtain
+        approval that no conflict or an appearance of conflict exists between your
+        financial interest and this position.","Evaluations":"If you are found qualified
+        for the position, your responses to the self-assessment vacancy questions
+        will be used to assign a numerical score. If your responses to the vacancy
+        questions are not supported by your resume then your score may be adjusted
+        lower by the Human Resources Specialist. Scores are not augmented by Veteran''s
+        preference points for this type of announcement (Merit Promotion). You will
+        be evaluated on the vacancy related questions that were designed to assess
+        your overall possession of the following competencies/knowledge, skills, and
+        abilities: Knowledge of a wide range of building management principles, concepts
+        and practices as well as a thorough understanding of building tenants and
+        client agencies needs, requirements and customer satisfaction drivers to operate,
+        maintain and manage real property assets in a manner that provides quality
+        building services at a reasonable cost and satisfies building tenants and
+        customer agencies.\nKnowledge of building operations and maintenance, including
+        Federal and industry operations and maintenance best practices; major systems
+        and equipment such as HVAC, controls, mechanical, electrical, plumbing, roofing,
+        structural, elevators, and renewable energy systems and how they contribute
+        to whole building energy and water use.\nKnowledge of programs such as commissioning,
+        building returning and continuous commissioning, energy and water efficiency,
+        sustainability, zero environmental footprint and related energy goals, custodial,
+        waste management and recycling; art and historic preservation; space alterations;
+        safety, emergency management, environmental management and concessions.\nSkills
+        in interpersonal relations and in written and oral communications required
+        to explain, evaluate and negotiate client and technical operating requirements;
+        coordinate work efforts and negotiate resolutions to problems; present information
+        and conduct town hall meetings, tenant interviews and discussions in a concise
+        and professional manner.\nKnowledge of qualitative and quantitative techniques
+        and statistical interpretation required to perform extensive coordination
+        and fact-finding in order to identify client agency and building tenants&rsquo;
+        facility needs in relation to customer satisfaction; evaluate and interpret
+        required customer survey responses and other similar data; analyze the effectiveness
+        and efficiency of property management programs and building profitability
+        initiatives; evaluate technical and program data, and to make decisions or
+        recommendations for action based on consideration of all aspects of a problem.
+        A variety of assessments/assessment tools may be used to evaluate candidates
+        for specific vacancies covered by this announcement. Candidates will be notified
+        when further assessments are implemented and provided with instructions on
+        how to access and complete the assessment(s). Be sure to APPLY EARLY as most
+        assessments must be completed fully and submitted before the announcement
+        closing. If you are a GSA Career Transition Assistance eligible, you must
+        be considered well qualified (minimum score or 85) to receive priority.CTAP
+        To preview questions please click here.","HowToApply":"You must submit a complete
+        online application including any required documents prior to 11:59 pm Eastern
+        Time on the closing date of the Announcement. Errors or omissions may result
+        in your not being considered for this vacancy. You can modify/complete your
+        application any time before the vacancy date/time deadline. Simply return
+        to USAJOBS, select the vacancy, and update your application. For more detailed
+        instructions on how to apply, read the Apply for a GSA Job on the GSA website.To
+        begin, click the Apply Online button on the vacancy announcement.Sign in or
+        register on USAJobs and select a resume and documents to include in your application.Once
+        you have clicked Apply for this position now, you will be taken to the GSA
+        site to complete the application process.Click the Apply To This Vacancy and
+        complete all steps in the application process until the Confirmation indicates
+        your application is complete. If you click Return to USAJobs or get timed
+        out prior to receiving confirmation, your application will not be submitted
+        and cannot be considered for this vacancy.Note: Review the REQUIRED DOCUMENTS
+        section of this announcement to determine which apply to you and must be submitted
+        online. You may choose one or more of the following options to submit your
+        document(s): Upload (from your computer); USAJOBS (click the \"USAJOBS\" link
+        to complete the transfer process) or FAX (read the \"Fax instructions\" provided
+        prior to printing the Fax Cover Sheet and faxing your information).Need Assistance?
+        If you cannot complete any part of the application process listed above, contact
+        the Human Resources Office/representative listed on the announcement prior
+        to the announcement deadline for instructions on how to proceed. Be sure to
+        receive prior HR approval to deviate from these instructions so that your
+        application will be considered.","WhatToExpectNext":"If your application is
+        complete, we will review your application to ensure you meet the basic qualification
+        requirements. We will further evaluate each applicant who meets the basic
+        qualifications on the knowledge, skills, abilities, and/or competencies required
+        of the position. The most highly qualified candidates will be referred to
+        the hiring manager for further consideration and possible interview. After
+        making a tentative job offer, we will conduct a suitability and/or security
+        background investigation. A final job offer for this position is typically
+        made within 40 days after the deadline for applications.Thank you for your
+        interest in working for U.S. General Services Administration!","RequiredDocuments":"You
+        must submit ALL required documents before the closing date/deadline to have
+        a complete application. Review the following list to determine which documents
+        must be submitted online. Note: If required to submit an SF-50 (Notice of
+        Personnel Action), an equivalent agency Notice of Personnel Action form is
+        acceptable. Such document(s) must show all of the following: Effective Date,
+        Position, title, series, grade, and rate of basic pay, Tenure Group, Position
+        Occupied Group, and Name of Agency.Current or Former Political Appointees:
+        Submit SF-50. Note: GSA employees (except for OIG employees) are not required
+        to submit a SF-50. ICTAP/CTAP Eligible: Submit (a) proof of eligibility including
+        agency notice; (b) SF-50 and (c) most recent performance rating.30% of More
+        Disabled Veteran, VEOA or VRA applicant or qualified spouse, widow/widower,
+        or parent: You must submit a copy of your Certificate of Release or Discharge
+        From Active Duty, DD-214 that shows the dates of your active duty service.
+        If selected, a DD-214 showing your type of discharge (member 4 copy) will
+        be required prior to appointment. If you are a disabled veteran, or are applying
+        under VRA or VEOA as a spouse, widow/widower, or parent of a veteran, you
+        must submit the following in addition to the DD-214: (1) completed SF-15 form;
+        and (2) proof of your entitlement. A list of documents which serve as acceptable
+        proof of entitlement is indicated on the SF-15 form.Active Duty Military Personnel-
+        Submit certification on a letterhead from the appropriate military branch
+        that includes your rank, character of service (must be under honorable conditions)
+        &amp; military service dates including discharge/release date (must be no
+        later than 120 days after the date the certification is submitted).Current
+        Federal Employees or Reinstatement Eligibles: Submit your latest SF-50. Note:
+        GSA employees (except for OIG employees) are not required to submit an SF-50.
+        Former Peace Corps or VISTA Volunteers: Submit your Description of Service
+        (DOS). Returned Peace Corps Volunteers (RPCV) should also state their RPCV
+        eligibility on their resume.People With Disabilities: Submit proof of eligibility
+        and certification of job readiness. Select the link People With Disabilities
+        for information on eligibility and documentation required.Current or former
+        Land Management Agency employees hired under competitive hiring procedures
+        for a time-limited appointment. (a) Submit one or more SF-50&#8217;s including
+        the most recent applicable one detailing your competitive time limited appointment(s)
+        with a Land Management Agency/Agencies that demonstrate you have served in
+        such appointments for a period or periods totaling more than 24 months without
+        a break of 2 or more years; and (b) provide a copy of your agency&#8217;s
+        annual performance appraisal(s) or written reference(s) from a supervisor
+        at the employing agency who can attest to your satisfactory performance during
+        each of the applicable appointments.","Benefits":"GSA offers its employees
+        a wide range ofbenefitsincluding: Federal health insurance plans (choose from
+        a wide range of plans); Life insurance coverage with several options to choose
+        from; Leave policies to help you take care of your personal, recreational,
+        and health care needs; Thrift Savings Plan (similar to a 401(k) plan); Flexible
+        work schedules and telework; Transit and child care subsidies; and Training
+        and development.","BenefitsUrl":"http://www.opm.gov/insure/federal_employ/index.asp","OtherInformation":"Bargaining
+        Unit status: 1217\nGSA does not accept applications or application materials
+        submitted with Government-paid postage.\nAdditional vacancies may be filled
+        from this announcement as needed. This vacancy announcement does not preclude
+        filling this position by other means. Management also has the right not to
+        fill the position.\nTravel, transportation, and relocation expenses are not
+        authorized for this position. Any travel, transportation, and relocation expenses
+        associated with reporting for duty in this position will be the responsibility
+        of the successful applicant.","KeyRequirements":["Meet time-in-grade requirements
+        within 30 days of closing date","U.S. Citizenship or National","Males born
+        after 12/31/1959 must have registered with the Selective Service","Meet all
+        eligibility requirements within 30 days of the closing date.","Direct Deposit
+        of salary check to financial organization required."],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"pbscvacancyinquiries@gsa.gov","AgencyContactPhone":"000-00-0000","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"Moderate
+        Risk (MR)","AdjudicationType":["Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"601502200","MatchedObjectDescriptor":{"PositionID":"21FASB277AVMP","PositionTitle":"Assisted
+        Acquisition Project Manager (1101)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/601502200","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/601502200?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Phoenix, Arizona","CountryCode":"United
+        States","CountrySubDivisionCode":"Arizona","CityName":"Phoenix, Arizona","Longitude":-112.075775,"Latitude":33.44826},{"LocationName":"Los
+        Angeles, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"Los
+        Angeles, California","Longitude":-118.245,"Latitude":34.0535},{"LocationName":"San
+        Diego, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Diego, California","Longitude":-117.162,"Latitude":32.7157},{"LocationName":"San
+        Francisco, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Honolulu,
+        Hawaii","CountryCode":"United States","CountrySubDivisionCode":"Hawaii","CityName":"Honolulu,
+        Hawaii","Longitude":-157.858,"Latitude":21.3047},{"LocationName":"Las Vegas,
+        Nevada","CountryCode":"United States","CountrySubDivisionCode":"Nevada","CityName":"Las
+        Vegas, Nevada","Longitude":-115.14,"Latitude":36.1719}],"OrganizationName":"Federal
+        Acquisition Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"General
+        Business And Industry","Code":"1101"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nThe
+        GS-13 salary rangestartsat:\nLos Angeles, CA - $105,224 per year\nPhoenix,
+        AZ - $95,457 per year\nLas Vegas, NV - $93,518 per year\nHonolulu, HI - $95,012
+        per year\nSan Diego, CA - $103,126 per year\nSan Francisco, CA - $112,400
+        per year\nIf you are a new federal employee, your starting salary will likely
+        be set at the Step 1 of the grade for which you are selected.To qualify, you
+        must have at least one year of specialized experience equivalent to the GS-12
+        level or higher in the Federal service.Specialized experience is providing
+        technical and acquisition consultation, customer service, and complex project
+        management for multiple state of the art technology Information Technology,
+        Telecommunications, and Professional Services projects for complex goods and
+        services.","PositionRemuneration":[{"MinimumRange":"93518.0","MaximumRange":"146120.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-14","PositionEndDate":"2021-05-28","PublicationStartDate":"2021-05-14","ApplicationCloseDate":"2021-05-28","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"As
+        an Assisted Acquisition Project Manager, you will perform highly complex technical
+        work and in-depth analysis in the acquisition of products and services for
+        federal customer agencies on a regional, national, or worldwide basis.Location
+        of position:Federal Acquisition Service (FAS) - Assisted Acquisition Services
+        (AAS) Division, Pacific Rim Region.\nWe are currently filling one vacancy,
+        but additional vacancies may be filled as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"13","HighGrade":"13","OrganizationCodes":"GS/GS30","Relocation":"False","HiringPath":["disability","fed-competitive","fed-transition","land","mspouse","overseas","peace","special-authorities","vet"],"TotalOpenings":"Few","AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"2","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104258","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104258&S=1","MajorDuties":["Performs
+        technical work and analysis in the acquisition of products and services for
+        Federal Clients on a regional, national, or worldwide basis.\nProvides technical
+        and acquisition support for requirements in the areas of Information Technology
+        and Professional Services products and services.\nResponsible for the analysis
+        of a wide range of customer agency requirements and the development, along
+        with the contracting officer, of acquisition solutions to satisfy the need.\nResponsible
+        for the full life cycle of the acquisition process including Interagency Agreement,
+        requirements analysis, Statement of Work (SOW), Performance Work Statement
+        (PWS) and/or Statement of Objectives (SOO) development, IGCE, acquisition
+        and supporting documents, financial management of agency funding in a fee-for-service,
+        reimbursable environment, the technical evaluation of industry proposals,
+        invoicing, and post award administration. Serves as a Contracting Officer
+        Representative (COR).\nPerforms other duties as assigned."],"Education":"Note:If
+        you are using foreign education to meet qualification requirements, you must
+        send a Certificate of Foreign Equivalency with your transcript in order to
+        receive credit for that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nUndergo and pass
+        a background investigation (Tier 5 investigation level). You must be granted
+        this clearance before you can start the job.\nHave your identity and work
+        status eligibility verified if you are not a GSA employee. We will use the
+        Department of Homeland Security&rsquo;s e-Verify system for this. Any discrepancies
+        must be resolved as a condition of continued employment.\nComplete a financial
+        disclosure report to verify that no conflict, or an appearance of conflict,
+        exists between your financial interest and this position. Position requires
+        the ability to obtain and maintain:\n- Federal Acquisition Certification in
+        Program Management (FAC-PM) Program Level III certification,\n- Federal Acquisition
+        Certification in Contracting Officer Representative (FAC-COR) Program Level
+        III certification.\n- Federal Acquisition Certification in Information Technology
+        (FAC-IT) Program Level III certification.\n- Future FAC certifications identified
+        by the GSA Senior Procurement Executive applicable to the GSA acquisition
+        community.\nGiven that Federal Acquisition Certification in Contracting (FAC-C)
+        Level III is a higher certification level than FAC-PM or FAC-COR, reciprocity
+        requirements are outlined on the Federal Acquisition Institutes website. Individuals
+        possessing a FAC-C certification should maintain the certification through
+        completion of continuous learning requirements, which attrite as annual acquisition
+        training to FAC-PM and FAC-COR.","Evaluations":"You will be evaluated on the
+        questions you answer during the application process, which will measure your
+        overall possession of the following competencies or knowledge, skills, and
+        abilities. Your responses to these questions must be supported by your resume
+        or your score may be lowered. Possesses a broad knowledge of government acquisition,
+        procurement and project management principles utilized by customer agencies
+        to conduct general business operations.\nFundamental knowledge of acquisition
+        procurement regulations, acquisition terminology, acquisition planning and
+        contract administration procedures and practices; agency regulations, and
+        the missions/functions of other Federal agencies in order to coordinate effectively
+        with vendors and user agency representatives on sensitive issues.\nExpert
+        knowledge of FAS operating procedures, interagency agreements and methods
+        used in developing agreements with other Federal agencies in order to meet
+        the requirements of Title 31. This includes agency interface, appropriation
+        law, billing procedures, invoice acceptance/rejections, laws governing privacy
+        of data, personal services, security, confidentiality of data and other proprietary
+        information, and codes of conduct.\nMastery knowledge and expert skill in
+        developing acquisition strategy for assigned customer agencies/projects, conducting
+        market research, determining contract type, executing the source selection
+        process, and conducting the administrative contracting process for the life
+        of task orders and contracts in accordance with applicable laws, regulations,
+        policies, and procedures.\nSkill in understanding the business objectives
+        of federal customer agencies and expert skill in transferring those objectives
+        into workable solutions by utilizing FAS or other federal agency contract
+        vehicles and acquisition strategies.\nMastery knowledge of analytical methods,
+        principles, and techniques required to receive, analyze, and resolve uniquely
+        complex customer requests and problems. Expert skill in conducting studies
+        and analysis to arrive at solutions for customer requirements that can be
+        nationwide or worldwide in nature or involve state-of-the-art or precedent-setting
+        business or technology needs.\nExpert skill in recommending effective integrated
+        solutions to meet assigned customer agency IT and/or Professional Services
+        requirements, using acquisition knowledge to recommend acquisition strategies
+        and advise customers on appropriate government contracting vehicles.\nVerbal
+        and written communication skills are required to accurately and concisely
+        translate a variety of requirements or specifications and perform relevant
+        and persuasive briefings to audiences that can include technical specialists
+        and high level officials with diverse needs.\nSkill in meeting and dealing
+        with high level agency and contractor executives in order to communicate,
+        defend and/or justify extensive and highly complex recommendations to customers.
+        Skill in conducting management reviews and presenting proposals to a variety
+        of individuals at all levels of the agency or customer agencies. Additional
+        assessments may be used, and, if so, you will be provided with further instructions.\nIf
+        you are eligible under Interagency Career Transition Assistance Plan or GSA&rsquo;s
+        Career Transition Assistance Plan(ICTAP/CTAP), you must receive a score of
+        85 or higher to receive priority. To preview questions please click here.","HowToApply":"Submit
+        a complete online application including any required documents prior to 11:59
+        pm Eastern Time on the closing date of the announcement. You can modify or
+        complete your application any time before the deadline. Simply return to USAJOBS,
+        select the vacancy, and update your application. For more detailed instructions
+        on how to apply, click here: Apply for a GSA Job.To begin, click the Apply
+        Online button on the vacancy announcement. Sign in or register on USAJobs
+        and select a resume and documents to include in your application.\nOnce you
+        have clicked Apply for this position now, you will be taken to the GSA site
+        to complete the application process.\nClick the Apply To This Vacancy and
+        complete all steps in the application process until the Confirmation indicates
+        your application is complete. If you click Return to USAJobs or get timed
+        out prior to receiving confirmation, your application will not be submitted
+        and cannot be considered for this job.\nNote: Review the REQUIRED DOCUMENTS
+        section of this announcement to determine which apply to you and must be submitted
+        online. You may choose one or more of the following options to submit your
+        document(s): Upload (from your computer); USAJOBS (click the \"USAJOBS\" link
+        to complete the transfer process) or FAX (read the &ldquo;Fax instructions&rdquo;
+        provided prior to printing the Fax Cover Sheet and faxing your information).
+        Need Assistance in Applying? Contact the HR representative listed on the announcement
+        prior to the application deadline. We are available to assist you Monday-Friday
+        during normal business hours. You must receive HR approval before deviating
+        from these instructions. Be sure to APPLY EARLY as most assessments must be
+        completed fully and submitted before the announcement closing.","WhatToExpectNext":"After
+        the closing date/deadline: ELIGIBILITY/QUALIFICATIONS: Your application will
+        be reviewed for all requirements.\nREFERRAL TO MANAGEMENT: If you meet all
+        the requirements, you may be referred to management for review and a possible
+        interview. SELECTION/TENTATIVE JOB OFFER: If you are selected, you will receive
+        a tentative offer and start the suitability and/or security background investigation
+        process.\nFINAL JOB OFFER:Once our security office determines you can come
+        on board, you will be given a final offer, which is typically 40 days after
+        the announcement closes.\nFINAL COMMUNICATION: Once the position is filled,
+        we will notify you of your status. You may also check your application status
+        by logging into USAJOBS and clicking &ldquo;Track this Application&rdquo;
+        on theApplicant Dashboard. Thank you for your interest in working for U.S.
+        General Services Administration!","RequiredDocuments":"ALL required documents
+        must be submitted before the closing date. Review the following list to determine
+        what you need to submit.Note: If required to submit an SF-50 (Notice of Personnel
+        Action), an equivalent agency Notice of Personnel Action form is acceptable.
+        Such document(s) must show all of the following: effective date, position,
+        title, series, grade, and rate of basic pay, tenure group 1 (career) or 2
+        (career-conditional), position occupied group, and name of agency. If you
+        are a GSA employee (except in the OIG), you are not required to submit an
+        SF-50.If you are a 30% or more disabled veteran, VEOA or VRA applicant or
+        qualified spouse, widow/widower, or parent:(a) Copy of your Certificate of
+        Release or Discharge From Active Duty, DD-214 that shows the dates of your
+        active duty service. If selected, a DD-214 showing your type of discharge
+        (member 4 copy) will be required prior to appointment.(b) If you are a disabled
+        veteran, or are applying under VRA or VEOA as a spouse, widow/widower, or
+        parent of a veteran, submit both of the following in addition to the DD-214:
+        (1)completed SF-15 form; and (2)proof of your entitlement (refer to SF-15
+        for complete list).\nIf you are active duty military- Certification on a letterhead
+        from your military branch that includes your rank, character of service (must
+        be under honorable conditions) &amp; military service dates including discharge/release
+        date (must be no later than 120 days after the date the certification is submitted).If
+        you are a current Federal employee or Reinstatement Eligible: Submit your
+        latest SF-50.If you are eligible under an Interchange Agreement: Submit your
+        latest SF-50.If you are a former Peace Corp or VISTA volunteer: Submit your
+        Description of Service.\nIf you are acurrent or former Land Management Agency
+        Employee- Submit a and b: (a) one or more SF-50s, including your most recent
+        one that shows you were on a competitive time-limited appointment(s) with
+        a Land Management Agencyand served on the appointment for a period(s) totaling
+        more than 24 months without a break of 2 or more years. (b) Copy of your agency&rsquo;s
+        annual performance appraisal(s) or written reference(s) from a supervisor
+        at the agency verifying satisfactory performance during your appointment(s).\nIf
+        you have a disability: Submit proof of eligibility. For information on eligibility
+        and required documentation, refer to USAJOBS&rsquo;s People With Disabilities
+        page.If you are applying under another special appointment authority: Submit
+        proof of your eligibility under the appropriate appointment authority. See
+        USAJOBS''s Resource Center for more information.If you areICTAP/CTAP eligible
+        - submit a, b, and c: (a) proof of eligibility including agency notice; (b)
+        SF-50, and (c) most recent performance appraisal.\nIf you are a current or
+        former political appointee: Submit your SF-50. College transcripts: If you
+        are using some or all of your college education to meet qualification requirements
+        for this position, you must submit a photocopy of your college transcript(s).
+        If selected, an official transcript will be required prior to appointment.
+        For education completed outside the United States, also submit a valid foreign
+        credential evaluation that substantiates possession of the required education.","Benefits":"You
+        will have access to many benefits including: Health insurance (choose from
+        a wide range of plans)\nLife insurance coverage with several options\nSick
+        leave and vacation time, including 10 paid holidays per year\nThrift Savings
+        Plan (similar to a 401(k) plan)\nFlexible work schedules\nTransit and child
+        care subsidies\nFlexible spending accounts\nLong-term care insurance\nTraining
+        and development","OtherInformation":"Bargaining Unit status: Varies based
+        on location.\nRelocation-related expenses arenotapproved and will be your
+        responsibility. Additional vacancies may be filled from this announcement
+        as needed; through other means; or not at all. *The applicant agrees they
+        must reside in one of the following states: Arizona, California, Hawaii, or
+        Nevada at time of Entrance of Duty/start date of position, if selected. The
+        applicant must be physically located in one of the identified States or be
+        willing to relocate, at their own expense, to one of the states listed, at
+        time of Entrance of Duty (EOD), if selected. The applicant understands that
+        the applicant will be required to report to a GSA office building or appropriate
+        federal facility within the commuting distance of the applicant''s residence
+        within the states of Arizona, California, Hawaii, or Nevada.","KeyRequirements":["US
+        Citizenship or National (Residents of American Samoa and Swains Island)","Meet
+        all eligibility criteria within 30 days of the closing date","Meet time-in-grade
+        within 30 days of the closing date, if applicable","Register with Selective
+        Service if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"arantxa.villalva@gsa.gov","AgencyContactPhone":"312-353-5547","SecurityClearance":"Top
+        Secret","DrugTestRequired":"False","PositionSensitivitiy":"Critical-Sensitive
+        (CS)/High Risk","AdjudicationType":["Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"601521900","MatchedObjectDescriptor":{"PositionID":"21FASA231ABMP","PositionTitle":"Contract
+        Specialist","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/601521900","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/601521900?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"San Francisco, California","CountryCode":"United
+        States","CountrySubDivisionCode":"California","CityName":"San Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Lakewood,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Lakewood,
+        Colorado","Longitude":-105.08274,"Latitude":39.71095},{"LocationName":"District
+        of Columbia, District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"District of Columbia, District of Columbia","Longitude":-77.03196,"Latitude":38.89037},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Philadelphia,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Philadelphia,
+        Pennsylvania","Longitude":-75.16237,"Latitude":39.95227},{"LocationName":"Fort
+        Worth, Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Fort
+        Worth, Texas","Longitude":-97.32925,"Latitude":32.74863},{"LocationName":"Ogden,
+        Utah","CountryCode":"United States","CountrySubDivisionCode":"Utah","CityName":"Ogden,
+        Utah","Longitude":-111.97046,"Latitude":41.222366},{"LocationName":"Salt Lake
+        City, Utah","CountryCode":"United States","CountrySubDivisionCode":"Utah","CityName":"Salt
+        Lake City, Utah","Longitude":-111.88823,"Latitude":40.75952},{"LocationName":"Tacoma,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Tacoma,
+        Washington","Longitude":-122.44166,"Latitude":47.255165}],"OrganizationName":"Federal
+        Acquisition Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Contracting","Code":"1102"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.The
+        GS-13 salary range starts at $93,081 per year. If you are a new federal employee,
+        your starting salary will likely be set at the Step 1 of the grade for which
+        you are selected.To qualify, you must have at least one year of specialized
+        experience equivalent to the GS-12 level or higher in the Federal service.Specialized
+        experience is one year of experience equivalent to the GS-12 in the Federal
+        service. Specialized experience is defined as responsibility for large-scale
+        centralized procurement of supplies, services, equipment, to meet the consolidated
+        requirements of one or several agencies or departments; developing the solicitation;
+        evaluating bids or offers; and, conducting negotiations. Experience involving
+        the procurement of supplies and services; utilizing formal advertising or
+        negotiation procedures; placing orders or establishing blanket purchase agreements
+        (BPAs) against the Multiple Award Schedule (MAS) contracts or making awards
+        of indefinite delivery, indefinite quantity (IDIQ) contracts.\nYou must meetthe
+        requirements in 1, 2, or 3 below: All of the following: (a)Completion of Training
+        listed in Level I &amp; II of FAC-C Course Requirements;orFAC-C Level II or
+        III, or a DAWIA level II or III certification. If your certification is over
+        2 years old, 80 hours of Continuous Learning Points are required to maintain
+        certification.(b)At least 4years of experience in contracting or related positions
+        including 1 year of specialized experience at or equivalent to work at the
+        level described below; and(c)Completion of a 4-year course of study leading
+        to a bachelor''s degree that included or was supplemented by at least 24 semester
+        hours in any combination of the following fields: accounting, business, finance,
+        law, contracts, purchasing, economics, industrial management, marketing, quantitative
+        methods, or organization and management.\nException:If you were in a GS-1102
+        position on January 1, 2000, you will be exempt from meeting the educational
+        requirements for the grade level of that position. However, to be promoted
+        you will have to meet Option 1 or 3. Waiver:GSA''s senior procurement executive
+        has the discretion to waive any or all of the requirements in 1 above. This
+        position has a positive education requirement:Applicants must submit a copy
+        of their college or university transcript(s) and certificates by the closing
+        date of announcements to verify qualifications. If selected, an official transcript
+        will be required prior to appointment.","PositionRemuneration":[{"MinimumRange":"92143.0","MaximumRange":"146120.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-14","PositionEndDate":"2021-06-01","PublicationStartDate":"2021-05-14","ApplicationCloseDate":"2021-06-01","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"As
+        a Contract Specialist, you will perform pre-award and post-award functions
+        involving highly specialized and complex procurements of Government-wide Contracts/Orders
+        with world-wide scope.\nThis position supports Region 8 FAS Acquisition Operations
+        Division (AOD) out of Lakewood CO. Location will be determined upon selection.
+        This isnota virtual position. The selectee will have to report to a regional
+        GSA office.We are currently filling one vacancy, but additional vacancies
+        may be filled","WhoMayApply":{"Name":"","Code":""},"LowGrade":"13","HighGrade":"13","OrganizationCodes":"GS/GS30","Relocation":"False","HiringPath":["disability","fed-competitive","fed-transition","land","mspouse","overseas","peace","special-authorities","vet"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104270","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104270&S=1","MajorDuties":["THIS
+        ANNOUNCEMENT HAS BEEN AMENDED TO EXTEND THE CLOSE DATE DUE TO ADDITION OF
+        TWO NEW DUTY LOCATIONS Develops procurement objectives for the program and
+        terms of competition and price range, determines and prepares the contractual
+        vehicle including the use of pricing arrangements, subcontracting policy,
+        set-aside policies and similar considerations. Prepares and maintains current
+        acquisition plans, associate milestone charts, and related schedules.\nConducts
+        negotiations independently and awards the contract. Negotiation decisions
+        are accepted as authoritative and serve as the basis for committing the Government
+        to contracts.\nIndependently plans work, determines work priorities and is
+        totally responsible for the acquisition, negotiation, administration or termination
+        of contracts for integrated services, hardware, software and professional
+        services acquisition. Leads acquisition team (e.g., Contracting Officer''s
+        Representatives, other Contract Specialists, and financial personnel) relating
+        to the acquisition process and the procurement and administration of contracts.\nPlans
+        and conducts post award conferences to ensure compliance with, arid full understanding
+        of, contractual requirements and to preclude unauthorized changes or alterations
+        in contract provisions.\nIncorporates changed contract requirements or settles
+        issues that develop after contract placement, e.g., equitable adjustments
+        in price and/or delivery schedule."],"Education":"Note:If you are using foreign
+        education to meet qualification requirements, you must send a Certificate
+        of Foreign Equivalency with your transcript in order to receive credit for
+        that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nUndergo and pass
+        a background investigation (Tier 5 investigation level). You must be granted
+        this clearance before you can start the job.\nHave your identity and work
+        status eligibility verified if you are not a GSA employee. We will use the
+        Department of Homeland Security&rsquo;s e-Verify system for this. Any discrepancies
+        must be resolved as a condition of continued employment.\nComplete a financial
+        disclosure report to verify that no conflict, or an appearance of conflict,
+        exists between your financial interest and this position.","Evaluations":"You
+        will be evaluated on the questions you answer during the application process,
+        which will measure your overall possession of the following competencies or
+        knowledge, skills, and abilities. Your responses to these questions must be
+        supported by your resume or your score may be lowered. Knowledge of and ability
+        to interpret laws, regulations, principles and policies to generate new procurement
+        concepts and make recommendations to top management.\nKnowledge of negotiation
+        techniques.\nKnowledge of contract types, methods, and techniques including
+        fixed price contracts, processing of unsolicited proposals, multiple awards,
+        and special provisions relating to contracts.\nAbility to effectively communicate
+        orally and in writing.\nKnowledge of contract administration policy and procedures.
+        Additional assessments may be used, and, if so, you will be provided with
+        further instructions.\nIf you are eligible under Interagency Career Transition
+        Assistance Plan or GSA&rsquo;s Career Transition Assistance Plan(ICTAP/CTAP),
+        you must receive a score of 85 or higher to receive priority. To preview questions
+        please click here.","HowToApply":"Submit a complete online application including
+        any required documents prior to 11:59 pm Eastern Time on the closing date
+        of the announcement. You can modify or complete your application any time
+        before the deadline. Simply return to USAJOBS, select the vacancy, and update
+        your application. For more detailed instructions on how to apply, click here:
+        Apply for a GSA Job.To begin, click the Apply Online button on the vacancy
+        announcement. Sign in or register on USAJobs and select a resume and documents
+        to include in your application.\nOnce you have clicked Apply for this position
+        now, you will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this job.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying? Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the announcement
+        closing.","WhatToExpectNext":"After the closing date/deadline: ELIGIBILITY/QUALIFICATIONS:
+        Your application will be reviewed for all requirements.\nREFERRAL TO MANAGEMENT:
+        If you meet all the requirements, you may be referred to management for review
+        and a possible interview. SELECTION/TENTATIVE JOB OFFER: If you are selected,
+        you will receive a tentative offer and start the suitability and/or security
+        background investigation process.\nFINAL JOB OFFER:Once our security office
+        determines you can come on board, you will be given a final offer, which is
+        typically 40 days after the announcement closes.\nFINAL COMMUNICATION: Once
+        the position is filled, we will notify you of your status. You may also check
+        your status by logging into USAJOBS. Go to My USAJOBS and then to Applications.
+        Thank you for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit.Note: If required to submit an SF-50
+        (Notice of Personnel Action), an equivalent agency Notice of Personnel Action
+        form is acceptable. Such document(s) must show all of the following: effective
+        date, position, title, series, grade, and rate of basic pay, tenure group
+        1 (career) or 2 (career-conditional), position occupied group, and name of
+        agency. If you are a GSA employee (except in the OIG), you are not required
+        to submit an SF-50.If you are a 30% or more disabled veteran, VEOA or VRA
+        applicant or qualified spouse, widow/widower, or parent:(a) Copy of your Certificate
+        of Release or Discharge From Active Duty, DD-214 that shows the dates of your
+        active duty service. If selected, a DD-214 showing your type of discharge
+        (member 4 copy) will be required prior to appointment.(b) If you are a disabled
+        veteran, or are applying under VRA or VEOA as a spouse, widow/widower, or
+        parent of a veteran, submit both of the following in addition to the DD-214:
+        (1)completed SF-15 form; and (2)proof of your entitlement (refer to SF-15
+        for complete list).\nIf you are active duty military- Certification on a letterhead
+        from your military branch that includes your rank, character of service (must
+        be under honorable conditions) &amp; military service dates including discharge/release
+        date (must be no later than 120 days after the date the certification is submitted).If
+        you are a current Federal employee or Reinstatement Eligible: Submit your
+        latest SF-50.If you are eligible under an Interchange Agreement: Submit your
+        latest SF-50.If you are a former Peace Corp or VISTA volunteer: Submit your
+        Description of Service.\nIf you are acurrent or former Land Management Agency
+        Employee- Submit a and b: (a) one or more SF-50s, including your most recent
+        one that shows you were on a competitive time-limited appointment(s) with
+        a Land Management Agencyand served on the appointment for a period(s) totaling
+        more than 24 months without a break of 2 or more years. (b) Copy of your agency&rsquo;s
+        annual performance appraisal(s) or written reference(s) from a supervisor
+        at the agency verifying satisfactory performance during your appointment(s).\nIf
+        you have a disability: Submit proof of eligibility. For information on eligibility
+        and required documentation, refer to USAJOBS&rsquo;s People With Disabilities
+        page.If you are applying under another special appointment authority: Submit
+        proof of your eligibility under the appropriate appointment authority. See
+        USAJOBS''s Resource Center for more information.If you areICTAP/CTAP eligible
+        - submit a, b, and c: (a) proof of eligibility including agency notice; (b)
+        SF-50, and (c) most recent performance appraisal.\nIf you are a current or
+        former political appointee: Submit your SF-50.\nCollege transcripts:If you
+        are using some or all of your college education to meet qualification requirements
+        for this position, you must submit a photocopy of your college transcript(s).
+        If selected, an official transcript will be required prior to appointment.
+        For education completed outside the United States, also submit a valid foreign
+        credential evaluation that substantiates possession of the required education.Contracting
+        Documentation: Submit A or B:\n(A) List of completed courses as described
+        in the requirements section of this announcement. The list must include: official
+        course title, course number, training provider, training hours completed,
+        and the date completed\n(B) Proof of contracting certification: FAC-C or DAWIA
+        Level II or higher certification (copy of certificate) If certification is
+        over 2 years old, also submit (a) or (b) below: (a) Continuous Learning Points
+        (CLPs) history identifying the completion of 80 CLPs every two years.The 80
+        CLPs every two years must be from the issuance date of certification to the
+        current period. (b) If you are a FAITAS member, you may submit your Continuous
+        Learning Achievement Certificate from FAITAS.On your \"My Continuous Learning\"
+        page, click on the \"approved\" link under Achievement Status to print a copy
+        of your most recent certificate.","Benefits":"You will have access to many
+        benefits including: Health insurance (choose from a wide range of plans)\nLife
+        insurance coverage with several options\nSick leave and vacation time, including
+        10 paid holidays per year\nThrift Savings Plan (similar to a 401(k) plan)\nFlexible
+        work schedules\nTransit and child care subsidies\nFlexible spending accounts\nLong-term
+        care insurance\nTraining and development","OtherInformation":"Bargaining Unit
+        status: 1260 AFGE\nRelocation-related expenses arenotapproved and will be
+        your responsibility. Additional vacancies may be filled from this announcement
+        as needed; through other means; or not at all.","KeyRequirements":["US Citizenship
+        or National (Residents of American Samoa and Swains Island)","Meet all eligibility
+        criteria within 30 days of the closing date","Meet time-in-grade within 30
+        days of the closing date, if applicable","Register with Selective Service
+        if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"ashley.e.brown@gsa.gov","AgencyContactPhone":"816-384-5710","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"601638600","MatchedObjectDescriptor":{"PositionID":"21STFB157MLDE","PositionTitle":"IT
+        Specialist","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/601638600","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/601638600?PostingChannelID="],"PositionLocationDisplay":"GSA
+        - US Locations, United States","PositionLocation":[{"LocationName":"Kansas
+        City, Missouri","CountryCode":"United States","CountrySubDivisionCode":"Missouri","CityName":"Kansas
+        City, Missouri","Longitude":-94.58306,"Latitude":39.10296},{"LocationName":"Washington,
+        District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904},{"LocationName":"Chicago,
+        Illinois","CountryCode":"United States","CountrySubDivisionCode":"Illinois","CityName":"Chicago,
+        Illinois","Longitude":-87.63241,"Latitude":41.88415},{"LocationName":"Atlanta,
+        Georgia","CountryCode":"United States","CountrySubDivisionCode":"Georgia","CityName":"Atlanta,
+        Georgia","Longitude":-84.39111,"Latitude":33.748314},{"LocationName":"Lakewood,
+        Colorado","CountryCode":"United States","CountrySubDivisionCode":"Colorado","CityName":"Lakewood,
+        Colorado","Longitude":-105.08274,"Latitude":39.71095},{"LocationName":"Seattle,
+        Washington","CountryCode":"United States","CountrySubDivisionCode":"Washington","CityName":"Seattle,
+        Washington","Longitude":-122.32945,"Latitude":47.60358},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146},{"LocationName":"Philadelphia,
+        Pennsylvania","CountryCode":"United States","CountrySubDivisionCode":"Pennsylvania","CityName":"Philadelphia,
+        Pennsylvania","Longitude":-75.16237,"Latitude":39.95227},{"LocationName":"San
+        Francisco, California","CountryCode":"United States","CountrySubDivisionCode":"California","CityName":"San
+        Francisco, California","Longitude":-122.4196,"Latitude":37.7771},{"LocationName":"Boston,
+        Massachusetts","CountryCode":"United States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston,
+        Massachusetts","Longitude":-71.0567,"Latitude":42.358635},{"LocationName":"Fort
+        Worth, Texas","CountryCode":"United States","CountrySubDivisionCode":"Texas","CityName":"Fort
+        Worth, Texas","Longitude":-97.32925,"Latitude":32.74863}],"OrganizationName":"Office
+        of the Chief Information Officer","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Information
+        Technology Management","Code":"2210"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.The
+        GS-14salary range starts at $108,885 to *$172,500 per year. (* this is the
+        highest possible locality pay which is San Francisco, CA) Locality pay will
+        be determined upon selection.If you are a new federal employee, your starting
+        salary will likely be set at the Step 1 of the grade for which you are selected.To
+        qualify, applicants applying for the GS-14 grade level must meet the following
+        requirements: Have IT-related experience demonstrating EACH of the four competencies
+        AND one year of specialized experience equivalent to the GS-13 level in the
+        Federal service as described below:\nIT SPECIALIST COMPETENCY REQUIREMENTS:\nAttention
+        to Detail - This skill is generally demonstrated by assignments where the
+        applicant investigates and evaluates &ldquo;state of the art&rdquo; technology
+        of the industry.\nCustomer Service - This skill is generally demonstrated
+        by assignments where the applicant confers with users to evaluate the effectiveness
+        of, or identify the need for, computer programs or management systems.\nOral
+        Communication - This skill is generally demonstrated by assignments where
+        the applicant persuades others to take a particular course of action or to
+        accept findings, recommendations, changes, or alternative viewpoints.\nProblem
+        Solving - This skill is generally demonstrated by assignments where the applicant
+        identifies and accommodates technology and resource constraints.\nSPECIALIZED
+        EXPERIENCE REQUIREMENTS: Specialized experience is defined as experience leading
+        the design, implementation, and maintenance of complex IT systems. Experience
+        must include evaluating, planning, designing, implementing and merging new
+        and improved IT solutions; and recommending and analyzing IT environments,
+        application programming interfaces, IT solution architectures and open source
+        and other technologies to provide technical recommendations for service, performance,
+        security and overall technical improvements.","PositionRemuneration":[{"MinimumRange":"108885.0","MaximumRange":"172500.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-14","PositionEndDate":"2021-05-28","PublicationStartDate":"2021-05-14","ApplicationCloseDate":"2021-05-28","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"This
+        position is located within the Office of GSA IT.\nLocation of position: The
+        Duty Station can be any GSA Regional Office Building or Field Office location
+        depending on where the selected candidate(s) is located. If a candidate is
+        already a GSA full-time telework employee they will be allowed to keep their
+        full-time telework status.\nWe are currently filling one vacancy, but additional
+        vacancies may be filled as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"14","HighGrade":"14","OrganizationCodes":"GS/GS28","Relocation":"False","HiringPath":["public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104307","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104307&S=1","MajorDuties":["The
+        incumbent will serve as an Information Technology (IT) Subject Matter Expert
+        (SME) in geospatial technology and Geographic Information Systems/Services
+        (GIS) in the General Services Administration(GSA), Office of GSA IT, Public
+        Buildings Information Technology Services. Provides geospatial technical expertise
+        on development, maintenance, coordination, and dissemination of Spatial Data.
+        Applies strong conceptual and practical understanding of Geographic Information
+        System (GIS) application software development and spatial analysis, data automation
+        procedures, data standards and quality assurance procedures, in accordance
+        with enterprise best practices, and the requirements of the Geospatial Data
+        Act of 2018 (GDA). Leads in the collection, management of enterprise data
+        sets, and analysis of geospatial data in support of the federal portfolio
+        of facilities for strategic planning, monitoring, evaluation, and communication
+        efforts. Monitors new developments in geographic information management, reviews
+        new developments, and participates in the development of emerging policy guidance
+        to identify role of geospatial data services in the conduct of agency business.
+        Ensures technology applications in use and/or being proposed address both
+        current and future business requirements and recommends how to apply, extend,
+        enhance or optimize the existing IT systems, programs or services. Maintains
+        business relationship with vendors and acts as the liaison between stakeholders
+        to resolve issues of workmanship, quality, timely delivery and/or non-delivery,
+        and adherence to established schedules and quality."],"Education":"Note: If
+        you are using foreign education to meet qualification requirements, you must
+        send a Certificate of Foreign Equivalency with your transcript in order to
+        receive credit for that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nUndergo and pass a background investigation (Tier 2 investigation
+        level).\nHave your identity and work status eligibility verified if you are
+        not a GSA employee. We will use the Department of Homeland Security&rsquo;s
+        e-Verify system for this. Any discrepancies must be resolved as a condition
+        of continued employment.","Evaluations":"We will use a method called Category
+        Rating to assess your application. Here&rsquo;s how it will work:\nYou will
+        be scored on the questions you answer during the application process, which
+        will measure your possession of the following competencies or knowledge, skills,
+        and abilities: Knowledge of geospatial technology associated with Geographic
+        Information System (GIS) and web services.\nKnowledge of IT systems development
+        practices, governing laws, regulations, methodologies and/or policies to provide
+        sound and authoritative technical guidance on all issues related to the assigned
+        program.\nSkill in interrelationships of multiple IT specialties; new IT developments
+        and applications; emerging technologies and their applications to business
+        lines; IT security concepts, standards, and methods; and defining milestones
+        and deliverables, monitoring activities, and evaluating and reporting on accomplishment.\nSkill
+        in applying, advanced IT principles, concepts, methods, standards, and practices
+        sufficient to accomplish assignments such as: developing and interpreting
+        policies, procedures, and strategies governing the planning and delivery of
+        services; providing expert technical advice, guidance, and recommendations
+        to management and other technical specialists on critical IT issues; applying
+        new developments to previously unsolvable problems; and making decisions or
+        recommendations that significantly influence important IT policies or programs.\nAbility
+        to apply analytical skills to a wide range of qualitative and/or quantitative
+        methods for the assessment and improvement of program effectiveness.\nAbility
+        to manage projects, priorities and requirements with competing deadlines.
+        Your answers to the questions will be used to place you in one of three categories:
+        Best Qualified, Well Qualified, or Qualified.\nWe will verify your answers
+        to the questions in your resume. If your resume doesn&rsquo;t support your
+        answers, we may lower your score, which could place you in a lower category.\nWithin
+        each category, veterans will receive selection priority over non-veterans.
+        Additional assessments may be used, and, if so, you will be provided with
+        further instructions.If you are eligible under Interagency Career Transition
+        Assistance Plan or GSA&rsquo;s Career Transition Assistance Plan(ICTAP/CTAP),
+        you must receive a score of 85 or higher to receive priority. To preview questions
+        please click here.","HowToApply":"Submit a complete online application including
+        any required documents prior to 11:59 pm Eastern Time on the closing date
+        of the announcement. You can modify or complete your application any time
+        before the deadline. Simply return to USAJOBS, select the vacancy, and update
+        your application. For more detailed instructions on how to apply, click here:
+        Apply for a GSA Job.To begin, click the Apply Online button on the vacancy
+        announcement. Sign in or register on USAJobs and select a resume and documents
+        to include in your application.\nOnce you have clicked Apply for this position
+        now, you will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this job.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying?Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the announcement
+        closing.","WhatToExpectNext":"After the closing date/deadline: ELIGIBILITY/QUALIFICATIONS:
+        Your application will be reviewed for all requirements.\nREFERRAL TO MANAGEMENT:
+        If you meet all the requirements, you may be referred to management for review
+        and a possible interview. SELECTION/TENTATIVE JOB OFFER: If you are selected,
+        you will receive a tentative offer and start the suitability and/or security
+        background investigation process.\nFINAL JOB OFFER:Once our security office
+        determines you can come on board, you will be given a final offer, which is
+        typically 40 days after the announcement closes\nFINAL COMMUNICATION: Once
+        the position is filled, we will notify you of your status. You may also check
+        your application status by logging into USAJOBS and clicking &ldquo;Track
+        this Application&rdquo; on theApplicant Dashboard. Thank you for your interest
+        in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit.\nIf you are claiming veterans&rsquo;
+        preference:(a) Copy of your Certificate of Release or Discharge From Active
+        Duty, DD-214 that shows the dates of your active duty service. If selected,
+        a DD-214 showing your type of discharge (member 4 copy) will be required prior
+        to appointment.(b) If you are claiming 10-point preference or derived preference
+        (a spouse, widow or widower, or parent of a deceased or disabled veteran),
+        submit both of the following in addition to the DD-214:(1) completedSF-15form;
+        and(2) proof of your entitlement (refer to SF-15 for complete list).\nIf you
+        are active duty military - Certification on a letterhead from your military
+        branch that includes your rank, character of service (must be under honorable
+        conditions) &amp; military service dates including discharge/release date
+        (must be no later than 120 days after the date the certification is submitted).If
+        you are ICTAP/CTAPeligible - submit a, b, and c: (a) proof of eligibility
+        including agency notice; (b) SF-50, and (c) most recent performance appraisal.\nCurrent
+        or Former Political Appointees:Submit SF-50.","Benefits":"You will have access
+        to many benefits including: Health insurance (choose from a wide range of
+        plans)\nLife insurance coverage with several options\nSick leave and vacation
+        time, including 10 paid holidays per year\nThrift Savings Plan (similar to
+        a 401(k) plan)\nFlexible work schedules\nTransit and child care subsidies\nFlexible
+        spending accounts\nLong-term care insurance\nTraining and development","BenefitsUrl":"https://www.gsa.gov/about-us/careers-at-gsa/why-work-at-gsa/employee-benefits","OtherInformation":"Bargaining
+        Unit status: Covered based on duty location\nRelocation-related expenses arenotapproved
+        and will be your responsibility. Travelexpenses associated with interviewsmaybeapproved.Determinations
+        will be made on a case-by-case basis.\nOn a case-by-case basis, the following
+        incentives may be approved:\n&middot; Recruitment incentive if you are new
+        to the federal government\n&middot; Relocation incentive if you are a current
+        federal employee\n&middot; Credit toward vacation leave if you are new to
+        the federal government\nAdditional vacancies may be filled from this announcement
+        as needed; through other means; or not at all.","KeyRequirements":["US Citizenship
+        or National (Residents of American Samoa and Swains Island)","Meet all eligibility
+        requirements within 30 days of the closing date.","Register with Selective
+        Service if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"Michael.Lowery@gsa.gov","AgencyContactPhone":"202-227-5396","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"Moderate
+        Risk (MR)","AdjudicationType":["Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"601684400","MatchedObjectDescriptor":{"PositionID":"21PBSB367MMOTR","PositionTitle":"Electrical
+        Engineer","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/601684400","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/601684400?PostingChannelID="],"PositionLocationDisplay":"Boston,
+        Massachusetts","PositionLocation":[{"LocationName":"Boston, Massachusetts","CountryCode":"United
+        States","CountrySubDivisionCode":"Massachusetts","CityName":"Boston, Massachusetts","Longitude":-71.0567,"Latitude":42.358635}],"OrganizationName":"Office
+        of Communications and Marketing","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Electrical
+        Engineering","Code":"0850"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"The
+        initial length of the job is one year but may become permanent.","Code":"15326"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.The
+        GS-7salary range starts at $48,641per year. The GS-9 salary range starts at
+        $58,498\nIf you are a new federal employee, your starting salary will likely
+        be set at the Step 1 of the grade for which you are selected. BASIC REQUIREMENTS
+        FOR ENGINEERS: A Degree in professional engineering OR a combination of college-level
+        education, training, and/or technical experience. For specifics on qualifying
+        education and/or experience - use the following link: Basic Requirements for
+        Engineer Positions. To qualify for the GS-07 level:In addition to the Basic
+        Requirements listed above, you may qualify for the GS-07 level based on one
+        of the following: At least one year of specialized experience equivalent to
+        the GS-05 level in the Federal service.Specialized experience is is applying
+        professional electrical engineering principles, concepts, and practices to
+        perform routine assignments; the ability to determine the technical ramifications
+        resulting from changes in such things as item design or customer requirements;
+        and familiarity with related architectural and engineering disciplines.;OR\nOne
+        full year of graduate level education (18 semester hours or the equivalent)
+        that is directly related to the position;OR\nCompleted all the requirements
+        for a Bachelor''s degree from an accredited college or university, plus I
+        have a grade point average (GPA) of 3.0 or higher out of a possible 4.0 as
+        recorded in the official transcript or as computed based on 4 years of education,
+        or as computed based on courses completed during the final 2 years of the
+        curriculum (grade point averages are rounded to one decimal place;OR\nCompleted
+        all the requirements for a Bachelor''s degree from an accredited college or
+        university, plus I have a(GPA) of 3.5 based on the average of he required
+        courses completed in the major field or the required courses in the major
+        field completed during the final 2 years of the curriculum (grade point averages
+        are rounded to one decimal place;OR\nCompleted all the requirements for a
+        Bachelor''s degree from an accredited college or university, pluselection
+        to membership in a national scholastic honor society (listed in the Association
+        of College Honor Societies: Booklet of Information and/or Baird''s Manual
+        of American College Fraternities);OR\nCombination of graduate level education
+        and appropriate specialized experience that together meet the qualification
+        requirements of this position. To qualify for the GS-09 level: In addition
+        to the Basic Requirements listed above, you may qualify for the GS-09 level
+        based on one of the following: At least one year of specialized experience
+        equivalent to the GS-07 level in the Federal service. Specialized experience
+        is progressively responsible experience applying professional electrical engineering
+        principles, concepts, and practices in the design of construction or alteration
+        projects involving buildings or major building systems of moderate complexity;
+        or assisting in the coordination of the activities of architects, engineers,
+        tenants and construction contractors on such projects. Such experience must
+        also include having assisted in managing projects and/or portions of projects
+        (balance scope/quality, schedule and budget) requiring the services of multiple
+        disciplines from project initiation phase through project closeout.;OR\nTwoyears
+        of progressively higher level graduate education leading to a master''s degree,
+        or a master''s or equivalent graduate degreethat is directly related to the
+        position;OR\nCombination of graduate level education and appropriate specialized
+        experience that together meet the qualification requirements of this position.
+        This position has a positive education requirement: Applicants must submit
+        a copy of their college or university transcript(s) and certificates by the
+        closing date of announcements to verify qualifications. If selected, an official
+        transcript will be required prior to appointment.","PositionRemuneration":[{"MinimumRange":"48641.0","MaximumRange":"77346.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-18","PositionEndDate":"2021-06-01","PublicationStartDate":"2021-05-18","ApplicationCloseDate":"2021-06-01","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"Are
+        you a graduating student or a recent grad? Join our Pathways Recent Graduate
+        Program! This one-year program offers professional and technical training,
+        mentoring and developmental opportunities. Location of position: Public Buildings
+        Service, Design and Construction Division, Boston, MAWe are currently filling
+        one vacancy, but additional vacancies may be filled as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"07","HighGrade":"09","OrganizationCodes":"GS/GS32","Relocation":"False","HiringPath":["graduates","public"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104228","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104228&S=1","MajorDuties":["As
+        a GS-7Electrical Engineer, you will: With assistance as required, analyzes
+        the electrical engineering issues in project assignment(s), then selects and
+        applies accepted project management techniques and organizational practices\nApplies
+        basic project managerial and evaluative techniques to the identification,
+        consideration, and resolution of issues or problems of a procedural or factual
+        nature\nIdentifies and develops data required for use by higher level personnel
+        in the management and direction of projects.\nAssists with basic qualitative
+        and quantitative A/E analytical techniques to research and gather narrative
+        and/or statistical information, applicable work methods, and procedures to
+        meet deadlines\nUnder close supervision, serves as a point of contact for
+        the customer and has responsibility for providing customer service As a GS-9
+        Electrical Engineer you will: Participates with agency personnel who are responsible
+        for defining the goals of the projects and working with them to prepare a
+        Project Management Plan. Assists in preparing assigned portions of schedules
+        for complete projects and reports on project status.\nMonitors project reviews,
+        schedules, and work for completing project. Resolves limited problems or conflicts
+        impeding progress on completion of projects.\nAssists with pre-bidding conferences
+        with prospective bidders to inform them of contract provisions and relative
+        responsibilities of A/E&rsquo;s, developers, lessor, and/or the government.\nAssists
+        with performance review and assessment of design development documents, as
+        well as the preparation of documents for agency officials, client agencies,
+        and contract A/E firms.\nPrepares material and information for higher level
+        personnel who negotiate contract specifications and design changes with organizational
+        elements of the agency and contractors.\nOn projects of limited complexity,
+        serves as a point of contact for the customer, and has responsibility for
+        providing customer service."],"Education":"Note: If you are using foreign
+        education to meet qualification requirements, you must send a Certificate
+        of Foreign Equivalency with your transcript in order to receive credit for
+        that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nRegister with the Selective Service, if you are a male born after
+        12/31/1959.\nServe a one yeartrial period, if required.\nUndergo and pass
+        a background investigation (Tier 2 investigation level).\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nComplete
+        a financial disclosure report to verify that no conflict, or an appearance
+        of conflict, exists between your financial interest and this position.\nSigned
+        participant agreement is required for employment under this Program.","Evaluations":"We
+        will use a method called Category Rating to assess your application. Here&rsquo;s
+        how it will work: You will be scored on the questions you answer during the
+        application process, which will measure your possession of the following competencies
+        or knowledge, skills, and abilities: Knowledge of basic electrical engineering
+        principles, concepts, and methodology; and skill in applying this knowledge
+        in carrying out elementary assignments, operations, or procedures.\nKnowledge
+        of commonly used project management practices and procedures that specifically
+        pertain to electrical engineering work.\nAbility to obtain, compile, analyze
+        and summarize information and quantitative data.\nKnowledge of state of the
+        art electrical engineering related software/computer systems\nAbility to communicate
+        both orally and in writing Your answers to the questions will be used to place
+        you in one of three categories: Best Qualified, Well Qualified, or Qualified\nWe
+        will verify your answers to the questions in your resume. If your resume doesn&rsquo;t
+        support your answers, we may lower your score, which could place you in a
+        lower category.\nWithin each category, veterans will receive selection priority
+        over non-veterans. To preview questions please click here.","HowToApply":"Submit
+        a complete online application including any required documents prior to 11:59
+        pm Eastern Time on the closing date of the announcement. You can modify or
+        complete your application any time before the deadline. Simply return to USAJOBS,
+        select the vacancy, and update your application. For more detailed instructions
+        on how to apply, click here: Apply for a GSA Job.To begin, click the Apply
+        Online button on the vacancy announcement. Sign in or register on USAJobs
+        and select a resume and documents to include in your application.\nOnce you
+        have clicked Apply for this position now, you will be taken to the GSA site
+        to complete the application process.\nClick the Apply To This Vacancy and
+        complete all steps in the application process until the Confirmation indicates
+        your application is complete. If you click Return to USAJobs or get timed
+        out prior to receiving confirmation, your application will not be submitted
+        and cannot be considered for this job.\nNote: Review the REQUIRED DOCUMENTS
+        section of this announcement to determine which apply to you and must be submitted
+        online. You may choose one or more of the following options to submit your
+        document(s): Upload (from your computer); USAJOBS (click the \"USAJOBS\" link
+        to complete the transfer process) or FAX (read the &ldquo;Fax instructions&rdquo;
+        provided prior to printing the Fax Cover Sheet and faxing your information).
+        Need Assistance in Applying? Contact the HR representative listed on the announcement
+        prior to the application deadline. We are available to assist you Monday-Friday
+        during normal business hours. You must receive HR approval before deviating
+        from these instructions. Be sure to APPLY EARLY as most assessments must be
+        completed fully and submitted before the announcement closing.","WhatToExpectNext":"After
+        the closing date/deadline:ELIGIBILITY/QUALIFICATIONS: Your application will
+        be reviewed for all requirements. REFERRAL TO MANAGEMENT: If you meet all
+        the requirements, you may be referred to management for review and a possible
+        interview. SELECTION/TENTATIVE JOB OFFER: If you are selected, you will receive
+        a tentative offer and start the suitability and/or security background investigation
+        process.\nFINAL JOB OFFER:Once our security office determines you can come
+        on board, you will be given a final offer, which is typically 40 days after
+        the announcement closes\nFINAL COMMUNICATION: Once the position is filled,
+        we will notify you of your status. You may also check your application status
+        by logging into USAJOBS and clicking &ldquo;Track this Application&rdquo;
+        on theApplicant Dashboard. Thank you for your interest in working for U.S.
+        General Services Administration!","RequiredDocuments":"ALL required documents
+        must be submitted before the closing date. Review the following list to determine
+        what you need to submit. Current or Former Political Appointees: Submit SF-50.\nIf
+        you are claiming veterans preference: (a) Copy of your Certificate of Release
+        or Discharge From Active Duty, DD-214 that shows the dates of your active
+        duty service. If selected, a DD-214 showing your type of discharge (member
+        4 copy) will be required prior to appointment. (b) If you are claiming 10-point
+        preference, submit both of the following in addition to the DD-214: (1) completedSF-15form;
+        and (2) proof of your entitlement (refer to SF-15 for complete list).\nIf
+        you are active duty military- Certification on a letterhead from your military
+        branch that includes your rank, character of service (must be under honorable
+        conditions) &amp; military service dates including discharge/release date
+        (must be no later than 120 days after the date the certification is submitted).\nCollege
+        transcripts: Your transcripts must show a, b, and c:(a) Proof of recent graduate
+        status (within past 2 years or on track to graduate by June 30, 2021; or within
+        past 6 years if you were prevented from applying due to your military service)(b)
+        Name of your college or university(c) Date your degree was awardedIf you are
+        currently pursuing a graduate degree, but you are claiming Recent Graduate
+        eligibility based on a previous degree, you must also include those transcripts.\nIf
+        you completed your education outside of the U.S., see Foreign Education information
+        for guidance on what we can accept.\nIf selected, an official transcript will
+        be required prior to appointment.Superior Academic Achievement: Submit transcripts
+        as described above. If you qualify based on your class rank or honor society
+        membership, submit documentation of it.","Benefits":"You will have access
+        to many benefits including: Health insurance (choose from a wide range of
+        plans)\nLife insurance coverage with several options\nSick leave and vacation
+        time, including 10 paid holidays per year\nThrift Savings Plan (similar to
+        a 401(k) plan)\nFlexible work schedules\nTransit and child care subsidies\nFlexible
+        spending accounts\nLong-term care insurance\nTraining and development","OtherInformation":"Bargaining
+        Unit status: AFGE\nIf you are selected at a grade lower than the full performance
+        level, you may be promoted up to that grade level without having to re-apply
+        or compete against other applicants.\nRelocation-related expenses arenotapproved
+        and will be your responsibility.\nOn a case-by-case basis, the following incentives
+        may be approved: Credit toward vacation leave if you are new to the federal
+        government Additional vacancies may be filled from this announcement as needed;
+        through other means; or not at all.","KeyRequirements":["US Citizenship or
+        National (Residents of American Samoa and Swains Island)","Register with the
+        Selective Service if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"02","AnnouncementClosingType":"01","AgencyContactEmail":"maura.murphy@gsa.gov","AgencyContactPhone":"212-264-5557","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"Moderate
+        Risk (MR)","AdjudicationType":["Credentialing"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"601687000","MatchedObjectDescriptor":{"PositionID":"21PBSC408SLOTR","PositionTitle":"Fire
+        Protection Engineer","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/601687000","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/601687000?PostingChannelID="],"PositionLocationDisplay":"District
+        of Columbia, District of Columbia","PositionLocation":[{"LocationName":"District
+        of Columbia, District of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"District of Columbia, District of Columbia","Longitude":-77.03196,"Latitude":38.89037}],"OrganizationName":"Public
+        Buildings Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Fire
+        Protection Engineering","Code":"0804"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"The
+        initial length of the job is one year but may become permanent.","Code":"15326"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.\nFor a brief video on creating a Federal resume, clickhere.\nThe
+        GS-7salary range starts at $49,157 per year, and the GS-9 salary range starts
+        at $60,129 per year.\nIf you are a new federal employee, your starting salary
+        will likely be set at the Step 1 of the grade for which you are selected.
+        It is preferred that you have an undergraduate or graduate degree from a college
+        or university offering a course of study in fire protection engineering, fire
+        protection engineering technology, or fire safety engineering that is accredited
+        by the Accreditation Board for Engineering and Technology or a similar accreditation\nBASIC
+        REQUIREMENTS FOR ENGINEERS: A Degree in professional engineering OR a combination
+        of college-level education, training, and/or technical experience. For specifics
+        on qualifying education and/or experience - use the following link: Basic
+        Requirements for Engineer Positions. GS-7 Level:In addition to the Basic Requirements
+        listed above, you must have one year of specialized experience equivalent
+        to the GS-05 in the Federal service. Specialized experience isapplying professional
+        fire protection engineering principles, concepts, and practices to perform
+        routine assignments; the ability to determine the technical ramifications
+        resulting from changes in such things as item design or customer requirements;
+        and familiarity with related architectural and engineering disciplines. ORSuperior
+        Academic Achievement (SAA) at the baccalaureate level is fully qualifying
+        at the GS-7 level. To claim SAA, submit documentation of one of the following:
+        Class standing -- You must be in the upper third of your graduating class
+        in the college, university, or major subdivision, such as the College of Liberal
+        Arts or the School of Business Administration, based on completed courses.\nGrade-point
+        average (rounded to one decimal point) of: **3.0 or higher out of a possible
+        4.0 (\"B\" or better)as recorded on your official transcript, or as computed
+        based on 4 years of education, or as computed based on courses completed during
+        the final 2 years of your curriculum; or\n**3.5 or higher out of a possible
+        4.0 (\"B+\" or better)based on the average of the required courses completed
+        in your major field or the required courses in your major field completed
+        during your final 2 years of the curriculum.\n3. Election to membership in
+        a national scholastic honor society in one of the national scholastic honor
+        societies listed by the Association of College Honor SocietiesORA combination
+        of graduate level education and appropriate specialized experience that together
+        meet the qualification requirements of this position.\nGS-9 Level:In addition
+        to the Basic Requirements listed above, you must have one year of specialized
+        experience equivalent to the GS-07 in the Federal service. Specialized experience
+        isprogressively responsible experience applying professional fire protection
+        engineering principles, concepts, and practices in the design of construction
+        or alteration projects involving buildings or major building systems of moderate
+        complexity; or assisting in the coordination of the activities of architects,
+        engineers, tenants and construction contractors on such projects. Such experience
+        must also include having assisted in managing projects and/or portions of
+        projects (balance scope/quality, schedule and budget) requiring the services
+        of multiple disciplines from project initiation phase through project closeout.ORTwo
+        years of progressively higher level graduate education leading to a master''s
+        degree, or a master''s or equivalent graduate degree that is directly related
+        to the position.ORA combination of graduate level education and appropriate
+        experience that together meet the qualification requirements of this position.\nQuality
+        Ranking Factors (QRFs) : QRFs are knowledge, skills, and abilities that could
+        be expected to significantly enhance performance in a position, but are not
+        essential for satisfactory performance. Applicants who possess such KSA''s
+        may be ranked above those who do not, but no one may be rated ineligible solely
+        for failure to possess such KSA''s . The Quality Ranking Factor for this position
+        isCertification as a \"qualified fire protection engineer\" required promotion
+        to the full performance GS 12 grade level. The incumbent must hold and retain
+        certification as a \"qualified fire protection engineer\", to include either:
+        1) An engineer having an undergraduate or graduate degree from a college or
+        university offering a course of study in fire protection engineering, fire
+        protection engineering technology, or fire safety engineering that is accredited
+        by the Accreditation Board for Engineering and Technology or a similar accreditation;
+        2) A licensed engineer (P.E.) who has passed the principles and practice of
+        engineering examination in fire protection administered by the National Council
+        of Examiners for Engineering and Surveying (NCEES); or 3) A professional engineer
+        (P.E. or similar designation) licensed in a related engineering discipline,
+        plus a minimum of 4 years work experience in fire protection engineering having
+        an understanding of the principles of physics and chemistry governing fire
+        growth, spread, and suppression.","PositionRemuneration":[{"MinimumRange":"49157.0","MaximumRange":"78167.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-17","PositionEndDate":"2021-06-07","PublicationStartDate":"2021-05-17","ApplicationCloseDate":"2021-06-07","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"Are
+        you a graduating student or a recent grad? Join our Pathways Recent Graduate
+        Program! This one-year program offers professional and technical training,
+        mentoring and developmental opportunities.\nLocation of position:Public Buildings
+        Service1800 F Street, Washington, DC 20006 We are currently filling one vacancy,
+        but additional vacancies may be filled as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"07","HighGrade":"09","OrganizationCodes":"GS/GS03","Relocation":"False","HiringPath":["graduates"],"TotalOpenings":"FEW","AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104287","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104287&S=1","MajorDuties":["Under
+        the guidance of an experienced Fire Protection Engineer, applies numerous
+        fire protection codes, standards, and building codes to GSA owned and leased
+        facilities.","Maintains close liaison with government and private engineers
+        and architects, research organizations, industry and technical code and standard
+        organizations to keep abreast of the latest developments.","Assists an experienced
+        Fire Protection Engineer in the development of risk assessments of government
+        owned and leased buildings in accordance with the Federal Fire Safety Act.","Reviews
+        drawings and specifications for building construction and renovation projects
+        and most space layouts to ensure compliance with GSA standards for fire protection,
+        exiting arrangements, and other safety features.","Under the mentorship of
+        an experienced Fire Protection Engineer, learns the realm of fire protection
+        engineering aspects including fire, smoke, life safety, and egress as related
+        to owned and leased buildings.","Coordinates with Project Managers in the
+        Design and Construction Division to ensure consistency of practices.","Identifies
+        fire hazards and their risks, the cost of protection, and fire safety design.","Under
+        the guidance of an experienced Fire Protection Engineer, conducts fire safety
+        surveys of GSA owned and leased buildings and conducts pre-lease and pre-lease
+        renewal surveys."],"Education":"Note: If you are using foreign education to
+        meet qualification requirements, you must send a Certificate of Foreign Equivalency
+        with your transcript in order to receive credit for that education. For further
+        information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nRegister with the Selective Service, if you are a male born after
+        12/31/1959.\nServe a one year trial period, if required.\nUndergo and pass
+        a background investigation (Tier 1 investigation level).\nHave your identity
+        and work status eligibility verified if you are not a GSA employee. We will
+        use the Department of Homeland Security&rsquo;s e-Verify system for this.
+        Any discrepancies must be resolved as a condition of continued employment.\nSigned
+        participant agreement is required for employment under this Program","Evaluations":"We
+        will use a method called Category Rating to assess your application. Here&rsquo;s
+        how it will work:\nYou will be scored on the questions you answer during the
+        application process, which will measure your possession of the following competencies
+        or knowledge, skills, and abilities: Knowledge of accepted practices for fire
+        protection engineering sufficient to provide developmental support and assistance
+        in planning, making recommendations and providing advice relative to the regional
+        Fire Protection Engineering Program.\nKnowledge and understanding of the codes
+        and standards of the National Fire Protection Association and National Model
+        Building Codes sufficient to locate applicable criteria and apply those criteria
+        to specific situations.\nKnowledge of commonly used project management practices
+        and procedures that specifically pertain to fire protection engineering work.\nAbility
+        to read and understand engineering drawings sufficient to review, suggest
+        edits and modifications for engineering specifications for the construction
+        of fire protection systems.\nKnowledge of basic fire protection engineering
+        principles, concepts, and methodology; and skill in applying this knowledge
+        in carrying out elementary assignments, operations, or procedures. Your answers
+        to the questions will be used to place you in one of three categories: Best
+        Qualified, Well Qualified, or Qualified.\nWe will verify your answers to the
+        questions in your resume. If your resume doesn&rsquo;t support your answers,
+        we may lower your score, which could place you in a lower category.\nWithin
+        each category, veterans will receive selection priority over non-veterans.
+        To preview questions please click here.","HowToApply":"Submit a complete online
+        application including any required documents prior to 11:59 pm Eastern Time
+        on the closing date of the announcement. You can modify or complete your application
+        any time before the deadline. Simply return to USAJOBS, select the vacancy,
+        and update your application. For more detailed instructions on how to apply,
+        click here: Apply for a GSA Job.\nTo begin, click the Apply Online button
+        on the vacancy announcement. Sign in or register on USAJobs and select a resume
+        and documents to include in your application.\nOnce you have clicked Apply
+        for this position now, you will be taken to the GSA site to complete the application
+        process.\nClick the Apply To This Vacancy and complete all steps in the application
+        process until the Confirmation indicates your application is complete. If
+        you click Return to USAJobs or get timed out prior to receiving confirmation,
+        your application will not be submitted and cannot be considered for this job.\nNote:
+        Review the REQUIRED DOCUMENTS section of this announcement to determine which
+        apply to you and must be submitted online. You may choose one or more of the
+        following options to submit your document(s): Upload (from your computer);
+        USAJOBS (click the \"USAJOBS\" link to complete the transfer process) or FAX
+        (read the &ldquo;Fax instructions&rdquo; provided prior to printing the Fax
+        Cover Sheet and faxing your information). Need Assistance in Applying? Contact
+        the HR representative listed on the announcement prior to the application
+        deadline. We are available to assist you Monday-Friday during normal business
+        hours. You must receive HR approval before deviating from these instructions.
+        Be sure to APPLY EARLY as most assessments must be completed fully and submitted
+        before the announcement closing.","WhatToExpectNext":"After the closing date/deadline:
+        ELIGIBILITY/QUALIFICATIONS: Your application will be reviewed for all requirements.\nREFERRAL
+        TO MANAGEMENT: If you meet all the requirements, you may be referred to management
+        for review and a possible interview. SELECTION/TENTATIVE JOB OFFER: If you
+        are selected, you will receive a tentative offer and start the suitability
+        and/or security background investigation process.\nFINAL JOB OFFER: Once our
+        security office determines you can come on board, you will be given a final
+        offer, which is typically 40 days after the announcement closes.\nFINAL COMMUNICATION:
+        Once the position is filled, we will notify you of your status. You may also
+        check your status by logging into USAJOBS. Go to My USAJOBS and then to Applications.
+        Thank you for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are claiming veterans preference:
+        (a) Copy of your Certificate of Release or Discharge From Active Duty, DD-214
+        that shows the dates of your active duty service. If selected, a DD-214 showing
+        your type of discharge (member 4 copy) will be required prior to appointment.
+        (b) If you are claiming 10-point preference, submit both of the following
+        in addition to the DD-214: (1) completedSF-15form; and (2) proof of your entitlement
+        (refer to SF-15 for complete list). If you are active duty military- Certification
+        on a letterhead from your military branch that includes your rank, character
+        of service (must be under honorable conditions) &amp; military service dates
+        including discharge/release date (must be no later than 120 days after the
+        date the certification is submitted). College transcripts: Your transcripts
+        must show a, b, and c:\n(a) Proof of recent graduate status (within past 2
+        years or on track to graduate within 30 days of the closing date; or within
+        past 6 years if you were prevented from applying due to your military service)\n(b)
+        Name of your college or university\n(c) Date your degree was awarded\nIf you
+        are currently pursuing a graduate degree, but you are claiming Recent Graduate
+        eligibility based on a previous degree, you must also include those transcripts.\nIf
+        you completed your education outside of the U.S., see Foreign Education information
+        for guidance on what we can accept.\nIf selected, an official transcript will
+        be required prior to appointment.\nSuperior Academic Achievement: Submit transcripts
+        as described above. If you qualify based on your class rank or honor society
+        membership, submit documentation of it.","Benefits":"You will have access
+        to many benefits including: Health insurance (choose from a wide range of
+        plans)\nLife insurance coverage with several options\nSick leave and vacation
+        time, including 10 paid holidays per year\nThrift Savings Plan (similar to
+        a 401(k) plan)\nFlexible work schedules\nTransit and child care subsidies\nFlexible
+        spending accounts\nLong-term care insurance\nTraining and development","OtherInformation":"Bargaining
+        Unit status: Not included in a bargaining unit If you are selected at a grade
+        lower than the full performance level, you may be promoted up to that grade
+        level without having to re-apply or compete against other applicants.\nRelocation-related
+        expenses arenotapproved and will be your responsibility. Travelexpenses associated
+        with interviewsmaybeapproved.Determinations will be made on a case-by-case
+        basis.\nOn a case-by-case basis, the following incentives may be approved:
+        Recruitment incentive if you are new to the federal government\nRelocation
+        incentive if you are a current federal employee\nCredit toward vacation leave
+        if you are new to the federal government Additional vacancies may be filled
+        from this announcement as needed; through other means; or not at all.","KeyRequirements":[],"WithinArea":"False","CommuteDistance":"0","ServiceType":"02","AnnouncementClosingType":"01","AgencyContactEmail":"pbscvacancyinquiries@gsa.gov","AgencyContactPhone":"000-000-0000","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"Non-sensitive
+        (NS)/Low Risk","AdjudicationType":["Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"601722900","MatchedObjectDescriptor":{"PositionID":"21STFA148LHMP","PositionTitle":"Human
+        Resources Specialist (Executive Resources)","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/601722900","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/601722900?PostingChannelID="],"PositionLocationDisplay":"Washington,
+        District of Columbia","PositionLocation":[{"LocationName":"Washington, District
+        of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904}],"OrganizationName":"Office
+        of Human Resources Management","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Human
+        Resources Management","Code":"0201"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.The
+        GS-14 salary range starts at $122,530per year.\nIf you are a new federal employee,
+        your starting salary will likely be set at the Step 1 of the grade for which
+        you are selected.\nSPECIALIZED EXPERIENCE:\nTo qualify, you must have at least
+        one year of specialized experience equivalent to the GS-13 level or higher
+        in the Federal service. Specialized experience includes performing the following:
+        identifying and proposing solutions to Senior/Executive level HR problems
+        and issues or developing new or modified HR procedures; and applying Human
+        Resources (HR) regulations, laws and procedures in association with recruitment,
+        selection, position management, compensation, authorization of HR personnel
+        actions, classification and special projects.","PositionRemuneration":[{"MinimumRange":"122530.0","MaximumRange":"159286.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-17","PositionEndDate":"2021-06-01","PublicationStartDate":"2021-05-17","ApplicationCloseDate":"2021-06-01","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"As
+        a Human Resources Specialist, you willbe responsible for all policy development,
+        operation employment activities that involve senior executives, Schedule C
+        experts and consultants. Location of position: General Services Administration,
+        Office of Human Resources Management, Washington, D.C.\nWe are currently filling
+        one vacancy, but additional vacancies may be filled through this announcement
+        in this or other GSA organizations within the same commuting area.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"14","HighGrade":"14","OrganizationCodes":"GS/GS14","Relocation":"False","HiringPath":["disability","fed-competitive","fed-transition","land","mspouse","overseas","peace","special-authorities","vet"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104315","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104315&S=1","MajorDuties":["As
+        a Human Resources Specialist, you will perform the following duties:\nAdvises
+        and consults with the Chief Human Capital Officer on the status of employment
+        activities and keeps him/her informed of significant developments. Consults
+        with staff members, the Office of Personnel, and with management officials
+        of all levels to assure that his/her activities are coordinated and integrated
+        with other personnel and management programs. Gives advice to senior specialists
+        and technicians in carrying out specific projects or assignments involving
+        employment of senior executives, Schedule C experts and consultants. Deals
+        with high-ranking officials of the agency, Office of Personnel Management
+        (OPM) and other Federal agencies to exchange information and resolve problems.
+        Handles a variety of complex and sensitive cases including senior executives,
+        Schedule C experts and consultants. Prepares executive recruitment packages
+        senior executive position descriptions, evaluation statements and other supporting
+        documentation. Specific cases involve key positions throughout and often have
+        confidential or sensitive aspects. As such, they require special handling
+        and an overall appreciation programs and functions of the Agency for prompt,
+        effective and accurate completion. Renders technical personnel advice and
+        assistance, both written and oral, to line management. Contacts include management
+        officials of the Agency. In these contacts, the incumbent represents the Office
+        of the Chief Human Capital Officer and must often make spontaneous decisions
+        or commitments for which the Chief Human Capital Officer will be held responsible.
+        Conducts a variety of work projects on staff matters contributing to overall
+        program objectives. Such projects include fact-gathering; analysis and evaluation
+        of material; written or oral presentation of conclusions both within and outside
+        of the Chief Human Capital Officer; and usually, preparation of formal reports,
+        issuance or other documents. Examples of specific projects include: identification
+        of criteria for filling executive positions; position classification; organizational
+        structure; job analysis and evaluation of the effectiveness of programs, their
+        sub-parts. Responsible for policy development, which includes developing,
+        implementing, coordinating and evaluating policies, practices, systems, procedures,
+        and regulations governing the GSA program for SES, Schedule C experts and
+        consultants. Continuously evaluates the operation policies and programs to
+        ensure their regulatory compliance, their adherence to GSA policy intent,
+        and their agreement with GSA''s needs; and make changes as necessary. Study
+        proposed legislation and regulations and determine effect/impact on assigned
+        programs in order to develop agency position."],"Education":"","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nServe a one year probationary period, if required.\nUndergo and pass
+        a background investigation (Tier 2 investigation level).","Evaluations":"You
+        will be evaluated on the questions you answer during the application process,
+        which will measure your overall possession of the following competencies or
+        knowledge, skills, and abilities. Your responses to these questions must be
+        supported by your resume or your score may be lowered. Skill in oral and written
+        communications to pre-pare, present, and explain, complex and/or highly technical
+        information.\nSkill in applying knowledge of directives, procedures, regulations,
+        and statues governing Human Capital operations and functions.\nAbility to
+        analyze and research matters needed to identify causes of problems, isolate
+        important factors, gather information bearing on questions, and devise improvements
+        and solutions.\nAbility to deal effectively with all levels of GSA management
+        on matters, which may be controversial, complex and sensitive. Additional
+        assessments may be used, and, if so, you will be provided with further instructions.
+        If you are eligible under Interagency Career Transition Assistance Plan or
+        GSA&rsquo;s Career Transition Assistance Plan(ICTAP/CTAP), you must receive
+        a score of 85 or higher to receive priority. To preview questions please click
+        here.","HowToApply":"Submit a complete online application including any required
+        documents prior to 11:59 pm Eastern Time on the closing date of the announcement.
+        You can modify or complete your application any time before the deadline.
+        Simply return to USAJOBS, select the vacancy, and update your application.
+        For more detailed instructions on how to apply, click here: Apply for a GSA
+        Job.To begin, click the Apply Online button on the vacancy announcement. Sign
+        in or register on USAJobs and select a resume and documents to include in
+        your application.\nOnce you have clicked Apply for this position now, you
+        will be taken to the GSA site to complete the application process.\nClick
+        the Apply To This Vacancy and complete all steps in the application process
+        until the Confirmation indicates your application is complete. If you click
+        Return to USAJobs or get timed out prior to receiving confirmation, your application
+        will not be submitted and cannot be considered for this job.\nNote: Review
+        the REQUIRED DOCUMENTS section of this announcement to determine which apply
+        to you and must be submitted online. You may choose one or more of the following
+        options to submit your document(s): Upload (from your computer); USAJOBS (click
+        the \"USAJOBS\" link to complete the transfer process) or FAX (read the &ldquo;Fax
+        instructions&rdquo; provided prior to printing the Fax Cover Sheet and faxing
+        your information). Need Assistance in Applying?Contact the HR representative
+        listed on the announcement prior to the application deadline. We are available
+        to assist you Monday-Friday during normal business hours. You must receive
+        HR approval before deviating from these instructions. Be sure to APPLY EARLY
+        as most assessments must be completed fully and submitted before the announcement
+        closing.","WhatToExpectNext":"After the closing date/deadline: ELIGIBILITY/QUALIFICATIONS:
+        Your application will be reviewed for all requirements.\nREFERRAL TO MANAGEMENT:
+        If you meet all the requirements, you may be referred to management for review
+        and a possible interview. SELECTION/TENTATIVE JOB OFFER: If you are selected,
+        you will receive a tentative offer and start the suitability and/or security
+        background investigation process.\nFINAL JOB OFFER:Once our security office
+        determines you can come on board, you will be given a final offer, which is
+        typically 40 days after the announcement closes.\nFINAL COMMUNICATION: Once
+        the position is filled, we will notify you of your status. You may also check
+        your application status by logging into USAJOBS and clicking &ldquo;Track
+        this Application&rdquo; on theApplicant Dashboard. Thank you for your interest
+        in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit.Note: If required to submit an SF-50
+        (Notice of Personnel Action), an equivalent agency Notice of Personnel Action
+        form is acceptable. Such document(s) must show all of the following: effective
+        date, position, title, series, grade, and rate of basic pay, tenure group
+        1 (career) or 2 (career-conditional), position occupied group, and name of
+        agency. If you are a GSA employee (except in the OIG), you are not required
+        to submit an SF-50. If you are a 30% or more disabled veteran, VEOA or VRA
+        applicant or qualified spouse, widow/widower, or parent:(a) Copy of your Certificate
+        of Release or Discharge From Active Duty, DD-214 that shows the dates of your
+        active duty service. If selected, a DD-214 showing your type of discharge
+        (member 4 copy) will be required prior to appointment.(b) If you are a disabled
+        veteran, or are applying under VRA or VEOA as a spouse, widow/widower, or
+        parent of a veteran, submit both of the following in addition to the DD-214:
+        (1) completed SF-15 form; and (2) proof of your entitlement (refer to SF-15
+        for complete list).\nIf you are active duty military- Certification on a letterhead
+        from your military branch that includes your rank, character of service (must
+        be under honorable conditions) &amp; military service dates including discharge/release
+        date (must be no later than 120 days after the date the certification is submitted).If
+        you are a current Federal employee or Reinstatement Eligible: Submit your
+        latest SF-50.If you are eligible under an Interchange Agreement: Submit your
+        latest SF-50.If you are a former Peace Corp or VISTA volunteer: Submit your
+        Description of Service.\nIf you are a current or former Land Management Agency
+        Employee - Submit a and b: (a) one or more SF-50s, including your most recent
+        one that shows you were on a competitive time-limited appointment(s) with
+        a Land Management Agencyand served on the appointment for a period(s) totaling
+        more than 24 months without a break of 2 or more years. (b) Copy of your agency&rsquo;s
+        annual performance appraisal(s) or written reference(s) from a supervisor
+        at the agency verifying satisfactory performance during your appointment(s).\nIf
+        you have a disability: Submit proof of eligibility. For information on eligibility
+        and required documentation, refer to USAJOBS&rsquo;s People With Disabilities
+        page.If you are applying under another special appointment authority: Submit
+        proof of your eligibility under the appropriate appointment authority. See
+        USAJOBS''s Resource Center for more information.If you areICTAP/CTAP eligible
+        - submit a, b, and c: (a) proof of eligibility including agency notice; (b)
+        SF-50, and (c) most recent performance appraisal.\nIf you are a current or
+        former political appointee: Submit your SF-50.","Benefits":"","BenefitsUrl":"https://www.gsa.gov/about-us/careers-at-gsa/why-work-at-gsa/employee-benefits","OtherInformation":"Bargaining
+        Unit status: Not Applicable\nSelected applicants may qualify for credit toward
+        annual leave accrual based on prior non-Federal work experience or uniformed
+        service experience.","KeyRequirements":["US Citizenship or National (Residents
+        of American Samoa and Swains Island)","Meet all eligibility criteria within
+        30 days of the closing date","Meet time-in-grade within 30 days of the closing
+        date, if applicable","Register with Selective Service if you are a male born
+        after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"Lauren.Hayes@GSA.Gov","AgencyContactPhone":"202-969-5585","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"Moderate
+        Risk (MR)","AdjudicationType":["Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"601747500","MatchedObjectDescriptor":{"PositionID":"21PBSB409MMOTR","PositionTitle":"Interdisciplinary","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/601747500","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/601747500?PostingChannelID="],"PositionLocationDisplay":"Multiple
+        Locations","PositionLocation":[{"LocationName":"Newark, New Jersey","CountryCode":"United
+        States","CountrySubDivisionCode":"New Jersey","CityName":"Newark, New Jersey","Longitude":-74.17419,"Latitude":40.73197},{"LocationName":"Kings
+        County, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"Kings County, New York","Longitude":-73.98988,"Latitude":40.692387},{"LocationName":"New
+        York, New York","CountryCode":"United States","CountrySubDivisionCode":"New
+        York","CityName":"New York, New York","Longitude":-74.0071,"Latitude":40.7146}],"OrganizationName":"Public
+        Buildings Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"General
+        Engineering","Code":"0801"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"The
+        initial length of the job is one year but may become permanent.","Code":"15326"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.The
+        GS-07salary range starts at $50,476per year and the GS-09 salary range starts
+        at $61,742 per year.\nIf you are a new federal employee, your starting salary
+        will likely be set at the Step 1 of the grade for which you are selected.\nThis
+        position is interdisciplinary, which means the duties and responsibilities
+        closely relate to more than one professional occupation. This position may
+        be filled in one of the following occupations: Architect, GS-0808;Civil Engineer,
+        GS-0810; Mechanical Engineer GS-0830; Electrical Engineer, GS-0850; General
+        Engineer, GS-0801; Fire Protection, GS-0804. This position has a positive
+        education requirement: Applicants must submit a copy of their college or university
+        transcript(s) and certificates by the closing date of announcements to verify
+        qualifications. If selected, an official transcript will be required prior
+        to appointment.BASIC REQUIREMENTS FOR ENGINEERS: A Degree in professional
+        engineering OR a combination of college-level education, training, and/or
+        technical experience. For specifics on qualifying education and/or experience
+        - use the following link: Basic Requirements for Engineer Positions. BASIC
+        REQUIREMENTS FOR ARCHITECTS: A Degree in architecture or related field; OR
+        a combination of college-level education, training, and/or technical experience.
+        For specifics on qualifying education, training, and/or experience - use the
+        following link: Basic Requirements for Architect Positions.\nTo qualify for
+        the GS-07 level:In addition to the Basic Requirements listed above, you may
+        qualify for the GS-07 level based on one of the following: Registered to practice
+        architecture by one of the State registration boards, using standards in compliance
+        with the basic minimum provisions recommended by the National Council of Architectural
+        Registration Boards;OR\nAt least one year of specialized experience equivalent
+        to the GS-05 level in the Federal service.Specialized experience is applying
+        professional architecture or engineering principles, concepts, and practices
+        to perform routine assignments; the ability to determine the technical ramifications
+        resulting from changes in such things as item design or customer requirements;
+        and familiarity with related architectural and engineering disciplines. ;OR\nOne
+        full year of graduate level education (18 semester hours or the equivalent)
+        that is directly related to the position;OR\nCompleted all the requirements
+        for a Bachelor''s degree from an accredited college or university, plus I
+        have a grade point average (GPA) of 3.0 or higher out of a possible 4.0 as
+        recorded in the official transcript or as computed based on 4 years of education,
+        or as computed based on courses completed during the final 2 years of the
+        curriculum (grade point averages are rounded to one decimal place;OR\nCompleted
+        all the requirements for a Bachelor''s degree from an accredited college or
+        university, plus I have a(GPA) of 3.5 based on the average of he required
+        courses completed in the major field or the required courses in the major
+        field completed during the final 2 years of the curriculum (grade point averages
+        are rounded to one decimal place;OR\nCompleted all the requirements for a
+        Bachelor''s degree from an accredited college or university, pluselection
+        to membership in a national scholastic honor society (listed in the Association
+        of College Honor Societies: Booklet of Information and/or Baird''s Manual
+        of American College Fraternities);OR\nCombination of graduate level education
+        and appropriate specialized experience that together meet the qualification
+        requirements of this position. To qualify for the GS-09 level:In addition
+        to the Basic Requirements listed above, you may qualify for the GS-09 level
+        based on one of the following: Registered to practice architecture by one
+        of the State registration boards, using standards in compliance with the basic
+        minimum provisions recommended by the National Council of Architectural Registration
+        Boards;OR\nAt least one year of specialized experience equivalent to the GS-07
+        level in the Federal service. Specialized experience is progressively responsible
+        experience in the design of construction or alteration projects involving
+        buildings or major building systems of moderate complexity; or assisting in
+        the coordination of the activities of architects, engineers, tenants and construction
+        contractors on such projects. Such experience must also include having assisted
+        in managing projects and/or portions of projects (balance scope/quality, schedule
+        and budget) requiring the services of multiple disciplines from project initiation
+        phase through project closeout;OR\nTwoyears of progressively higher level
+        graduate education leading to a master''s degree, or a master''s or equivalent
+        graduate degreethat is directly related to the position;OR Combination of
+        graduate level education and appropriate specialized experience that together
+        meet the qualification requirements of this position. Superior Academic Achievement
+        (SAA) at the baccalaureate level is fully qualifying at the GS-7 level. To
+        claim SAA, submit documentation of one of the following:1. Class standing
+        -- You must be in the upper third of your graduating class in the college,
+        university, or major subdivision, such as the College of Liberal Arts or the
+        School of Business Administration, based on completed courses.2. Grade-point
+        average (rounded to one decimal point) of: 3.0 or higher out of a possible
+        4.0 (\"B\" or better) as recorded on your official transcript, or as computed
+        based on 4 years of education, or as computed based on courses completed during
+        the final 2 years of your curriculum; or\n3.5 or higher out of a possible
+        4.0 (\"B+\" or better) based on the average of the required courses completed
+        in your major field or the required courses in your major field completed
+        during your final 2 years of the curriculum. 3. Election to membership in
+        a national scholastic honor society in one of the national scholastic honor
+        societies listed by theAssociation of College Honor Societies.","PositionRemuneration":[{"MinimumRange":"50476.0","MaximumRange":"80263.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-18","PositionEndDate":"2021-06-01","PublicationStartDate":"2021-05-18","ApplicationCloseDate":"2021-06-01","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"Are
+        you a graduating student or a recent grad? Join our Pathways Recent Graduate
+        Program! This one-year program offers professional and technical training,
+        mentoring and developmental opportunities. Location of position:Public Buildings
+        Service, Design &amp; Construction Division, New York, NY, or Newark, NJ or
+        Kings County (Brooklyn) NYWe are currently filling two vacancies, but additional
+        vacancies may be filled as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"07","HighGrade":"09","OrganizationCodes":"GS/GS03","Relocation":"False","HiringPath":["graduates"],"AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104311","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104311&S=1","MajorDuties":["This
+        position isbeing announced under the Pathways Recent Graduates Program. This
+        program affords developmental experiences in the Federal Government intended
+        to promote possible careers in the civil service to individuals who have recently
+        graduated from qualifying educational institutions or programs. Successful
+        applicants are placed in a dynamic, developmental program with the potential
+        to lead to a civil service career in the Federal Government.Information about
+        the Recent Graduates Program can be found athttp://www.opm.gov/HiringReform/Pathways/program/graduates/\nAs
+        an architector engineer,you will be responsible for assisting in the overall
+        architectural/engineering (A/E) project management of various leasing, design
+        and construction projects assigned, including, but not limited to, planning,
+        acquisition, design, and construction of new buildings and complexes, as well
+        as the renovation of existing ones. Examples of duties include: Assisting
+        withanalyzing the A/E issues in project assignment(s),selecting and applying
+        accepted project management techniques and organizational practices.\nDetermining
+        the most effective methodology needed to meet project goals and milestones
+        concerned with planning, organizing, controlling, coordinating, reviewing,
+        and recommending or approving design, construction, and related work.\nAssisting
+        with basic qualitative and quantitative A/E analytical techniques toresearch
+        and gather narrative and/or statistical information, applicable work methods,
+        and procedures to meet deadlines. Carrying out the successive steps in fact
+        finding and analysis of issues necessary to complete each phase of the project.\nApplying
+        basic project managerial and evaluative techniques to the identification,
+        consideration, and resolution of issues or problems of a procedural or factual
+        nature.\nIdentifying and developing data required for use by higher level
+        personnel in the management and direction of projects.\nAssisting higher level
+        personnel in preparing briefings to management and/or senior staff employee(s)d
+        on project status and recommendations.\nUnder close supervision, serving as
+        a point of contact for the customer and has responsibility for providing customer
+        service."],"Education":"Note: If you are using foreign education to meet qualification
+        requirements, you must send a Certificate of Foreign Equivalency with your
+        transcript in order to receive credit for that education. For further information,
+        visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html\nYou
+        must provide a copy of ALL of your college/vocational/technical transcript(s),
+        including current enrollment if applicable.See \"Required Documents\" section
+        for additional information.\nPreference eligible veterans precluded from applying
+        due to military service obligation may apply up to 2 years from the date of
+        discharge/release from active duty, but no more than 6 years after the date
+        educational requirements are met. Applicants may refer to the U.S. Department
+        of Education''s Institutional Accreditation System to determine whether their
+        school/program is accredited:http://ope.ed.gov/accreditation/Search.aspx.A
+        post-secondary certificate program must have been completed at a qualifying
+        educational institution equivalent to at least 1 academic year of full-time
+        study that is part of an accredited college-level, technical, trade, vocational,
+        or business school curriculum.Education completed outside of the United States
+        must be deemed equivalent to that gained in conventional/accredited U.S. education
+        programs to be acceptable for Federal employment. See OPM''sGeneral Policiesfor
+        information on crediting education.","Requirements":"If selected, you must
+        meet the following conditions: Receive authorization from OPM on any job offer
+        you receive, if you are or were (within the last 5 years) a political Schedule
+        A, Schedule C or Non-Career SES employee in the Executive Branch.\nRegister
+        with the Selective Service, if you are a male born after 12/31/1959.\nServe
+        a one yeartrial period, if required.\nUndergo and pass a background investigation
+        (Tier 2 investigation level).\nHave your identity and work status eligibility
+        verified if you are not a GSA employee. We will use the Department of Homeland
+        Security&rsquo;s e-Verify system for this. Any discrepancies must be resolved
+        as a condition of continued employment.\nSigned participant agreement is required
+        for employment under this Program.","Evaluations":"We will use a method called
+        Category Rating to assess your application. Here&rsquo;s how it will work:
+        You will be scored on the questions you answer during the application process,
+        which will measure your possession of the following competencies or knowledge,
+        skills, and abilities: Knowledge of basic Architecture or Engineering principles,
+        concepts, and methodology; and skill in applying this knowledge in carrying
+        out elementary assignments, operations, or procedures.\nKnowledge of commonly
+        used project management practices and procedures that specifically pertain
+        to A/E work.\nAbility to obtain, compile, analyze and summarize information
+        and quantitative data.\nKnowledge of state of the art A/E related software/computer
+        systems.\nAbility to manage projects, priorities and requirements.\nKnowledge
+        of procurement principles and procedures and of different types of contracts.\nKnowledge
+        of established assessment and evaluative techniques and methodologies including
+        cost/benefit analysis, acquisition planning, risk management, knowledge management,
+        and forecasting.\nKnowledge and understanding of the Federal funding process
+        and budget process.\nKnowledge of professional A/E principles, concepts and
+        practices applicable to the design, layout, construction, repair and/or alterations
+        to a variety of conventional structures.\nKnowledge and skill to adapt standard
+        design and construction practices and techniques to establish design parameters;
+        and prepare project justifications and specifications for plans and designs
+        for new construction and renovation projects.\nAbility to communicate both
+        orally and in writing. Your answers to the questions will be used to place
+        you in one of three categories: Best Qualified, Well Qualified, or Qualified.\nWe
+        will verify your answers to the questions in your resume. If your resume doesn&rsquo;t
+        support your answers, we may lower your score, which could place you in a
+        lower category.\nWithin each category, veterans will receive selection priority
+        over non-veterans. To preview questions please click here.","HowToApply":"Submit
+        a complete online application including any required documents prior to 11:59
+        pm Eastern Time on the closing date of the announcement. You can modify or
+        complete your application any time before the deadline. Simply return to USAJOBS,
+        select the vacancy, and update your application. For more detailed instructions
+        on how to apply, click here: Apply for a GSA Job.To begin, click the Apply
+        Online button on the vacancy announcement. Sign in or register on USAJobs
+        and select a resume and documents to include in your application.\nOnce you
+        have clicked Apply for this position now, you will be taken to the GSA site
+        to complete the application process.\nClick the Apply To This Vacancy and
+        complete all steps in the application process until the Confirmation indicates
+        your application is complete. If you click Return to USAJobs or get timed
+        out prior to receiving confirmation, your application will not be submitted
+        and cannot be considered for this job.\nNote: Review the REQUIRED DOCUMENTS
+        section of this announcement to determine which apply to you and must be submitted
+        online. You may choose one or more of the following options to submit your
+        document(s): Upload (from your computer); USAJOBS (click the \"USAJOBS\" link
+        to complete the transfer process) or FAX (read the &ldquo;Fax instructions&rdquo;
+        provided prior to printing the Fax Cover Sheet and faxing your information).
+        Need Assistance in Applying? Contact the HR representative listed on the announcement
+        prior to the application deadline. We are available to assist you Monday-Friday
+        during normal business hours. You must receive HR approval before deviating
+        from these instructions. Be sure to APPLY EARLY as most assessments must be
+        completed fully and submitted before the announcement closing.","WhatToExpectNext":"After
+        the closing date/deadline:ELIGIBILITY/QUALIFICATIONS: Your application will
+        be reviewed for all requirements. REFERRAL TO MANAGEMENT: If you meet all
+        the requirements, you may be referred to management for review and a possible
+        interview. SELECTION/TENTATIVE JOB OFFER: If you are selected, you will receive
+        a tentative offer and start the suitability and/or security background investigation
+        process.\nFINAL JOB OFFER:Once our security office determines you can come
+        on board, you will be given a final offer, which is typically 40 days after
+        the announcement closes\nFINAL COMMUNICATION: Once the position is filled,
+        we will notify you of your status. You may also check your application status
+        by logging into USAJOBS and clicking &ldquo;Track this Application&rdquo;
+        on theApplicant Dashboard. Thank you for your interest in working for U.S.
+        General Services Administration!","RequiredDocuments":"ALL required documents
+        must be submitted before the closing date. Review the following list to determine
+        what you need to submit. Current or Former Political Appointees: Submit SF-50.\nIf
+        you are claiming veterans preference: (a) Copy of your Certificate of Release
+        or Discharge From Active Duty, DD-214 that shows the dates of your active
+        duty service. If selected, a DD-214 showing your type of discharge (member
+        4 copy) will be required prior to appointment. (b) If you are claiming 10-point
+        preference, submit both of the following in addition to the DD-214: (1) completedSF-15form;
+        and (2) proof of your entitlement (refer to SF-15 for complete list).\nIf
+        you are active duty military- Certification on a letterhead from your military
+        branch that includes your rank, character of service (must be under honorable
+        conditions) &amp; military service dates including discharge/release date
+        (must be no later than 120 days after the date the certification is submitted).\nCollege
+        transcripts: Your transcripts must show a, b, and c:(a) Proof of recent graduate
+        status (within past 2 years or on track to graduate by June 30, 2021; or within
+        past 6 years if you were prevented from applying due to your military service)(b)
+        Name of your college or university(c) Date your degree was awarded\nYou must
+        provide a copy of ALL of your college/vocational/technical transcript(s),
+        including current enrollment if applicable.\nIf you are currently pursuing
+        a graduate degree, but you are claiming Recent Graduate eligibility based
+        on a previous degree, you must also include those transcripts.\nIf you completed
+        your education outside of the U.S., see Foreign Education information for
+        guidance on what we can accept.\nIf selected, an official transcript will
+        be required prior to appointment.Superior Academic Achievement: Submit transcripts
+        as described above. If you qualify based on your class rank or honor society
+        membership, submit documentation of it.","Benefits":"You will have access
+        to many benefits including: Health insurance (choose from a wide range of
+        plans)\nLife insurance coverage with several options\nSick leave and vacation
+        time, including 10 paid holidays per year\nThrift Savings Plan (similar to
+        a 401(k) plan)\nFlexible work schedules\nTransit and child care subsidies\nFlexible
+        spending accounts\nLong-term care insurance\nTraining and development","OtherInformation":"Bargaining
+        Unit status: AFGE\nIf you are selected at a grade lower than the full performance
+        level, you may be promoted up to that grade level without having to re-apply
+        or compete against other applicants.\nRelocation-related expenses arenotapproved
+        and will be your responsibility. Additional vacancies may be filled from this
+        announcement as needed; through other means; or not at all.","KeyRequirements":["US
+        Citizenship or National (Residents of American Samoa and Swains Island)","Meet
+        all eligibility criteria by 6/30/2021.","Apply online (see How to Apply section)","Signed
+        participant agreement is required for employment under this Program."],"WithinArea":"False","CommuteDistance":"0","ServiceType":"02","AnnouncementClosingType":"01","AgencyContactEmail":"maura.murphy@gsa.gov","AgencyContactPhone":"212-264-5557","SecurityClearance":"Other","DrugTestRequired":"False","AdjudicationType":[],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"601807800","MatchedObjectDescriptor":{"PositionID":"21FASC267AHOTR","PositionTitle":"Industrial
+        Engineer","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/601807800","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/601807800?PostingChannelID="],"PositionLocationDisplay":"Washington,
+        District of Columbia","PositionLocation":[{"LocationName":"Washington, District
+        of Columbia","CountryCode":"United States","CountrySubDivisionCode":"District
+        of Columbia","CityName":"Washington, District of Columbia","Longitude":-77.032,"Latitude":38.8904}],"OrganizationName":"Federal
+        Acquisition Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Industrial
+        Engineering","Code":"0896"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"The
+        initial length of the job is one year but may become permanent.","Code":"15326"}],"QualificationSummary":"We
+        are currently filling one vacancy, but additional vacancies may be filled
+        through this announcement in this or other GSA organizations within the same
+        commuting area; through other means, or not at all.\nFor each job on your
+        resume, provide: the exact dates you held each job (from month/year to month/year)\nnumber
+        of hours per week you worked (if part time). If you have volunteered your
+        service through a National Service program (e.g., Peace Corps, Americorps),
+        we encourage you to apply and include this experience on your resume.For a
+        brief video on creating a Federal resume, clickhere.\nTheGS-07salary range
+        starts at$49,157.00per year.TheGS-09salary range starts at$60,129.00per year.If
+        you are a new federal employee, your starting salary will likely be set at
+        the Step 1 of the grade for which you are selected.\nBasic Requirement: To
+        be eligible for the position, you must meet the Basic Requirement for the
+        position.\nCarefully read the following statements A through G which outline
+        the Basic Requirements for all engineering positions in the Federal Service.
+        (A) Degree: Professional Engineering. To be acceptable, the curriculum must
+        be in a school of engineering with at least one curriculum accredited by the
+        Accreditation Board for Engineering and Technology (ABET) as a professional
+        engineering curriculum. (B) Degree: Professional Engineering including differential
+        &amp; integral calculus &amp; courses (more advanced than 1st yr. physics
+        &amp; chemistry) in 5 of the following areas: statics, dynamics; strength
+        of materials; fluid mechanics, hydraulics; thermodynamics; electrical fields
+        &amp; circuits; nature &amp; properties of material (relating to particle
+        &amp; aggregate structure to properties) &amp; any other comparable area of
+        engineering science or physics such as optics, heat transfer, soil mechanics,
+        or electronics. (C) College level education, training and/or technical experience
+        that furnished (1) a thorough knowledge of the physical &amp; mathematical
+        sciences underlying professional engineering, and (2) a good understanding
+        both theoretical and practical, of the engineering sciences and techniques,
+        and their applications to one of the branches of engineering, evidenced by
+        current registration as a professional engineer by any State, the District
+        of Columbia, Guam, or Puerto Rico. (D) College level education, training and/or
+        technical experience that furnished (1) a thorough knowledge of the physical
+        &amp; mathematical sciences underlying professional engineering, and (2) a
+        good understanding both theoretical and practical, of the engineering sciences
+        and techniques, and their applications to one of the branches of engineering,
+        evidenced by successfully passing the Engineer-in-Training (EIT) examination.
+        (E) College level education, training and/or technical experience that furnished
+        (1) a thorough knowledge of the physical &amp; mathematical sciences underlying
+        professional engineering, and (2) a good understanding both theoretical and
+        practical, of the engineering sciences &amp; techniques, and their applications
+        to one of the branches of engineering, evidenced by successfully passing the
+        written test administered by the Boards of Engineering Examiners in the various
+        States, D.C., Guam or Puerto Rico. (F) College level education, training and/or
+        technical experience -- evidenced by successful completion of at least 60
+        semester hrs. of courses in the physical, mathematical, &amp; engineering
+        sciences &amp; in engineering that included the courses specified in Option
+        B above. Courses must be fully acceptable toward meeting the requirements
+        of a professional engineering curriculum. (G) College level education, training
+        &amp; or technical experience evidenced by successful completion of a curriculum
+        leading a bachelor''s degree in engineering technology or in an appropriate
+        professional field (e.g., physics, chemistry, architecture, computer science,
+        mathematics, hydrology, or geology), AND at least 1 year of professional engineering
+        experience acquired under professional engineering supervision &amp; guidance.\nAdditional
+        Requirement: In addition to the basic requirement, in order to be rated as
+        qualified for this position, the HR Office must be able to determine that
+        the applicant meets the following education or specialized experience requirement.\nSpecialized
+        Experience GS-7:To qualify, you must have at least one year of specialized
+        experience equivalent to the GS-05level or higher in the Federal service.Specialized
+        experience is performing industrial engineering tasks of limited scope and
+        difficulty which are screened by a higher grade engineer.\nSubstitution of
+        Education for Experience GS-7: Applicants may also qualify on the basis of
+        education as follows: 1 year of graduate-level education OR superior academic
+        achievement OR completed a 5-year program of study of at least 160 semester
+        hours leading to a bachelor''s degree in engineering OR have a combination
+        of graduate level education in engineering or a related field and appropriate
+        specialized experience. The total percentage must equal at least 100 percent
+        to qualify.\nSuperior Academic Achievement (SAA) at the baccalaureate level
+        is fully qualifying at the GS-7 level. To claim SAA, submit documentation
+        of one of the following: Class standing -- You must be in the upper third
+        of your graduating class in the college, university, or major subdivision,
+        such as the College of Liberal Arts or the School of Business Administration,
+        based on completed courses.\nGrade-point average (rounded to one decimal point)
+        of: 3.0 or higher out of a possible 4.0 (\"B\" or better) as recorded on your
+        official transcript, or as computed based on 4 years of education, or as computed
+        based on courses completed during the final 2 years of your curriculum; or\n3.5
+        or higher out of a possible 4.0 (\"B+\" or better) based on the average of
+        the required courses completed in your major field or the required courses
+        in your major field completed during your final 2 years of the curriculum.
+        Election to membership in a national scholastic honor society in one of the
+        national scholastic honor societies listed by the Association of College Honor
+        Societies Specialized Experience GS-9:To qualify, you must have at least one
+        year of specialized experience equivalent to the GS-07 level or higher in
+        the Federal service.Specialized experience is performing independent industrial
+        engineering, modeling, and simulation studies/surveys of projects analysis
+        and modeling for recurring assignments which gradually increase in difficulty
+        and complexity designed to increase as well as broaden knowledge of industrial
+        engineering, modeling and simulation pertinent to the organization.\nSubstitution
+        of Education for Experience GS-9: Applicants may also qualify on the basis
+        of education as follows: Two years of progressively higher level graduate
+        education leading to a master''s degreeor equivalent graduate degree OR have
+        a combination of graduate education and experience to qualify. Total percentage
+        must equal at least 100 percent to qualify.","PositionRemuneration":[{"MinimumRange":"49157.0","MaximumRange":"78167.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-14","PositionEndDate":"2021-06-07","PublicationStartDate":"2021-05-14","ApplicationCloseDate":"2021-06-07","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"Announcement
+        has been amended to include additional education qualifications and extend
+        the close date to June 7, 2021.\nAre you a graduating student or a recent
+        grad? Join our Pathways Recent Graduate Program! This one-year program offers
+        professional and technical training, mentoring and developmental opportunities.
+        Location of position: GSA, FAS, General Supplies and Services in Washington,
+        DC.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"07","HighGrade":"09","OrganizationCodes":"GS/GS30","Relocation":"False","HiringPath":["graduates"],"TotalOpenings":"Few","AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104244","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104244&S=1","MajorDuties":["Duties
+        for GS-07... Assist with basic qualitative and quantitative analytical techniques
+        to research and gather narrative and/or statistical information, applicable
+        work methods, and procedures to meet deadlines.\nUnder close supervision and
+        assistance as required, apply basic project managerial and evaluative techniques
+        to the identification, consideration, and resolution of issues or problems
+        of a procedural or factual nature.\nAssist higher level personnel in preparing
+        briefings to management and/or senior staff employee(s) on project status
+        and recommendations.\nPerform other project management work selected by the
+        supervisor to enhance his/her developing skill and experience base. Duties
+        for GS-09... Assist in the development of new specifications and standards
+        and the modification of existing specifications and standards for assigned
+        items.\nAssist in the review of proposed and existing military specifications
+        and standards used in FAS procurement. Presents findings and recommendations
+        to preparing activity.\nDevelop and maintain contract support documents, commercial
+        item descriptions (CID''s), item purchase descriptions (IPD''s) to maximize
+        potential bidder&rsquo;s interest and enhance competition.\nIdentify and recommend
+        items for either elimination or addition to the GSA supply system based upon
+        projected economies andstandardization studies. Makes recommendations to higher
+        graded specialists concerning the disposition of supplier requests for deviations
+        from technical contractual obligations."],"Education":"","Requirements":"If
+        selected, you must meet the following conditions: Serve a one yeartrial period,
+        if required.\nRegister with the Selective Service, if you are a male born
+        after 12/31/1959\nHave your identity and work status eligibility verified
+        if you are not a GSA employee. We will use the Department of Homeland Security&rsquo;s
+        e-Verify system for this. Any discrepancies must be resolved as a condition
+        of continued employment.\nUndergo and pass a background investigation (Tier
+        2 investigation level). If you are not a GSA employee, you must be granted
+        this clearance before you start the job.\nComplete a financial disclosure
+        report to verify that no conflict, or an appearance of conflict, exists between
+        your financial interest and this position.\nReceive authorization from OPM
+        on any job offer you receive, if you are or were (within the last 5 years)
+        a political Schedule A, Schedule C or Non-Career SES employee in the Executive
+        Branch.\nSigned participant agreement is required for employment under this
+        Program.","Evaluations":"We will use a method called Category Rating to assess
+        your application. Here&rsquo;s how it will work: You will be scored on the
+        questions you answer during the application process, which will measure your
+        possession of the following competencies or knowledge, skills, and abilities:
+        GS-07... Knowledge of basic principles, concepts, and methodology of an Industrial
+        Engineering, and skill in applying this knowledge in carrying out elementary
+        assignments, operations, or procedures.\nKnowledge of the organization''s
+        programs and operations.\nKnowledge of commonly used project management practices,
+        procedures, regulations, precedents, policies, and guides that specifically
+        pertain to the work assigned.\nAbility to work independently on routine or
+        continuing assignments. GS-09... Knowledge of conventional industrial engineering
+        concepts in order to assist in thedevelopment and analysis of technical specifications
+        and standards for assigned commodities.\nSkill in written and oral communication.\nKnowledge
+        of applicable technological principles, i.e., industrial processes; production
+        techniques; quality control measures; salient characteristics and properties;
+        and needs peculiar to Government customer usage for assigned commodities.\nKnowledge
+        of GSA''s policies, regulations and procedures for assisting in the composition
+        andmaintenance of Government specifications. Your answers to the questions
+        will be used to place you in one of three categories: Best Qualified, Well
+        Qualified, or Qualified.\nWe will verify your answers to the questions in
+        your resume. If your resume doesn&rsquo;t support your answers, we may lower
+        your score, which could place you in a lower category.\nWithin each category,
+        veterans will receive selection priority over non-veterans. We will assess
+        your application to make sure you: are eligible to apply, e.g., a recent graduate;
+        and\nmeet the minimum education and/or experience requirements, which are
+        described in the Qualifications section If you meet the criteria above, you
+        will be referred to the selecting official. Veterans will receive selection
+        priority over non-veterans. To preview questions please click here.","HowToApply":"Submit
+        a complete online application including any required documents prior to 11:59
+        pm Eastern Time on the closing date of the announcement. You can modify or
+        complete your application any time before the deadline. Simply return to USAJOBS,
+        select the vacancy, and update your application. For more detailed instructions
+        on how to apply, click here: Apply for a GSA Job.To begin, click the Apply
+        Online button on the vacancy announcement. Sign in or register on USAJobs
+        and select a resume and documents to include in your application.\nOnce you
+        have clicked Apply for this position now, you will be taken to the GSA site
+        to complete the application process.\nClick the Apply To This Vacancy and
+        complete all steps in the application process until the Confirmation indicates
+        your application is complete. If you click Return to USAJobs or get timed
+        out prior to receiving confirmation, your application will not be submitted
+        and cannot be considered for this job.\nNote: Review the REQUIRED DOCUMENTS
+        section of this announcement to determine which apply to you and must be submitted
+        online. You may choose one or more of the following options to submit your
+        document(s): Upload (from your computer); USAJOBS (click the \"USAJOBS\" link
+        to complete the transfer process) or FAX (read the &ldquo;Fax instructions&rdquo;
+        provided prior to printing the Fax Cover Sheet and faxing your information).
+        Need Assistance in Applying? Contact the HR representative listed on the announcement
+        prior to the application deadline. We are available to assist you Monday-Friday
+        during normal business hours. You must receive HR approval before deviating
+        from these instructions. Be sure to APPLY EARLY as most assessments must be
+        completed fully and submitted before the announcement closing.","WhatToExpectNext":"After
+        the closing date/deadline: ELIGIBILITY/QUALIFICATIONS: Your application will
+        be reviewed for all requirements.\nREFERRAL TO MANAGEMENT: If you meet all
+        the requirements, you may be referred to management for review and a possible
+        interview. SELECTION/TENTATIVE JOB OFFER: If you are selected, you will receive
+        a tentative offer and start the suitability and/or security background investigation
+        process.\nFINAL JOB OFFER: Once our security office determines you can come
+        on board, you will be given a final offer, which is typically 40 days after
+        the announcement closes.\nFINAL COMMUNICATION: Once the position is filled,
+        we will notify you of your status. You may also check your status by logging
+        into USAJOBS. Go to My USAJOBS and then to Applications. Thank you for your
+        interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. If you are claiming veterans preference:
+        (a) Copy of your Certificate of Release or Discharge From Active Duty, DD-214
+        that shows the dates of your active duty service. If selected, a DD-214 showing
+        your type of discharge (member 4 copy) will be required prior to appointment.
+        (b) If you are claiming 10-point preference, submit both of the following
+        in addition to the DD-214:\n(1) completedSF-15form; and\n(2) proof of your
+        entitlement (refer to SF-15 for complete list). If you are active duty military-
+        Certification on a letterhead from your military branch that includes your
+        rank, character of service (must be under honorable conditions) &amp; military
+        service dates including discharge/release date (must be no later than 120
+        days after the date the certification is submitted). College transcripts:
+        Your transcripts must show a, b, and c:(a) Proof of recent graduate status
+        (within past 2 years or on track to graduate by July 5, 2021; or within past
+        6 years if you were prevented from applying due to your military service)(b)
+        Name of your college or university(c) Date your degree was awardedIf you are
+        currently pursuing a graduate degree, but you are claiming Recent Graduate
+        eligibility based on a previous degree, you must also include those transcripts.\nIf
+        you completed your education outside of the U.S., see Foreign Education information
+        for guidance on what we can accept.\nIf selected, an official transcript will
+        be required prior to appointment.Superior Academic Achievement: Submit transcripts
+        as described above. If you qualify based on your class rank or honor society
+        membership, submit documentation of it.","Benefits":"You will have access
+        to many benefits including: Health insurance (choose from a wide range of
+        plans)\nLife insurance coverage with several options\nSick leave and vacation
+        time, including 10 paid holidays per year\nThrift Savings Plan (similar to
+        a 401(k) plan)\nFlexible work schedules\nTransit and child care subsidies\nFlexible
+        spending accounts\nLong-term care insurance\nTraining and development","OtherInformation":"Bargaining
+        Unit status: NA\nIf you are selected at a grade lower than the full performance
+        level, you may be promoted up to that grade level without having to re-apply
+        or compete against other applicants.\nRelocation-expenses are not approved
+        and will be your responsibility.\nAdditional vacancies may be filled from
+        this announcement as needed; through other means; or not at all.","KeyRequirements":["US
+        Citizenship or National (Residents of American Samoa and Swains Island)","Meet
+        all eligibility criteria within 30 days of the closing date","Register with
+        Selective Service, if you are a male born after 12/31/1959"],"WithinArea":"False","CommuteDistance":"0","ServiceType":"02","AnnouncementClosingType":"01","AgencyContactEmail":"amina.hamilton@gsa.gov","AgencyContactPhone":"202-969-5593","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"Noncritical-Sensitive
+        (NCS)/Moderate Risk","AdjudicationType":["Suitability/Fitness"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0},{"MatchedObjectId":"601814200","MatchedObjectDescriptor":{"PositionID":"21PBSB403SHMP","PositionTitle":"Building
+        Manager","PositionURI":"https://www.usajobs.gov:443/GetJob/ViewDetails/601814200","ApplyURI":["https://www.usajobs.gov:443/GetJob/ViewDetails/601814200?PostingChannelID="],"PositionLocationDisplay":"Oxford,
+        Mississippi","PositionLocation":[{"LocationName":"Oxford, Mississippi","CountryCode":"United
+        States","CountrySubDivisionCode":"Mississippi","CityName":"Oxford, Mississippi","Longitude":-89.518776,"Latitude":34.364014}],"OrganizationName":"Public
+        Buildings Service","DepartmentName":"General Services Administration","JobCategory":[{"Name":"Building
+        Management","Code":"1176"}],"JobGrade":[{"Code":"GS"}],"PositionSchedule":[{"Name":"Full-time","Code":"1"}],"PositionOfferingType":[{"Name":"Permanent","Code":"15317"}],"QualificationSummary":"For
+        each job on your resume, provide: the exact dates you held each job (from
+        month/year to month/year)\nnumber of hours per week you worked (if part time).
+        If you have volunteered your service through a National Service program (e.g.,
+        Peace Corps, Americorps), we encourage you to apply and include this experience
+        on your resume.For a brief video on creating a Federal resume, clickhere.\nTheGS-09
+        salary range starts at $53,433.00 per year.\nTheGS-11 salary range starts
+        at $64,649.00 per year.\nTheGS-12 salary range starts at $77,488.00 per year.\nIf
+        you are a new federal employee, your starting salary will likely be set at
+        the Step 1 of the grade for which you are selected.To qualify for the GS-09,
+        you must demonstrate one year of experience equivalent to the GS-07 in the
+        Federal service.Specialized experience is defined as implementing programs
+        related to the operation and maintenance of small (e.g. 200K sq ft) commercial
+        buildings (or equivalent non-housing small office buildings) and leased space;
+        analyzing the effectiveness and efficiency of building operations, automated
+        systems, and mechanical equipment; interacting with customers and stakeholders
+        regarding building services in order to assess their needs and recommend solutions;
+        and assisting with managing or monitoring real property budgetary and financial
+        data.\nOR\nHave a master''s or equivalent level degree or 2 full years of
+        progressively higher level graduate education leading to such a degree or
+        an LL.B. or JD. This education provided you with the knowledge, skills, and
+        abilities necessary to do the work of the position. ORpossess a combination
+        of graduate level education and appropriate experience that together meet
+        the qualification requirements of this position.To qualify for the GS-11,
+        you must demonstrate one year of experience equivalent to the GS-09 in the
+        Federal service.Specialized experience is defined as implementing programs
+        related to the operation and maintenance of small to medium-size (e.g. 200K
+        to 500K sq ft), multi-level, commercial buildings (or equivalent non-housing
+        small to medium-size office buildings) and leased space; analyzing the effectiveness
+        and efficiency of building operations, automated systems, and mechanical equipment;
+        interacting with customers and stakeholders regarding building services in
+        order to assess their needs and recommend solutions; and assisting with managing
+        or monitoring real property budgetary and financial data.\nOR\nHave 3 years
+        of progressively higher-level graduate education leading to a Ph.D. or a Ph.D.
+        or equivalent doctoral degree. This education providedyou the knowledge, skills,
+        and abilities necessary to do the work of the position ORhave a combination
+        of graduate level education and appropriate experience that together meet
+        the qualification requirements of this position.\nTo qualify for the GS-12,
+        you must demonstrate one year of experience equivalent to the GS-11 in the
+        Federal service.Specialized experience is defined as evaluating policies and
+        implementing programs related to the operation and maintenance of medium size
+        (e.g. 500K sq ft), multi-level, commercial buildings (or equivalent non-housing
+        high rise building) and leased space; analyzing the effectiveness and efficiency
+        of building operations, automated systems, and mechanical equipment; establishing
+        and maintaining customer satisfaction programs that include feedback mechanisms
+        used to evaluate the effectiveness of services provided; and managing or monitoring
+        real property budgetary and financial data.","PositionRemuneration":[{"MinimumRange":"53433.0","MaximumRange":"100739.0","RateIntervalCode":"Per
+        Year"}],"PositionStartDate":"2021-05-18","PositionEndDate":"2021-06-01","PublicationStartDate":"2021-05-18","ApplicationCloseDate":"2021-06-01","PositionFormattedDescription":[{"Label":"Dynamic
+        Teaser","LabelDescription":"Hit highlighting for keyword searches."}],"UserArea":{"Details":{"JobSummary":"As
+        a Building Manager, you will provide occupants of both Federal Government
+        buildings and privately leased space with safe, secure, clean, and sustainable
+        facilities in which to conduct agency business.\nLocation of Position: Public
+        Buildings Service, Property ManagementDivision, Oxford,MS\nWe are currently
+        filling one vacancy in each location, but additional vacancies may be filled
+        as needed.","WhoMayApply":{"Name":"","Code":""},"LowGrade":"09","HighGrade":"12","OrganizationCodes":"GS/GS03","Relocation":"False","HiringPath":["disability","fed-competitive","fed-transition","land","mspouse","overseas","peace","special-authorities","vet"],"TotalOpenings":"FEW","AppointmentExplanationText":"Permanent","AgencyMarketingStatement":"","TravelCode":"1","ApplyOnlineUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104304","DetailStatusUrl":"https://jobs.monstergovt.com/gsa/ros/rosDashboard.hms?O=1&J=104304&S=1","MajorDuties":["Customer
+        Satisfaction Develops and promotes positive working relationships with customer
+        agencies and client personnel, and maintains continuous liaison with building
+        tenants and top management officials of customer agencies and tenants at facilities
+        managed.\nWorks closely with other GSA personnel, customer agency personnel
+        and contractors in the planning, design, renovation, construction, alteration,
+        operation, maintenance and repair of assigned buildings.\nWorks with tenant
+        agencies, building occupants, contractors, appropriate GSA program experts
+        and other stakeholders to coordinate sustainability-related programs as applicable.
+        Contract Administration Manages the contracting and leasing administration
+        process as needed on behalf of tenant agencies and GSA. In this capacity,
+        oversees force account operations (where applicable) and administers various
+        types of contracts, leases, and serves as the contracting officer&rsquo;s
+        representative (COR). Develops and implements a cost effective quality assurance
+        plan; monitors contractor''s quality control and performance; plans and oversees
+        the work of on-site contractor personnel; informs the contracting officer
+        of any technical or contractual difficulties encountered; informs the contractor
+        of failures to comply with technical requirements of the contract.\nEvaluates
+        any proposed contract changes and makes recommendations to the Contracting
+        Officer regarding changes in scope of performance standards to improve service
+        delivery and meet customers&rsquo; needs, or changes in the site conditions;
+        performs final inspection of completed work against contract requirements
+        and approves or rejects the final product in whole or in part. Lease Administration
+        Collaborates with the lessor&rsquo;s facility staff to ensure that service
+        levels are delivered as required in the lease.\nProvides contract administration
+        and lease management services to ensure that lessors comply with the scope,
+        terms and conditions of the lease.\nMeets with lessors, property managers
+        and contractors to discuss and potentially resolve complaints or disputes
+        concerning issues such as quality of services delivered, adequacy of maintenance
+        and operation of mechanical systems, custodial services or grounds maintenance.
+        Building/Facility Management Exercises full responsibility and authority for
+        the day to day operations of a designated building or groups of buildings
+        within the GSA inventory. Manages building operations, maintenance, repair,
+        alteration, historic preservation, recycling, concessions, safety, environmental
+        and security in GSA-owned and leased buildings assigned. Promotes and monitors
+        efficient occupant space utilization, energy and water conservation, sustainability
+        and environmental hazards programs, and fire and security protection.\nManages
+        grounds and exteriors including parking structures and lots, site utilities,
+        landscaping and grounds, snow removal, and exterior building maintenance;
+        assesses the effect of climate and extreme environmental conditions and evaluates
+        the performance of grounds and exterior elements; assesses the need for alterations
+        in grounds and exterior elements; and manage the maintenance and custodial
+        needs of grounds and exterior elements.\nMonitors information and trends related
+        to facility management technologies and assesses their applicability in assigned
+        buildings; plans for and oversees the acquisition, installation, operation,
+        maintenance, upgrade, and disposition of components supporting facility management
+        technologies. Project Management Directs and coordinates the operation of
+        all construction, alteration and repair projects to minimize or ideally avoid
+        adverse impact to customer agencies. Ensures that customer agencies are aware
+        of the schedule and timing of building related activities that may impact
+        their operation. Financial Management Participates and engages in planning
+        and developing operating budgets and all related Federal Buildings Fund procedures
+        and activities for assigned facilities. Activities include preparation of
+        the annual budget estimates for maintenance, mechanical workloads, utility
+        rate increases; development of overtime and additional services estimates;
+        related equipment, pest control and waste systems; and the cost of minor repairs,
+        and security support.\nUses Life Cycle Cost Analysis and Total Cost of Ownership
+        concepts and is fully engaged in development of budgets for building services,
+        repair and alteration, and capital design and construction."],"Education":"If
+        you are using foreign education to meet qualification requirements, you must
+        send a Certificate of Foreign Equivalency with your transcript in order to
+        receive credit for that education. For further information, visit:https://www2.ed.gov/about/offices/list/ous/international/usnei/us/edlite-visitus-forrecog.html","Requirements":"If
+        selected, you must meet the following conditions: Receive authorization from
+        OPM on any job offer you receive, if you are or were (within the last 5 years)
+        a Schedule A, Schedule C, or non-career SES political appointee\nServe a one
+        year probationary period, if required.\nUndergo and pass a background investigation
+        (Tier 2 investigation level).\nHave your identity and work status eligibility
+        verified if you are not a GSA employee. We will use the Department of Homeland
+        Security&rsquo;s e-Verify system for this. Any discrepancies must be resolved
+        as a condition of continued employment.\nWork is normally performed in an
+        office setting; however, incumbent is routinely required to travel and may
+        be exposed to slippery or uneven ground, failing objects, constructions and
+        site conditions, noise dust and environment or other discomforts and hazards.\nBuilding
+        Managers are designated as essential employees. An essential employee is one
+        designated to report to, or remain at work in emergency situations, such as
+        hazardous weather condition, to protect life, safety, health or property.
+        Dismissal or closure announcements do not apply to essential employees. They
+        must report to or remain at work, unless otherwise directed by their supervisor.\nHave
+        a valid driver''s license.","Evaluations":"You will be evaluated on the questions
+        you answer during the application process, which will measure your overall
+        possession of the following competencies or knowledge, skills, and abilities.
+        Your responses to these questions must be supported by your resume or your
+        score may be lowered. Knowledge of qualitative and quantitative techniques
+        and statistical interpretation required to perform extensive coordination
+        and fact-finding in order to identify client agency and building tenants&rsquo;
+        facility needs in relation to customer satisfaction.\nAdvanced skills in interpersonal
+        relations and in written and oral communications required to explain, evaluate
+        and negotiate client and technical operating requirements.\nKnowledge of contracting
+        rules and regulations regarding the technical soundness of contractor-provided
+        supplies/services/processes and decisions to ensure services provided meet
+        contract specifications as well as business and workplace needs of the tenant.\nIn-depth
+        analytical knowledge of the property management industry, including private
+        sector leasing protocols and practices involving facility operations and systems.\nTechnical
+        knowledge of building operations and maintenance, including Federal and industry
+        operations and maintenance best practices; major systems and equipment such
+        as HVAC, controls, mechanical, electrical, plumbing, roofing, structural,
+        elevators, and renewable energy systems and how they contribute to whole building
+        energy and water use.\nAbility to integrate knowledge of legal, engineering,
+        architecture, fire and life safety, physical security, food service, finance,
+        asset preservation, HVAC, environment, cost estimation, contracting, lease
+        management so that the diverse issues are satisfactorily coordinated and analyzed,
+        conflicts resolved, risks identified and mitigated as necessary and buildings
+        operated in a manner that conforms to technical requirements and responds
+        to client needs.\nAbility required to plan, schedule, and balance all technical
+        aspects of multiple tenant requirements, such as complex alterations, and
+        to independently determine and execute the appropriate sequencing of work
+        required to fulfill client agency needs and to inform them regarding the status
+        of projects.\nKnowledge ofbusiness policies, processes and initiatives related
+        to Property Management programs. Additional assessments may be used. If further
+        assessments are used, you will be provided with instructions. If you are eligible
+        under Interagency Career Transition Assistance Plan or GSA&rsquo;s Career
+        Transition Assistance Plan(ICTAP/CTAP), you must receive a score of 85 or
+        higher to receive priority.You will be evaluated on the questions you answer
+        during the application process, which will measure your overall possession
+        of the following competencies or knowledge, skills, and abilities. Your responses
+        to these questions must be supported by your resume or your score may be lowered.
+        To preview questions please click here.","HowToApply":"Submit a complete online
+        application including any required documents prior to 11:59 pm Eastern Time
+        on the closing date of the announcement. You can modify or complete your application
+        any time before the deadline. Simply return to USAJOBS, select the vacancy,
+        and update your application. For more detailed instructions on how to apply,
+        click here: Apply for a GSA Job.\nTo begin, click the Apply Online button
+        on the vacancy announcement. Sign in or register on USAJobs and select a resume
+        and documents to include in your application.\nOnce you have clicked Apply
+        for this position now, you will be taken to the GSA site to complete the application
+        process.\nClick the Apply To This Vacancy and complete all steps in the application
+        process until the Confirmation indicates your application is complete. If
+        you click Return to USAJobs or get timed out prior to receiving confirmation,
+        your application will not be submitted and cannot be considered for this job.\nNote:
+        Review the REQUIRED DOCUMENTS section of this announcement to determine which
+        apply to you and must be submitted online. You may choose one or more of the
+        following options to submit your document(s): Upload (from your computer);
+        USAJOBS (click the \"USAJOBS\" link to complete the transfer process) or FAX
+        (read the &ldquo;Fax instructions&rdquo; provided prior to printing the Fax
+        Cover Sheet and faxing your information). Need Assistance in Applying? Contact
+        the HR representative listed on the announcement prior to the application
+        deadline. We are available to assist you Monday-Friday during normal business
+        hours. You must receive HR approval before deviating from these instructions.
+        Be sure to APPLY EARLY as most assessments must be completed fully and submitted
+        before the announcement closing.","WhatToExpectNext":"After the closing date/deadline:
+        ELIGIBILITY/QUALIFICATIONS: Your application will be reviewed for all requirements.\nREFERRAL
+        TO MANAGEMENT: If you meet all the requirements, you may be referred to management
+        for review and a possible interview. SELECTION/TENTATIVE JOB OFFER: If you
+        are selected, you will receive a tentative offer and start the suitability
+        and/or security background investigation process.\nFINAL JOB OFFER:Once our
+        security office determines you can come on board, you will be given a final
+        offer, which is typically 40 days after the announcement closes.\nFINAL COMMUNICATION:
+        Once the position is filled, we will notify you of your status. You may also
+        check your status by logging into USAJOBS. Go to My USAJOBS and then to Applications.
+        Thank you for your interest in working for U.S. General Services Administration!","RequiredDocuments":"ALL
+        required documents must be submitted before the closing date. Review the following
+        list to determine what you need to submit. Note: If required to submit an
+        SF-50 (Notice of Personnel Action), an equivalent agency Notice of Personnel
+        Action form is acceptable. Such document(s) must show all of the following:
+        effective date, position, title, series, grade, and rate of basic pay, tenure
+        group 1 (career) or 2 (career-conditional), position occupied group, and name
+        of agency. If you are a GSA employee (except in the OIG), you are not required
+        to submit an SF-50.\nIf you are a 30% or more disabled veteran, VEOA or VRA
+        applicant or qualified spouse, widow/widower, or parent: (a) Copy of your
+        Certificate of Release or Discharge From Active Duty, DD-214 that shows the
+        dates of your active duty service. If selected, a DD-214 showing your type
+        of discharge (member 4 copy) will be required prior to appointment. (b) If
+        you are a disabled veteran, or are applying under VRA or VEOA as a spouse,
+        widow/widower, or parent of a veteran, submit both of the following in addition
+        to the DD-214: (1) completedSF-15form; and (2) proof of your entitlement (refer
+        to SF-15 for complete list).\nIf you are active duty military: Certification
+        on a letterhead from your military branch that includes your rank, character
+        of service (must be under honorable conditions) &amp; military service dates
+        including discharge/release date (must be no later than 120 days after the
+        date the certification is submitted).\nIf you are a current Federal employee
+        or Reinstatement Eligible: Submit your latest SF-50.\nIf you are eligible
+        under an Interchange Agreement:Submit your latest SF-50.\nIf you are a former
+        Peace Corps or VISTA volunteer:Submit your Description of Service.\nIf you
+        are acurrent or former Land Management Agency Employee- Submit a and b: (a)
+        one or more SF-50s, including your most recent one that shows you were on
+        a competitive time-limited appointment(s) with a Land Management Agencyand
+        served on the appointment for a period(s) totaling more than 24 months without
+        a break of 2 or more years. (b) Copy of your agency&rsquo;s annual performance
+        appraisal(s) or written reference(s) from a supervisor at the agency verifying
+        satisfactory performance during your appointment(s).\nIf you have a disability:
+        Submit proof of eligibility. For information on eligibility and required documentation,
+        refer to USAJOBS&rsquo;s People With Disabilities page.\nIf you are applying
+        under another special appointment authority: Submit proof of your eligibility
+        under the appropriate appointment authority. See USAJOBS''s Resource Center
+        for more information.\nIf you are ICTAP/CTAPeligible - submit a, b, and c:
+        (a) proof of eligibility including agency notice; (b) SF-50, and (c) most
+        recent performance appraisal.\nIf you are a current or former political appointee:
+        Submit your SF-50.\nCollege transcripts: If you are using some or all of your
+        college education to meet qualification requirements for this position, you
+        must submit a photocopy of your college transcript(s). If selected, an official
+        transcript will be required prior to appointment. For education completed
+        outside the United States, also submit a valid foreign credential evaluation
+        that substantiates possession of the required education.","Benefits":"You
+        will have access to many benefits including: Health insurance (choose from
+        a wide range of plans)\nLife insurance coverage with several options\nSick
+        leave and vacation time, including 10 paid holidays per year\nThrift Savings
+        Plan (similar to a 401(k) plan)\nFlexible work schedules\nTransit and child
+        care subsidies\nFlexible spending accounts\nLong-term care insurance\nTraining
+        and development","OtherInformation":"We are also accepting applications from
+        all U.S. Citizens and Nationals under Vacancy Announcement# 21PBSB404SHDE.
+        You must apply separately to each announcement to be considered for both.\nBargaining
+        Unit status: NFFEIf you are selected at a grade lower than the full performance
+        level, you may be promoted up to that grade level without having to re-apply
+        or compete against other applicants.Relocation-related expenses arenotapproved
+        and will be your responsibility.\nWe are currently filling one vacancy, but
+        additional vacancies may be filled from this announcement as needed; through
+        other means; or not at all.","KeyRequirements":["US Citizenship or National
+        (Residents of American Samoa and Swains Island)","Meet time-in-grade requirements
+        within 30 days of closing date","Males born after 12/31/1959 must have registered
+        with the Selective Service","Meet all eligibility requirements within 30 days
+        of the closing date.","Apply online (See How to Apply section.)","Direct Deposit
+        of salary check to financial organization required."],"WithinArea":"False","CommuteDistance":"0","SecondAnnouncementUrl":"601814700","ServiceType":"01","AnnouncementClosingType":"01","AgencyContactEmail":"shana.hunter@gsa.gov","AgencyContactPhone":"404-331-3186","SecurityClearance":"Other","DrugTestRequired":"False","PositionSensitivitiy":"Noncritical-Sensitive
+        (NCS)/Moderate Risk","AdjudicationType":["Credentialing"],"TeleworkEligible":true},"IsRadialSearch":false}},"RelevanceRank":0}],"UserArea":{"NumberOfPages":"4","IsRadialSearch":false}}}'
+    http_version:
+  recorded_at: Fri, 28 May 2021 17:29:50 GMT
+recorded_with: VCR 4.0.0


### PR DESCRIPTION
This PR adds an integration test for a job search by agency. I realized during the legacy SERP removal that this feature was not well covered by existing tests.

https://search.gov/manual/govbox-jobs.html