### PR TITLE
SRCH-2331 the basic_affiliate fixture uses the default search engine

### DIFF
--- a/spec/fixtures/affiliates.yml
+++ b/spec/fixtures/affiliates.yml
@@ -48,7 +48,6 @@ basic_affiliate:
   name: nps.gov
   website: http://www.nps.gov
   is_sayt_enabled: false
-  search_engine: Google
   youtube_profiles: nps
   api_access_key: basic_key
 

--- a/spec/models/web_search_spec.rb
+++ b/spec/models/web_search_spec.rb
@@ -116,23 +116,6 @@ describe WebSearch do
         described_class.new(@valid_options).send(:search)
       end
     end
-
-    context 'when Google is the engine' do
-      before do
-        @affiliate = affiliates(:basic_affiliate)
-        @valid_options = {query: 'government', affiliate: @affiliate}
-        google_search = GoogleWebSearch.new(@valid_options)
-        allow(GoogleWebSearch).to receive(:new).and_return google_search
-        allow(google_search).to receive(:execute_query)
-      end
-
-      it 'should instrument the call to the search engine with the proper action.service namespace and query param hash' do
-        expect(@affiliate.search_engine).to eq('Google')
-        expect(ActiveSupport::Notifications).to receive(:instrument).
-          with('google_web_search.usasearch', hash_including(query: hash_including(term: 'government')))
-        described_class.new(@valid_options).send(:search)
-      end
-    end
   end
 
   describe '#run' do
@@ -226,21 +209,6 @@ describe WebSearch do
 
         its(:module_tag) { is_expected.to eq('AWEB') }
         its(:fake_total?) { is_expected.to be_true }
-      end
-
-      context 'when the search_engine is Google' do
-        subject(:search) do
-          affiliate = affiliates(:usagov_affiliate)
-          affiliate.search_engine = 'Google'
-
-          described_class.new(affiliate: affiliate,
-                              page: 1,
-                              query: 'highlight enabled')
-        end
-
-        before { search.run }
-
-        its(:module_tag) { is_expected.to eq('GWEB') }
       end
 
       context 'when sitelinks are present in at least one result' do

--- a/spec/models/web_search_spec.rb
+++ b/spec/models/web_search_spec.rb
@@ -1,64 +1,62 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe WebSearch do
   fixtures :affiliates, :site_domains
-  let(:affiliate) {  affiliates(:usagov_affiliate) }
+  let(:affiliate) { affiliates(:usagov_affiliate) }
+  let(:valid_options) do
+    { query: 'government', affiliate: affiliate }
+  end
 
   describe '.new' do
-    before do
-      @affiliate = affiliates(:usagov_affiliate)
-      @valid_options = {query: 'government', affiliate: @affiliate}
-    end
-
-    it 'should have a settable query' do
-      search = described_class.new(@valid_options)
+    it 'has a settable query' do
+      search = described_class.new(valid_options)
       expect(search.query).to eq('government')
     end
 
-    it 'should have a settable affiliate' do
-      search = described_class.new(@valid_options)
-      expect(search.affiliate).to eq(@affiliate)
+    it 'has a settable affiliate' do
+      search = described_class.new(valid_options)
+      expect(search.affiliate).to eq(affiliate)
     end
 
-    it 'should not require a query' do
-      described_class.new({affiliate: @affiliate})
+    it 'does not require a query' do
+      described_class.new(affiliate: affiliate)
     end
 
-    it 'should ignore invalid params' do
-      search = described_class.new(@valid_options.merge(page: {foo: 'bar'}))
+    it 'ignores invalid params' do
+      search = described_class.new(valid_options.merge(page: { foo: 'bar' }))
       expect(search.page).to eq(1)
     end
 
-    it 'should ignore params outside the allowed range' do
-      search = described_class.new(@valid_options.merge(page: -1))
+    it 'ignores params outside the allowed range' do
+      search = described_class.new(valid_options.merge(page: -1))
       expect(search.page).to eq(Pageable::DEFAULT_PAGE)
     end
 
-    it 'should set matching site limits' do
-      @affiliate.site_domains.create!(domain: 'foo.com')
-      @affiliate.site_domains.create!(domain: 'bar.gov')
-      search = described_class.new({query: 'government', affiliate: @affiliate, site_limits: 'foo.com/subdir1 foo.com/subdir2 include3.gov'})
-      expect(search.matching_site_limits).to eq(%w(foo.com/subdir1 foo.com/subdir2))
+    it 'sets matching site limits' do
+      affiliate.site_domains.create!(domain: 'foo.com')
+      affiliate.site_domains.create!(domain: 'bar.gov')
+      search = described_class.new(query: 'government', affiliate: affiliate, site_limits: 'foo.com/subdir1 foo.com/subdir2 include3.gov')
+      expect(search.matching_site_limits).to eq(%w[foo.com/subdir1 foo.com/subdir2])
     end
 
     context 'when affiliate has custom google CX+Key set and google search enabled' do
       before do
-        @affiliate.search_engine = 'Google'
-        @affiliate.google_cx = '1234567890.abc'
-        @affiliate.google_key = 'some_key'
+        affiliate.search_engine = 'Google'
+        affiliate.google_cx = '1234567890.abc'
+        affiliate.google_key = 'some_key'
       end
 
-      it 'should use that for the search' do
+      it 'uses that for the search' do
         expect(GoogleWebSearch).to receive(:new).with(hash_including(google_cx: '1234567890.abc', google_key: 'some_key'))
-        described_class.new(@valid_options)
+        described_class.new(valid_options)
       end
     end
 
     skip 'when the search engine is Azure' do
-      #disabling until tests are removed:
-      #https://www.pivotaltracker.com/story/show/134719601
+      # disabling until tests are removed:
+      # https://www.pivotaltracker.com/story/show/134719601
 
-      before { @affiliate.search_engine = 'Azure' }
+      before { affiliate.search_engine = 'Azure' }
 
       it 'searches using Azure web engine' do
         HostedAzureWebEngine.should_receive(:new).
@@ -67,132 +65,133 @@ describe WebSearch do
                               per_page: 10,
                               query: 'government (site:gov OR site:mil)'))
 
-        described_class.new @valid_options
+        described_class.new valid_options
       end
     end
-
   end
 
   describe '#cache_key' do
-    before do
-      @valid_options = {query: 'government', affiliate: affiliate, page: 5}
+    let(:valid_options) do
+      { query: 'government', affiliate: affiliate, page: 5 }
     end
 
-    it 'should output a key based on the query, options (including affiliate id), and search engine parameters' do
-      expect(described_class.new(@valid_options).cache_key).to eq("government (site:gov OR site:mil):{:query=>\"government\", :page=>5, :affiliate_id=>#{affiliate.id}}:BingV6")
+    it 'outputs a key based on the query, options (including affiliate id), and search engine parameters' do
+      expect(described_class.new(valid_options).cache_key).to eq("government (site:gov OR site:mil):{:query=>\"government\", :page=>5, :affiliate_id=>#{affiliate.id}}:BingV6")
     end
   end
 
   describe 'instrumenting search engine calls' do
     context 'when BingV6 is the engine' do
       before do
-        @valid_options = {query: 'government', affiliate: affiliate}
-        bing_search = BingV6WebSearch.new(@valid_options)
+        valid_options = { query: 'government', affiliate: affiliate }
+        bing_search = BingV6WebSearch.new(valid_options)
         allow(BingV6WebSearch).to receive(:new).and_return bing_search
         allow(bing_search).to receive(:execute_query)
       end
 
-      it 'should instrument the call to the search engine with the proper action.service namespace and query param hash' do
+      it 'instruments the call to the search engine with the proper action.service namespace and query param hash' do
         expect(affiliate.search_engine).to eq('BingV6')
         expect(ActiveSupport::Notifications).to receive(:instrument).
           with('bing_v6_web_search.usasearch', hash_including(query: hash_including(term: 'government')))
-        described_class.new(@valid_options).send(:search)
+        described_class.new(valid_options).send(:search)
       end
     end
 
     context 'when BingV7 is the engine' do
       before do
         affiliate.search_engine = 'BingV7'
-        @valid_options = {query: 'government', affiliate: affiliate}
-        bing_search = BingV7WebSearch.new(@valid_options)
+        valid_options = { query: 'government', affiliate: affiliate }
+        bing_search = BingV7WebSearch.new(valid_options)
         allow(BingV7WebSearch).to receive(:new).and_return bing_search
         allow(bing_search).to receive(:execute_query)
       end
 
-      it 'should instrument the call to the search engine with the proper action.service namespace and query param hash' do
+      it 'instruments the call to the search engine with the proper action.service namespace and query param hash' do
         expect(affiliate.search_engine).to eq('BingV7')
         expect(ActiveSupport::Notifications).to receive(:instrument).
           with('bing_v7_web_search.usasearch', hash_including(query: hash_including(term: 'government')))
-        described_class.new(@valid_options).send(:search)
+        described_class.new(valid_options).send(:search)
       end
     end
   end
 
   describe '#run' do
     context 'when searching with a blacklisted query term' do
-      before do
-        @search = described_class.new(query: Search::BLACKLISTED_QUERIES.sample, affiliate: affiliate)
+      let(:search) do
+        described_class.new(query: Search::BLACKLISTED_QUERIES.sample, affiliate: affiliate)
       end
 
-      it 'should return false when searching' do
-        expect(@search.run).to be false
+      it 'returns false when searching' do
+        expect(search.run).to be false
       end
 
-      it 'should have 0 results' do
-        @search.run
-        expect(@search.results.size).to be_zero
+      it 'has 0 results' do
+        search.run
+        expect(search.results.size).to be_zero
       end
 
-      it 'should set error message' do
-        @search.run
-        expect(@search.error_message).to eq(I18n.translate(:empty_query))
+      it 'sets error message' do
+        search.run
+        expect(search.error_message).to eq(I18n.t(:empty_query))
       end
     end
 
     context 'when searching with really long queries' do
-      before do
-        @search = described_class.new(query: 'X' * (Search::MAX_QUERYTERM_LENGTH + 1), affiliate: affiliate)
+      let(:search) do
+        described_class.new(query: 'X' * (Search::MAX_QUERYTERM_LENGTH + 1), affiliate: affiliate)
       end
 
-      it 'should return false when searching' do
-        expect(@search.run).to be false
+      it 'returns false when searching' do
+        expect(search.run).to be false
       end
 
-      it 'should have 0 results' do
-        @search.run
-        expect(@search.results.size).to be_zero
+      it 'has 0 results' do
+        search.run
+        expect(search.results.size).to be_zero
       end
 
-      it 'should set error message' do
-        @search.run
-        expect(@search.error_message).to eq(I18n.translate(:too_long))
+      it 'sets error message' do
+        search.run
+        expect(search.error_message).to eq(I18n.t(:too_long))
       end
     end
 
     context 'when paginating' do
-
       let(:affiliate) { affiliates(:basic_affiliate) }
 
-      it 'should default to page 1 if no valid page number was specified' do
-        expect(described_class.new({query: 'government', affiliate: affiliate}).page).to eq(Pageable::DEFAULT_PAGE)
-        expect(described_class.new({query: 'government', affiliate: affiliate, page: ''}).page).to eq(Pageable::DEFAULT_PAGE)
-        expect(described_class.new({query: 'government', affiliate: affiliate, page: 'string'}).page).to eq(Pageable::DEFAULT_PAGE)
+      it 'defaults to page 1 if no valid page number was specified' do
+        expect(described_class.new(query: 'government', affiliate: affiliate).page).to eq(Pageable::DEFAULT_PAGE)
+        expect(described_class.new(query: 'government', affiliate: affiliate, page: '').page).to eq(Pageable::DEFAULT_PAGE)
+        expect(described_class.new(query: 'government', affiliate: affiliate, page: 'string').page).to eq(Pageable::DEFAULT_PAGE)
       end
 
-      it 'should set the page number' do
-        search = described_class.new({query: 'government', affiliate: affiliate, page: 2})
+      it 'sets the page number' do
+        search = described_class.new(query: 'government', affiliate: affiliate, page: 2)
         expect(search.page).to eq(2)
       end
     end
 
     describe 'logging module impressions' do
-      before do
-        @search = described_class.new({query: 'government', affiliate: affiliates(:basic_affiliate)})
-        allow(@search).to receive(:search)
-        allow(@search).to receive(:handle_response)
-        allow(@search).to receive(:populate_additional_results)
-        allow(@search).to receive(:module_tag).and_return 'BWEB'
-        allow(@search).to receive(:spelling_suggestion).and_return 'foo'
+      let(:search) do
+        described_class.new(query: 'government', affiliate: affiliates(:basic_affiliate))
       end
 
-      it 'should assign module_tag to BWEB' do
-        @search.run
-        expect(@search.module_tag).to eq('BWEB')
+      before do
+        allow(search).to receive(:search)
+        allow(search).to receive(:handle_response)
+        allow(search).to receive(:populate_additional_results)
+        allow(search).to receive(:module_tag).and_return 'BWEB'
+        allow(search).to receive(:spelling_suggestion).and_return 'foo'
+      end
+
+      it 'assigns module_tag to BWEB' do
+        search.run
+        expect(search.module_tag).to eq('BWEB')
       end
 
       skip 'when search_engine is Azure' do
-        #disabling until tests are removed:
-        #https://www.pivotaltracker.com/story/show/134719601
+        # disabling until tests are removed:
+        # https://www.pivotaltracker.com/story/show/134719601
 
         subject(:search) do
           affiliate = affiliates(:usagov_affiliate)
@@ -215,31 +214,30 @@ describe WebSearch do
         let(:results) { [{ 'foo' => 'bar' }, { 'sitelinks' => 'yep' }] }
 
         before do
-          @search.instance_variable_set('@results', results)
+          search.instance_variable_set('@results', results)
         end
 
-        it 'should log the DECOR module' do
-          @search.run
-          expect(@search.modules).to include('DECOR')
+        it 'logs the DECOR module' do
+          search.run
+          expect(search.modules).to include('DECOR')
         end
-
       end
     end
 
     describe 'populating additional results' do
-      before do
-        @search = described_class.new(query: 'english', affiliate: affiliates(:non_existent_affiliate), geoip_info: 'test')
+      let(:search) do
+        described_class.new(query: 'english', affiliate: affiliates(:non_existent_affiliate), geoip_info: 'test')
       end
 
-      it 'should get the info from GovboxSet' do
+      it 'gets the info from GovboxSet' do
         expect(GovboxSet).to receive(:new).with('english', affiliates(:non_existent_affiliate), 'test', site_limits: []).and_return nil
-        @search.run
+        search.run
       end
     end
 
     # TODO: remove this along with the rest of the Bing stuff being deprecated
     #       this temporary spec is only here for code coverage
-    context 'when the affiliate has Bing results'  do
+    context 'when the affiliate has Bing results' do
       subject(:search) do
         affiliate = affiliates(:usagov_affiliate)
         affiliate.search_engine = 'BingV6'
@@ -253,24 +251,25 @@ describe WebSearch do
     end
 
     context 'when the affiliate has no Bing/Google results, but has indexed documents' do
+      let(:non_affiliate) { affiliates(:non_existent_affiliate) }
+
       before do
         ElasticIndexedDocument.recreate_index
-        @non_affiliate = affiliates(:non_existent_affiliate)
-        @non_affiliate.site_domains.create(domain: 'nonsense.com')
-        @non_affiliate.indexed_documents.destroy_all
+        non_affiliate.site_domains.create(domain: 'nonsense.com')
+        non_affiliate.indexed_documents.destroy_all
         1.upto(15) do |index|
-          @non_affiliate.indexed_documents << IndexedDocument.new(title: "Indexed Result no_result #{index}",
-                                                                  url: "http://nonsense.com/#{index}.html",
-                                                                  description: 'This is an indexed result no_result.',
-                                                                  last_crawl_status: IndexedDocument::OK_STATUS)
+          non_affiliate.indexed_documents << IndexedDocument.new(title: "Indexed Result no_result #{index}",
+                                                                 url: "http://nonsense.com/#{index}.html",
+                                                                 description: 'This is an indexed result no_result.',
+                                                                 last_crawl_status: IndexedDocument::OK_STATUS)
         end
         ElasticIndexedDocument.commit
-        expect(@non_affiliate.indexed_documents.size).to eq(15)
-        expect(ElasticIndexedDocument.search_for(q:'indexed', affiliate_id: @non_affiliate.id, language: @non_affiliate.indexing_locale).total).to eq(15)
+        expect(non_affiliate.indexed_documents.size).to eq(15)
+        expect(ElasticIndexedDocument.search_for(q: 'indexed', affiliate_id: non_affiliate.id, language: non_affiliate.indexing_locale).total).to eq(15)
       end
 
       it 'fills the results with the Odie docs' do
-        search = described_class.new(query: 'no_results', affiliate: @non_affiliate)
+        search = described_class.new(query: 'no_results', affiliate: non_affiliate)
         search.run
         expect(search.total).to eq(15)
         expect(search.startrecord).to eq(1)
@@ -279,107 +278,110 @@ describe WebSearch do
         expect(search.results.last['unescapedUrl']).to match(/nonsense.com/)
         expect(search.module_tag).to eq('AIDOC')
       end
-
     end
 
     context 'when affiliate has no Bing/Google results and IndexedDocuments search returns nil' do
+      let(:non_affiliate) { affiliates(:non_existent_affiliate) }
+      let(:search) { described_class.new(query: 'no_results', affiliate: non_affiliate) }
+
       before do
-        @non_affiliate = affiliates(:non_existent_affiliate)
-        @non_affiliate.boosted_contents.destroy_all
+        non_affiliate.boosted_contents.destroy_all
         allow(ElasticIndexedDocument).to receive(:search_for).and_return nil
-        @search = described_class.new(query: 'no_results', affiliate: @non_affiliate)
       end
 
-      it 'should return a search with a zero total' do
-        @search.run
-        expect(@search.total).to eq(0)
-        expect(@search.results).not_to be_nil
-        expect(@search.results).to be_empty
-        expect(@search.startrecord).to be_nil
-        expect(@search.endrecord).to be_nil
+      it 'returns a search with a zero total' do
+        search.run
+        expect(search.total).to eq(0)
+        expect(search.results).not_to be_nil
+        expect(search.results).to be_empty
+        expect(search.startrecord).to be_nil
+        expect(search.endrecord).to be_nil
       end
 
-      it 'should still return true when searching' do
-        expect(@search.run).to be true
+      it 'still returns true when searching' do
+        expect(search.run).to be true
       end
 
-      it 'should populate additional results' do
-        expect(@search).to receive(:populate_additional_results).and_return true
-        @search.run
+      it 'populates additional results' do
+        expect(search).to receive(:populate_additional_results).and_return true
+        search.run
       end
-
     end
 
     context 'when affiliate has no Bing/Google results and there is an orphan document in the Odie index' do
+      let(:non_affiliate) { affiliates(:non_existent_affiliate) }
+
       before do
         ElasticIndexedDocument.recreate_index
-        @non_affiliate = affiliates(:non_existent_affiliate)
-        @non_affiliate.indexed_documents.destroy_all
-        odie = @non_affiliate.indexed_documents.create!(title: 'PDF Title', description: 'PDF Description', url: 'http://nonsense.gov/pdf1.pdf', doctype: 'pdf', last_crawl_status: IndexedDocument::OK_STATUS)
+        non_affiliate.indexed_documents.destroy_all
+        odie = non_affiliate.indexed_documents.create!(title: 'PDF Title', description: 'PDF Description', url: 'http://nonsense.gov/pdf1.pdf', doctype: 'pdf', last_crawl_status: IndexedDocument::OK_STATUS)
         ElasticIndexedDocument.commit
         odie.delete
       end
 
-      it 'should return with zero results' do
-        search = described_class.new(query: 'no_results', affiliate: @non_affiliate)
+      it 'returns with zero results' do
+        search = described_class.new(query: 'no_results', affiliate: non_affiliate)
         search.run
         expect(search.results).to be_blank
       end
-
     end
 
     describe 'ODIE backfill' do
       context 'when we want X Bing/Google results from page Y and there are X of them' do
+        let(:search) { described_class.new(query: 'english', affiliate: affiliate) }
+
         before do
-          @search = described_class.new(query: 'english', affiliate: affiliate)
-          @search.run
+          search.run
         end
 
-        it 'should return the X Bing/Google results' do
-          expect(@search.total).to be > 1000
-          expect(@search.results.size).to eq(20)
-          expect(@search.startrecord).to eq(1)
-          expect(@search.endrecord).to eq(20)
+        it 'returns the X Bing/Google results' do
+          expect(search.total).to be > 1000
+          expect(search.results.size).to eq(20)
+          expect(search.startrecord).to eq(1)
+          expect(search.endrecord).to eq(20)
         end
       end
 
       context 'when we want X Bing/Google results from page Y and there are 0 <= n < X of them' do
+        let(:search) do
+          described_class.new(query: 'odie backfill page 2', affiliate: affiliate, page: 2)
+        end
+
         before do
-          @search = described_class.new(query: 'odie backfill page 2', affiliate: affiliate, page: 2)
           ElasticIndexedDocument.recreate_index
 
           bing_api_url = "#{BingV6WebSearch::API_HOST}#{BingV6WebSearch::API_ENDPOINT}"
           page2_6results = Rails.root.join('spec/fixtures/json/bing_v6/web_search/page2_6results.json').read
           stub_request(:get, /#{bing_api_url}.*odie backfill page 2/).
-            to_return( status: 200,  body: page2_6results)
+            to_return(status: 200, body: page2_6results)
         end
 
         context 'when the affiliate has social image feeds and there are Odie results' do
           before do
             affiliate.indexed_documents.create!(
               title: 'odie backfill page 2', description: 'odie backfill page 2',
-              url: 'http://nonsense.gov', last_crawl_status: IndexedDocument::OK_STATUS)
+              url: 'http://nonsense.gov', last_crawl_status: IndexedDocument::OK_STATUS
+            )
             ElasticIndexedDocument.commit
             allow(affiliate).to receive(:has_social_image_feeds?).and_return true
           end
 
-          it 'should indicate that there is another page of results' do
-            @search.run
-            expect(@search.total).to be >= 20
-            expect(@search.results.size).to be == 6
-            expect(@search.startrecord).to be == 11
-            expect(@search.endrecord).to be == 16
+          it 'indicates that there is another page of results' do
+            search.run
+            expect(search.total).to be >= 20
+            expect(search.results.size).to be == 6
+            expect(search.startrecord).to be == 11
+            expect(search.endrecord).to be == 16
           end
         end
 
         context 'when there are no Odie results' do
-
-          it 'should return the X Bing/Google results' do
-            @search.run
-            expect(@search.total).to be >= 20
-            expect(@search.results.size).to be == 6
-            expect(@search.startrecord).to be == 11
-            expect(@search.endrecord).to be == 16
+          it 'returns the X Bing/Google results' do
+            search.run
+            expect(search.total).to be >= 20
+            expect(search.results.size).to be == 6
+            expect(search.startrecord).to be == 11
+            expect(search.endrecord).to be == 16
           end
         end
       end
@@ -392,8 +394,8 @@ describe WebSearch do
       let(:search) { described_class.new(affiliate: affiliate, query: query) }
 
       before do
-        affiliate.site_domains.create!(domain: included_domain )
-        affiliate.excluded_domains.create!(domain: excluded_domain )
+        affiliate.site_domains.create!(domain: included_domain)
+        affiliate.excluded_domains.create!(domain: excluded_domain)
         search.run
       end
 
@@ -522,7 +524,7 @@ describe WebSearch do
     let(:affiliate) { affiliates(:non_existent_affiliate) }
     let(:search) { described_class.new(query: 'english', affiliate: affiliate) }
 
-    it 'should generate a JSON representation of total, start and end records, and search results' do
+    it 'generates a JSON representation of total, start and end records, and search results' do
       search.run
       json = search.to_json
       expect(json).to match(/total/)
@@ -537,7 +539,7 @@ describe WebSearch do
         search.instance_variable_set(:@error_message, 'Some error')
       end
 
-      it 'should output an error if an error is detected' do
+      it 'outputs an error if an error is detected' do
         json = search.to_json
         expect(json).to match(/"error":"Some error"/)
       end
@@ -551,16 +553,16 @@ describe WebSearch do
         search.run
       end
 
-      it 'should output boosted results' do
+      it 'outputs boosted results' do
         json = search.to_json
         expect(json).to match(%r{boosted <strong>english</strong> content})
       end
     end
 
     context 'when jobs are present' do
-      before do
-        @jobs_array = []
-        @jobs_array << Hashie::Mash.new(
+      let(:jobs_array) do
+        jobs_array = []
+        jobs_array << Hashie::Mash.new(
           id: 'usajobs:12345',
           position_title: 'Physician  (Primary Care - Women Clinic)',
           organization_name: 'Veterans Affairs, Veterans Health Administration',
@@ -572,8 +574,9 @@ describe WebSearch do
           locations: [
             'Memphis, TN', 'Lansing, MI'
           ],
-          url: 'https://www.usajobs.gov/GetJob/ViewDetails/12345')
-        @jobs_array << Hashie::Mash.new(
+          url: 'https://www.usajobs.gov/GetJob/ViewDetails/12345'
+        )
+        jobs_array << Hashie::Mash.new(
           id: 'usajobs:23456',
           position_title: 'PHYSICAL THERAPIST',
           organization_name: 'Veterans Affairs, Veterans Health Administration',
@@ -585,14 +588,18 @@ describe WebSearch do
           locations: [
             'Fulton, MD'
           ],
-          url: 'https://www.usajobs.gov/GetJob/ViewDetails/23456')
-        allow(search).to receive(:jobs).and_return @jobs_array
+          url: 'https://www.usajobs.gov/GetJob/ViewDetails/23456'
+        )
       end
 
-      it 'should output jobs' do
+      before do
+        allow(search).to receive(:jobs).and_return jobs_array
+      end
+
+      it 'outputs jobs' do
         json = search.to_json
         parsed = JSON.parse(json)
-        expect(parsed['jobs'].to_json).to eq(@jobs_array.to_json)
+        expect(parsed['jobs'].to_json).to eq(jobs_array.to_json)
       end
     end
 
@@ -601,7 +608,7 @@ describe WebSearch do
         search.instance_variable_set(:@spelling_suggestion, 'spell it this way')
       end
 
-      it 'should output spelling suggestion' do
+      it 'outputs spelling suggestion' do
         json = search.to_json
         expect(json).to match(/spell it this way/)
       end
@@ -612,7 +619,7 @@ describe WebSearch do
         allow(search).to receive(:related_search).and_return ['also <strong>search</strong> this']
       end
 
-      it 'should output unhighlighted related search' do
+      it 'outputs unhighlighted related search' do
         json = search.to_json
         expect(json).to match(/also search this/)
       end
@@ -623,7 +630,7 @@ describe WebSearch do
     let(:affiliate) { affiliates(:non_existent_affiliate) }
     let(:search) { described_class.new(query: 'english', affiliate: affiliate) }
 
-    it 'should generate a XML representation of total, start and end records, and search results' do
+    it 'generates a XML representation of total, start and end records, and search results' do
       search.run
       xml = search.to_xml
       expect(xml).to match(/total/)
@@ -638,18 +645,17 @@ describe WebSearch do
         search.instance_variable_set(:@error_message, 'Some error')
       end
 
-      it 'should output an error if an error is detected' do
+      it 'outputs an error if an error is detected' do
         xml = search.to_xml
         expect(xml).to match(/Some error/)
       end
     end
-
   end
 
   describe "helper 'has' methods" do
     let(:search) { described_class.new(query: 'english', affiliate: affiliates(:non_existent_affiliate)) }
 
-    it 'should raise an error when no helper can be found' do
+    it 'raises an error when no helper can be found' do
       expect { search.not_here }.to raise_error(NoMethodError)
     end
   end

--- a/spec/models/web_search_spec.rb
+++ b/spec/models/web_search_spec.rb
@@ -82,9 +82,12 @@ describe WebSearch do
 
   describe 'instrumenting search engine calls' do
     context 'when BingV6 is the engine' do
+      let(:valid_options) do
+        { query: 'government', affiliate: affiliate }
+      end
+      let(:bing_search) { BingV6WebSearch.new(valid_options) }
+
       before do
-        valid_options = { query: 'government', affiliate: affiliate }
-        bing_search = BingV6WebSearch.new(valid_options)
         allow(BingV6WebSearch).to receive(:new).and_return bing_search
         allow(bing_search).to receive(:execute_query)
       end

--- a/spec/vcr_cassettes/api_controller_search/options.yml
+++ b/spec/vcr_cassettes/api_controller_search/options.yml
@@ -2,72 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.googleapis.com/customsearch/v1?alt=json&cx=<GOOGLE_SEARCH_CX>&key=<GOOGLE_API_KEY>&lr=lang_en&q=fish%20site:nps.gov&quotaUser=USASearch&safe=medium
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - USASearch
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      Connection:
-      - keep-alive
-      Keep-Alive:
-      - '30'
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 26 Apr 2018 23:28:53 GMT
-      Expires:
-      - Thu, 26 Apr 2018 23:28:53 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303433; quic=51303432; quic=51303431; quic=51303339;
-        quic=51303335,quic=":443"; ma=2592000; v="43,42,41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "usageLimits",
-            "reason": "accessNotConfigured",
-            "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
-            "extendedHelp": "https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333"
-           }
-          ],
-          "code": 403,
-          "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 26 Apr 2018 23:28:53 GMT
-- request:
-    method: get
-    uri: https://www.bingapis.com/api/v6/search?AppId=<BING_V6_APP_ID>&count=20&mkt=en-US&offset=0&q=fish%20(site:nps.gov)&responseFilter=WebPages,SpellSuggestions&safeSearch=moderate&textDecorations=true&traffictype=test
+    uri: https://api.cognitive.microsoft.com/bing/v7.0/search?count=20&mkt=en-US&offset=0&q=fish%20(site:nps.gov)&responseFilter=WebPages&safeSearch=moderate&textDecorations=true&traffictype=test
     body:
       encoding: US-ASCII
       string: ''
@@ -75,7 +10,7 @@ http_interactions:
       User-Agent:
       - USASearch
       Ocp-Apim-Subscription-Key:
-      - "<BING_V6_APP_ID>"
+      - "<BING_V7_SUBSCRIPTION_ID>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -91,202 +26,249 @@ http_interactions:
     headers:
       Cache-Control:
       - private, max-age=0
-      Content-Length:
-      - '3422'
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
-      - Fri, 27 Apr 2018 16:01:45 GMT
+      - Wed, 09 Jun 2021 14:04:02 GMT
       Vary:
       - Accept-Encoding
       P3p:
       - CP="NON UNI COM NAV STA LOC CURa DEVa PSAa PSDa OUR IND"
-      Set-Cookie:
-      - MUID=28A7111CB2FB693A1E2F1AC2B36C68B6; path=/; expires=Wed, 22-May-2019 16:02:46
-        GMT; domain=bingapis.com
-      - MUIDB=28A7111CB2FB693A1E2F1AC2B36C68B6; path=/; httponly; expires=Wed, 22-May-2019
-        16:02:46 GMT
-      - SRCHD=AF=NOFORM; domain=.bingapis.com; expires=Mon, 27-Apr-2020 16:02:45 GMT;
-        path=/
-      - SRCHUID=V=2&GUID=07A68F3C1338452ABD771B8B07AAA378&dmnchg=1; domain=.bingapis.com;
-        expires=Mon, 27-Apr-2020 16:02:45 GMT; path=/
-      - SRCHUSR=DOB=20180427; domain=.bingapis.com; expires=Mon, 27-Apr-2020 16:02:45
-        GMT; path=/
-      - _EDGE_S=mkt=en-us&F=1&SID=005BE6C980DE6DA61DF0ED1781496C63; path=/; httponly;
-        domain=bingapis.com
-      - _EDGE_V=1; path=/; httponly; expires=Wed, 22-May-2019 16:02:46 GMT; domain=bingapis.com
-      - _SS=SID=005BE6C980DE6DA61DF0ED1781496C63; domain=.bingapis.com; path=/
+      X-Snr-Routing:
+      - '1'
       Bingapis-Traceid:
-      - EEC6FC55F6C04D70B71D77138159B3BE
+      - 006B1BC305DD4E2796922C570B9E1446
+      Bingapis-Sessionid:
+      - D6B7074249A54108BF0DD104B685101B
       X-Msedge-Clientid:
-      - 28A7111CB2FB693A1E2F1AC2B36C68B6
+      - 14A780CBCACB6EF80708909ACBD96FC0
       X-Msapi-Userstate:
-      - 13f8
+      - bd95
       Bingapis-Market:
       - en-US
+      X-Search-Responseinfo:
+      - InternalResponseTime=232,MSDatacenter=BN2B
+      X-Cache:
+      - CONFIG_NOCACHE
       X-Msedge-Ref:
-      - 'Ref A: EEC6FC55F6C04D70B71D77138159B3BE Ref B: CO1EDGE0121 Ref C: 2018-04-27T16:02:46Z'
+      - 'Ref A: 006B1BC305DD4E2796922C570B9E1446 Ref B: BLUEDGE1620 Ref C: 2021-06-09T14:05:02Z'
+      Apim-Request-Id:
+      - 7f50dba7-0d57-4ad5-bbe7-6ccf8273428a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Csp-Billing-Usage:
+      - CognitiveServices.BingSearchV7.Transaction=1
       Date:
-      - Fri, 27 Apr 2018 16:02:45 GMT
+      - Wed, 09 Jun 2021 14:05:01 GMT
     body:
       encoding: UTF-8
-      string: '{"_type": "SearchResponse", "instrumentation": {"pingUrlBase": "https:\/\/www.bingapis.com\/api\/ping?IG=2782CC85C06C4FAA93265DAC8B103500&CID=28A7111CB2FB693A1E2F1AC2B36C68B6&ID=",
-        "pageLoadPingUrl": "https:\/\/www.bingapis.com\/api\/ping\/pageload?IG=2782CC85C06C4FAA93265DAC8B103500&CID=28A7111CB2FB693A1E2F1AC2B36C68B6&Type=Event.CPT&DATA=0"},
-        "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=fish+(site%3anps.gov)",
-        "webSearchUrlPingSuffix": "DevEx,5537.1", "totalEstimatedMatches": 2160000,
-        "value": [{"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.0", "name":
-        "Fish - Rocky Mountain National Park (U.S. National Park ...", "url": "https:\/\/www.nps.gov\/romo\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5092.1", "displayUrl": "https:\/\/www.nps.gov\/romo\/learn\/nature\/fish.htm",
-        "snippet": "Fish known to be native to the area that became Rocky Mountain
-        National Park were cutthroat trout, suckers and sculpins. These fish were
-        only historically found in the lower reaches of what would become the park
-        due to waterfalls and cascades which served as fish migration barriers.",
-        "dateLastCrawled": "2018-04-18T17:21:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.1",
-        "name": "Fish - Glacier National Park (U.S. National Park Service)",
-        "url": "https:\/\/www.nps.gov\/glac\/learn\/nature\/fish.htm", "urlPingSuffix":
-        "DevEx,5109.1", "displayUrl": "https:\/\/www.nps.gov\/glac\/learn\/nature\/fish.htm",
-        "snippet": "Bull trout in St. Mary drainage . Shannon Downey \/ USFWS. The
-        historic assemblage of fish species in Glacier National Park is restricted
-        in number due to the relatively recent withdrawal of continental glaciers
-        from the region.", "dateLastCrawled": "2018-04-22T14:28:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.2", "name": "Fish - Olympic
-        National Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/olym\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5128.1", "displayUrl": "https:\/\/www.nps.gov\/olym\/learn\/nature\/fish.htm",
-        "snippet": "Sockeye Salmon . If rivers are the veins of Olympic National Park,
-        then salmon are the blood coursing through them, delivering essential nutrients
-        from the sea to freshwater and forest ecosystems.", "dateLastCrawled": "2018-04-22T22:05:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.3", "name": "Fish
-        - Zion National Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/zion\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5144.1", "displayUrl": "https:\/\/www.nps.gov\/zion\/learn\/nature\/fish.htm",
-        "snippet": "The Virgin River Habitat. Flowing through Zion National Park are
-        the North and East forks of the Virgin River and their various tributaries.
-        These streams are all part of the Virgin River drainage, which is part of
-        the larger Colorado River Basin.", "dateLastCrawled": "2018-04-19T18:15:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.4", "name": "Fish
-        - Capitol Reef National Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/care\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5160.1", "displayUrl": "https:\/\/www.nps.gov\/care\/learn\/nature\/fish.htm",
-        "snippet": "SALMONIDAE-- Trout & Chars. Brown Trout (Salmo trutta): Brown
-        trout are native to Europe and western Asia and are found in the park in the
-        Fremont River.They are piscivorous (fish-eating) but also consume amphibians,
-        rodents, and invertebrates, including insects, snails, and crayfish.", "dateLastCrawled":
-        "2018-04-09T04:32:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.5",
-        "name": "Fish - Yosemite National Park (U.S. National Park Service)",
-        "url": "https:\/\/www.nps.gov\/yose\/learn\/nature\/fish.htm", "urlPingSuffix":
-        "DevEx,5177.1", "displayUrl": "https:\/\/www.nps.gov\/yose\/learn\/nature\/fish.htm",
-        "snippet": "Native fish are only found in the lower elevations of Yosemite.
-        Native fish—including California roach, Sacramento pikeminnow, hardhead,
-        and riffle sculpin—inhabit the lower reaches of the Merced River up to the
-        vicinity of El Portal.", "dateLastCrawled": "2018-04-19T19:01:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.6", "name": "Fish
-        - Mount Rainier National Park (U.S. National Park ...", "url": "https:\/\/www.nps.gov\/mora\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5194.1", "displayUrl": "https:\/\/www.nps.gov\/mora\/learn\/nature\/fish.htm",
-        "snippet": "Rainbow Trout US Fish & Wildlife Service. Rainbow Trout \/ Steelhead
-        Oncorhyncus mykiss. These two fish are the same species, but Rainbow trout
-        live entirely in freshwater while Steelhead trout are ocean-living and only
-        spawn in freshwater.", "dateLastCrawled": "2018-04-18T14:05:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.7", "name": "Fish
-        - Colonial National Historical Park (U.S. National ...", "url": "https:\/\/www.nps.gov\/colo\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5210.1", "displayUrl": "https:\/\/www.nps.gov\/colo\/learn\/nature\/fish.htm",
-        "snippet": "Waters surrounding this park are rich with a large number of fish
-        species that are harvested commercially for consumption. The York River is
-        saltier than the James and supports different species.", "dateLastCrawled":
-        "2018-04-16T07:52:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.8",
-        "name": "Fish - Biscayne National Park (U.S. National Park Service)",
-        "url": "https:\/\/www.nps.gov\/bisc\/learn\/nature\/fish.htm", "urlPingSuffix":
-        "DevEx,5227.1", "displayUrl": "https:\/\/www.nps.gov\/bisc\/learn\/nature\/fish.htm",
-        "snippet": "Fauna include both temperate and tropical species. The fish
-        are primarily marine species. Some freshwater species, documented in canals
-        that empty into the park, ...", "dateLastCrawled": "2018-04-21T05:15:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.9", "name": "Fish
-        - Death Valley National Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/deva\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5244.1", "displayUrl": "https:\/\/www.nps.gov\/deva\/learn\/nature\/fish.htm",
-        "snippet": "Fish. Pupfish at Salt Creek are easily viewed during the springtime
-        mating season. amargosa pupfish Cyprinodon nevadensis amargosa Found in the
-        Amargosa River ...", "dateLastCrawled": "2018-04-22T08:31:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.10", "name": "Fish - Great
-        Smoky Mountains National Park (U.S. National ...", "url": "https:\/\/www.nps.gov\/grsm\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5261.1", "about": [{"name": "Great Smoky Mountains
-        National Park"}], "displayUrl": "https:\/\/www.nps.gov\/grsm\/learn\/nature\/fish.htm",
-        "snippet": "The Great Smoky Mountains National Park boasts over 2,100 miles
-        of streams and is home to 67 species of fish in 12 different families, including
-        lampreys, ...", "dateLastCrawled": "2018-04-22T07:02:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.11", "name": "Fish - Wrangell
-        - St Elias National Park & Preserve (U.S ...", "url": "https:\/\/www.nps.gov\/wrst\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5278.1", "displayUrl": "https:\/\/www.nps.gov\/wrst\/learn\/nature\/fish.htm",
-        "snippet": "Fish Surveys. A freshwater fish survey was done in Wrangell-St.
-        Elias in 2001-2003 (this report contains information from Denali National
-        Park and Preserve and Yukon ...", "dateLastCrawled": "2018-04-11T15:33:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.12", "name": "Fish
-        - Big Hole National Battlefield (U.S. National Park ...", "url": "https:\/\/www.nps.gov\/biho\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5294.1", "displayUrl": "https:\/\/www.nps.gov\/biho\/learn\/nature\/fish.htm",
-        "snippet": "nature, animals, fish, battlefield, american indians, nez perce,
-        military", "dateLastCrawled": "2018-04-19T08:29:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.13",
-        "name": "Fish - Glen Canyon National Recreation Area (U.S. National ...",
-        "url": "https:\/\/www.nps.gov\/glca\/learn\/nature\/fish.htm", "urlPingSuffix":
-        "DevEx,5311.1", "displayUrl": "https:\/\/www.nps.gov\/glca\/learn\/nature\/fish.htm",
-        "snippet": "The fish that lived here before Glen Canyon Dam was built are
-        being pushed out of their habitat. Take care if you see one. Last updated:
-        November 29, 2017.", "dateLastCrawled": "2018-04-16T03:44:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14", "name": "Fishing - Everglades
-        National Park (U.S. National Park ...", "url": "https:\/\/www.nps.gov\/ever\/planyourvisit\/fishing.htm",
-        "urlPingSuffix": "DevEx,5328.1", "about": [{"name": "Everglades National Park"}],
-        "displayUrl": "https:\/\/www.nps.gov\/ever\/planyourvisit\/fishing.htm",
-        "snippet": "One third of Everglades National Park is covered by water, ...
-        Florida Fish and Wildlife Conservation Commission Fishing in Florida website.",
-        "dateLastCrawled": "2018-04-20T10:59:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15",
-        "name": "Fish - Grand Canyon National Park (U.S. National Park Service)",
-        "url": "https:\/\/www.nps.gov\/grca\/learn\/nature\/fish.htm", "urlPingSuffix":
-        "DevEx,5345.1", "displayUrl": "https:\/\/www.nps.gov\/grca\/learn\/nature\/fish.htm",
-        "snippet": "NPS photo by Kristen M. Caldon. The Colorado River running through
-        Grand Canyon once hosted one of the most distinctive fish assemblages in
-        North America.", "dateLastCrawled": "2018-04-19T18:08:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16", "name": "Fish - Missouri
-        National Recreational River (U.S. National ...", "url": "https:\/\/www.nps.gov\/mnrr\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5361.1", "displayUrl": "https:\/\/www.nps.gov\/mnrr\/learn\/nature\/fish.htm",
-        "snippet": "Native fish on the Missouri National Recreational River are
-        relatively productive and dominated by cool and warmwater species, including
-        catfish, sauger, suckers, and naturally reproducing populations of paddlefish.",
-        "dateLastCrawled": "2018-04-16T10:27:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.17",
-        "name": "Fish - Shenandoah National Park (U.S. National Park Service)",
-        "url": "https:\/\/www.nps.gov\/shen\/learn\/nature\/fish.htm", "urlPingSuffix":
-        "DevEx,5378.1", "displayUrl": "https:\/\/www.nps.gov\/shen\/learn\/nature\/fish.htm",
-        "snippet": "Black Nosed Dace . Thirty-eight species of fish have been recorded
-        in park waters. The mountain streams of the park are one of the last completely
-        protected strongholds of the native eastern brook trout (Salvinus fontinalis).",
-        "dateLastCrawled": "2018-04-14T12:21:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.18",
-        "name": "Fish - Everglades National Park (U.S. National Park Service)",
-        "url": "https:\/\/www.nps.gov\/ever\/learn\/nature\/fish.htm", "urlPingSuffix":
-        "DevEx,5395.1", "displayUrl": "https:\/\/www.nps.gov\/ever\/learn\/nature\/fish.htm",
-        "snippet": "Gulf toadfish. Photo courtesy Texas Parks and Wildlife Department.
-        From the time of the earliest occupation of the Everglades, fish have served
-        as an important staple for locals.", "dateLastCrawled": "2018-04-20T16:26:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.19", "name": "Fish
-        - Padre Island National Seashore (U.S. National Park ...", "url": "https:\/\/www.nps.gov\/pais\/learn\/nature\/fish.htm",
-        "urlPingSuffix": "DevEx,5412.1", "displayUrl": "https:\/\/www.nps.gov\/pais\/learn\/nature\/fish.htm",
-        "snippet": "Lookdown in the Malaquite Visitor Center viewing aquarium. NPS
-        Photo. The following 149 species of fish have been documented at the National
-        Seashore by our Resources Management staff.", "dateLastCrawled": "2018-04-19T06:33:00.0000000Z"}]},
-        "rankingResponse": {"mainline": {"items": [{"answerType": "WebPages", "resultIndex":
-        0, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.0"}}, {"answerType":
-        "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.1"}},
-        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.2"}},
-        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.3"}},
-        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.4"}},
-        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.5"}},
-        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.6"}},
-        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.7"}},
-        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.8"}},
-        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.9"}},
-        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.10"}},
-        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.11"}},
-        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.12"}},
-        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.13"}},
-        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14"}},
-        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15"}},
-        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16"}},
-        {"answerType": "WebPages", "resultIndex": 17, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.17"}},
-        {"answerType": "WebPages", "resultIndex": 18, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.18"}},
-        {"answerType": "WebPages", "resultIndex": 19, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.19"}}]}}}'
-    http_version: 
-  recorded_at: Fri, 27 Apr 2018 16:02:46 GMT
+      string: '{"_type": "SearchResponse", "queryContext": {"originalQuery": "fish
+        (site:nps.gov)"}, "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=fish+(site%3anps.gov)",
+        "totalEstimatedMatches": 1870000, "value": [{"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0",
+        "name": "Fish - Rocky Mountain National Park (U.S. National Park ...", "url":
+        "https:\/\/www.nps.gov\/romo\/learn\/nature\/fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/romo\/learn\/nature\/fish.htm",
+        "snippet": "Fish. Fish known to be native to the area that became Rocky
+        Mountain National Park were cutthroat trout, suckers and sculpins. These fish
+        were only historically found in the lower reaches of what would become the
+        park due to waterfalls and cascades which served as fish migration barriers.
+        Cold water temperatures make it probable that many of ...", "dateLastCrawled":
+        "2021-04-28T02:19:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1", "name":
+        "Fish - Capitol Reef National Park (U.S. National Park Service)", "url":
+        "https:\/\/www.nps.gov\/care\/learn\/nature\/fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/care\/learn\/nature\/fish.htm",
+        "snippet": "Fish. Much of the Capitol Reef region is considered “high desert,”
+        with an average of 8 inches (20.3 cm) of precipitation a year. Despite this
+        classification, there are a few perennial (year-round) water sources, like
+        the Fremont River and Sulphur Creek, that can support fish populations.
+        The park is home to several species, some native and ...", "dateLastCrawled":
+        "2021-04-14T06:43:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2", "name":
+        "Fish - Mount Rainier National Park (U.S. National Park ...", "url": "https:\/\/www.nps.gov\/mora\/learn\/nature\/fish.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/mora\/learn\/nature\/fish.htm",
+        "snippet": "Native Fish at Mount Rainier National Park. A native species
+        is defined as one that is naturally occurring in the ecosystem, has the capability
+        of self-sustaining its population, and has evolved alongside unique environments.",
+        "dateLastCrawled": "2020-12-22T10:30:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3",
+        "name": "Jawless Fish - Fish & Fishing (U.S. National Park Service)",
+        "url": "https:\/\/www.nps.gov\/subjects\/fishing\/jawless-fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/subjects\/fishing\/jawless-fish.htm",
+        "snippet": "Jawless Fish. Jawless fish are the most primitive fishes living
+        today. Jawless fish: Lack jaws. Feed by suction with the help of a round
+        muscular mouth and rows of teeth. Have cylindrical and long bodies. Do not
+        have paired fins and scales like most fish. There are two categories of
+        jawless fish: hagfish and lampreys.", "dateLastCrawled": "2020-12-05T04:03:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4",
+        "name": "Fish - Canyonlands National Park (U.S. National Park Service)",
+        "url": "https:\/\/www.nps.gov\/cany\/learn\/nature\/fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/cany\/learn\/nature\/fish.htm",
+        "snippet": "Today, non-native fish dominate the rivers. One study done at
+        the Confluence in Canyonlands found 95 percent of the fish to be non-native.
+        Carp and channel catfish are the most commonly seen. Carp are native to Asia
+        and were hailed as the greatest food fish ever by the U.S. Bureau of Fisheries.",
+        "dateLastCrawled": "2021-02-21T10:33:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5",
+        "name": "Catch and Release Fishing - Fish & Fishing (U.S. National ...",
+        "url": "https:\/\/www.nps.gov\/subjects\/fishing\/catch-and-release-fishing.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/subjects\/fishing\/catch-and-release-fishing.htm",
+        "snippet": "Removing fish from water causes stress, suffocation, and possible
+        internal injury. Use wet hands or gloves to handle fish. Wet hands or gloves
+        will help reduce the loss of a fish’s protective mucus. Provide proper support.
+        Avoid removing fish from the support of the surrounding water any more than
+        necessary.", "dateLastCrawled": "2021-02-08T17:57:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6",
+        "name": "Fish - Isle Royale National Park (U.S. National Park Service)",
+        "url": "https:\/\/www.nps.gov\/isro\/learn\/nature\/fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/isro\/learn\/nature\/fish.htm",
+        "snippet": "The species is thought to be a surviving remnant of fish species
+        that transitioned from soft rayed fish such as herring or trout to spiny
+        rayed fish such as perch and walleye. Did you also know that the burbot,
+        also known by several other names including eelpout, dogfish, lawyer, and
+        ling is the only member of the cod family - Gadidae - that ...", "dateLastCrawled":
+        "2021-01-04T04:26:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7", "name":
+        "Fishing - Everglades National Park (U.S. National Park ...", "url": "https:\/\/www.nps.gov\/ever\/planyourvisit\/fishing.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/ever\/planyourvisit\/fishing.htm",
+        "snippet": "Fishing in a nutshell Freshwater Fishing. License: A Florida freshwater
+        fishing license is required to fish in freshwater or to possess fresh water
+        species.; Bait: Live or dead fish (including minnows and shiners) or amphibians,
+        and non-preserved fish eggs or roe, are prohibited.Digging for bait inside
+        the park is not permitted. Closed to Fishing: No fishing is allowed at the
+        Ernest F. Coe ...", "dateLastCrawled": "2021-06-01T20:23:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8",
+        "name": "Fishing - Valles Caldera National Preserve (U.S. National ...",
+        "url": "https:\/\/www.nps.gov\/vall\/planyourvisit\/fishing.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/vall\/planyourvisit\/fishing.htm",
+        "snippet": "To fish inside the preserve, anglers must have a fishing permit
+        issued by the preserve as well as a valid New Mexico Fishing License. Due
+        to COVID-19, we now offer an electronic annual fishing special use permit
+        that will be valid through March 31, 2022 in addition to single-day use fishing
+        permits that are issued on site.", "dateLastCrawled": "2021-05-10T07:45:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9",
+        "name": "Fishing - Crater Lake National Park (U.S. National Park ...", "url":
+        "https:\/\/www.nps.gov\/crla\/planyourvisit\/fishing.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/crla\/planyourvisit\/fishing.htm",
+        "snippet": "There is no evidence that native fish ever lived in Crater Lake.
+        However, between 1888 and 1941 the lake was stocked with seven different species
+        of fish, only two of those species thrive today. It is currently estimated
+        that the lake supports approximately 60,000 kokanee salmon (Oncorhynchus nerka;
+        landlocked sockeye salmon) and rainbow trout.", "dateLastCrawled": "2021-05-10T21:27:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10",
+        "name": "Fish - Death Valley National Park (U.S. National Park Service)",
+        "url": "https:\/\/www.nps.gov\/deva\/learn\/nature\/fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/deva\/learn\/nature\/fish.htm",
+        "snippet": "Fish. Found in Devils Hole, 37 miles east of Furnace Creek,
+        in western Nevada. Found in Salt Creek in the central part of Death Valley.
+        A boardwalk along the Salt Creek Interpretive Trail allows for easy viewing
+        of the fish in Winter and Spring. Found in Cottonball Marsh on the west
+        side of central Death Valley.", "dateLastCrawled": "2021-02-21T09:33:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11",
+        "name": "Fish of the Mississippi River - Mississippi National River ...",
+        "url": "https:\/\/www.nps.gov\/miss\/learn\/nature\/fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/miss\/learn\/nature\/fish.htm",
+        "snippet": "Fish supply food for otters, eagles, humans, and other fish.
+        Some are critical to the life cycle of mussels. Their presence (or absence)
+        says much about water quality. More than 120 species of fish inhabit the
+        river below St. Anthony Falls, a diversity made possible by the many habitats
+        available in currents, pools, and backwaters.", "dateLastCrawled": "2021-05-30T18:14:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12",
+        "name": "Fish - Obed Wild & Scenic River (U.S. National Park Service)",
+        "url": "https:\/\/www.nps.gov\/obed\/learn\/nature\/fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/obed\/learn\/nature\/fish.htm",
+        "snippet": "Flatheads are predatory fish and will consume bass, bream, shad,
+        crayfish, and even other catfish. Spawning for the flathead occurs in late
+        spring when water temperatures reach 70 degrees. One or both parents excavate
+        the nest that is usually made in a natural cavity or near a large, submerged
+        object. The nest is guarded and up to 100,000 eggs ...", "dateLastCrawled":
+        "2020-08-07T14:45:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13", "name":
+        "Fish - Redwood National and State Parks (U.S. National ...", "url": "https:\/\/www.nps.gov\/redw\/learn\/nature\/fish.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/redw\/learn\/nature\/fish.htm",
+        "snippet": "Obviously, fish are some of the most difficult wildlife to observe,
+        but with determination and good timing, some of the more spectacular or interesting
+        native fish species can be added to your park wildlife “I-saw-that” list.
+        The most famous and showiest native fish are the salmon and trout that glide
+        through park streams. Most parks salmon ...", "dateLastCrawled": "2020-12-25T15:56:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14",
+        "name": "Fish - Zion National Park (U.S. National Park Service)", "url":
+        "https:\/\/www.nps.gov\/zion\/learn\/nature\/fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/zion\/learn\/nature\/fish.htm",
+        "snippet": "The fish of the Virgin River drainage have evolved adaptations
+        to the unique local conditions, including heavy silt loads, frequent floods,
+        and wide fluctuations in water temperature and discharge. Unfortunately, outside
+        of the park the native fish of the Virgin River have experienced population
+        declines due to habitat fragmentation and the ...", "dateLastCrawled": "2020-11-28T01:29:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15",
+        "name": "Fishing - Lake Mead National Recreation Area (U.S ...", "url":
+        "https:\/\/www.nps.gov\/lake\/planyourvisit\/fishing.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/lake\/planyourvisit\/fishing.htm",
+        "snippet": "Fish cleaning stations are located at Hemenway Harbor, Callville
+        Bay, Echo Bay, Temple Bar, Willow Beach, Cottonwood Cove and Katherine Landing.
+        Please dispose of fish guts properly. Please do not place them on the ground
+        or feed them to wild animals.", "dateLastCrawled": "2021-06-06T13:07:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16",
+        "name": "Freshwater Drum\/Sheepshead (Aplodinotus grunniens ...", "url":
+        "https:\/\/www.nps.gov\/miss\/learn\/nature\/freshwater-drum-sheepshead-aplodinotus-grunniens.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/miss\/learn\/nature\/freshwater-drum-sheepshead-aplodinotus-grunniens.htm",
+        "snippet": "Fish of the Mississippi River. Introduction. The freshwater
+        drum is a fish known for its noise. Males make a grunting or rumbling sound
+        during the breeding season, which is thought to attract females. That noisiness
+        generated many colorful nicknames, including croaker, thunder pumper, grunter,
+        grinder, bubbler.", "dateLastCrawled": "2021-05-12T15:26:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17",
+        "name": "Fish - Grand Teton National Park (U.S. National Park Service)",
+        "url": "https:\/\/www.nps.gov\/grte\/learn\/nature\/fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/grte\/learn\/nature\/fish.htm",
+        "snippet": "Fish in turn control plant and insect populations. The well-being
+        of fish worldwide is threatened by pollution, loss of habitat and overfishing.
+        Grand Teton National Park has a worldwide reputation for its excellent trout
+        fishing. Of the five species of trout present in the park, however, only the
+        Snake River cutthroat trout is native.", "dateLastCrawled": "2021-03-02T23:24:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18",
+        "name": "Fish - North Cascades National Park (U.S. National Park ...", "url":
+        "https:\/\/www.nps.gov\/noca\/learn\/nature\/fish.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/noca\/learn\/nature\/fish.htm",
+        "snippet": "While thousands of fish return each year, many salmon runs have
+        been in decline for many years as a result of logging, dams, over-harvesting,
+        cross-breeding with genetically inferior hatchery fish and a variety of
+        other factors. Both Puget Sound Chinook salmon and Coastal Puget Sound bull
+        trout (char) were listed as a threatened species in 1999.", "dateLastCrawled":
+        "2021-05-27T19:34:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19", "name":
+        "Fish - Glacier National Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/glac\/learn\/nature\/fish.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/glac\/learn\/nature\/fish.htm",
+        "snippet": "Fish. The historic assemblage of fish species in Glacier National
+        Park is restricted in number due to the relatively recent withdrawal of continental
+        glaciers from the region. The human urge to tinker with natural systems is
+        no better illustrated than in the park fishery, which has been radically changed
+        by human manipulations.", "dateLastCrawled": "2021-03-21T22:13:00.0000000Z",
+        "language": "en", "isNavigational": false}]}, "rankingResponse": {"mainline":
+        {"items": [{"answerType": "WebPages", "resultIndex": 0, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0"}},
+        {"answerType": "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1"}},
+        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2"}},
+        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3"}},
+        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4"}},
+        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5"}},
+        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6"}},
+        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7"}},
+        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8"}},
+        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9"}},
+        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10"}},
+        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11"}},
+        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12"}},
+        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13"}},
+        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14"}},
+        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15"}},
+        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16"}},
+        {"answerType": "WebPages", "resultIndex": 17, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17"}},
+        {"answerType": "WebPages", "resultIndex": 18, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18"}},
+        {"answerType": "WebPages", "resultIndex": 19, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19"}}]}}}'
+    http_version:
+  recorded_at: Wed, 09 Jun 2021 14:05:02 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/searches_controller/searching_on_a_routed_keyword_referrer_matches_redirect_url_it_should_behave_like_a_routed_query_that_matches_the_referrer.yml
+++ b/spec/vcr_cassettes/searches_controller/searching_on_a_routed_keyword_referrer_matches_redirect_url_it_should_behave_like_a_routed_query_that_matches_the_referrer.yml
@@ -2,136 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.googleapis.com/customsearch/v1?alt=json&cx=<GOOGLE_SEARCH_CX>&key=<GOOGLE_API_KEY>&lr=lang_en&q=foo%20bar&quotaUser=USASearch&safe=medium
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - USASearch
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      Connection:
-      - keep-alive
-      Keep-Alive:
-      - '30'
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 22 Mar 2018 23:02:00 GMT
-      Expires:
-      - Thu, 22 Mar 2018 23:02:00 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303432; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="42,41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "usageLimits",
-            "reason": "keyInvalid",
-            "message": "Bad Request"
-           }
-          ],
-          "code": 400,
-          "message": "Bad Request"
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 22 Mar 2018 23:02:00 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/customsearch/v1?alt=json&cx=<GOOGLE_SEARCH_CX>&key=<GOOGLE_API_KEY>&lr=lang_en&q=foo%20bar%20site:nps.gov&quotaUser=USASearch&safe=medium
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - USASearch
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      Connection:
-      - keep-alive
-      Keep-Alive:
-      - '30'
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 26 Apr 2018 23:29:11 GMT
-      Expires:
-      - Thu, 26 Apr 2018 23:29:11 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303433; quic=51303432; quic=51303431; quic=51303339;
-        quic=51303335,quic=":443"; ma=2592000; v="43,42,41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "usageLimits",
-            "reason": "accessNotConfigured",
-            "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
-            "extendedHelp": "https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333"
-           }
-          ],
-          "code": 403,
-          "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 26 Apr 2018 23:29:11 GMT
-- request:
-    method: get
-    uri: https://www.bingapis.com/api/v6/search?AppId=<BING_V6_APP_ID>&count=20&mkt=en-US&offset=0&q=foo%20bar%20(site:nps.gov)&responseFilter=WebPages,SpellSuggestions&safeSearch=moderate&textDecorations=true&traffictype=test
+    uri: https://api.cognitive.microsoft.com/bing/v7.0/search?count=20&mkt=en-US&offset=0&q=foo%20bar%20(site:nps.gov)&responseFilter=WebPages&safeSearch=moderate&textDecorations=true&traffictype=test
     body:
       encoding: US-ASCII
       string: ''
@@ -139,7 +10,7 @@ http_interactions:
       User-Agent:
       - USASearch
       Ocp-Apim-Subscription-Key:
-      - "<BING_V6_APP_ID>"
+      - "<BING_V7_SUBSCRIPTION_ID>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -155,167 +26,213 @@ http_interactions:
     headers:
       Cache-Control:
       - private, max-age=0
-      Content-Length:
-      - '3442'
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
-      - Fri, 27 Apr 2018 16:01:59 GMT
+      - Wed, 09 Jun 2021 14:03:04 GMT
       Vary:
       - Accept-Encoding
       P3p:
       - CP="NON UNI COM NAV STA LOC CURa DEVa PSAa PSDa OUR IND"
-      Set-Cookie:
-      - MUID=3F08A82E2840667819E9A3F029D76794; path=/; expires=Wed, 22-May-2019 16:02:59
-        GMT; domain=bingapis.com
-      - MUIDB=3F08A82E2840667819E9A3F029D76794; path=/; httponly; expires=Wed, 22-May-2019
-        16:02:59 GMT
-      - SRCHD=AF=NOFORM; domain=.bingapis.com; expires=Mon, 27-Apr-2020 16:02:59 GMT;
-        path=/
-      - SRCHUID=V=2&GUID=84F299E5ABEA48F1BE93B32FA240271D&dmnchg=1; domain=.bingapis.com;
-        expires=Mon, 27-Apr-2020 16:02:59 GMT; path=/
-      - SRCHUSR=DOB=20180427; domain=.bingapis.com; expires=Mon, 27-Apr-2020 16:02:59
-        GMT; path=/
-      - _EDGE_S=mkt=en-us&F=1&SID=22DF529F4C28659B393559414DBF6476; path=/; httponly;
-        domain=bingapis.com
-      - _EDGE_V=1; path=/; httponly; expires=Wed, 22-May-2019 16:02:59 GMT; domain=bingapis.com
-      - _SS=SID=22DF529F4C28659B393559414DBF6476; domain=.bingapis.com; path=/
+      X-Snr-Routing:
+      - '1'
       Bingapis-Traceid:
-      - 0C3814E4169346F7A857AC411FB9969E
+      - AB513CA98C3140C8B695DAB5072A2C89
+      Bingapis-Sessionid:
+      - EC7D93B9AD904F09852FC24C1CC447EA
       X-Msedge-Clientid:
-      - 3F08A82E2840667819E9A3F029D76794
+      - 354C5EF819F7688237684EA918B8692B
       X-Msapi-Userstate:
-      - ef72
+      - 26b5
       Bingapis-Market:
       - en-US
+      X-Search-Responseinfo:
+      - InternalResponseTime=310,MSDatacenter=BN2B
+      X-Cache:
+      - CONFIG_NOCACHE
       X-Msedge-Ref:
-      - 'Ref A: 0C3814E4169346F7A857AC411FB9969E Ref B: CO1EDGE0216 Ref C: 2018-04-27T16:02:59Z'
+      - 'Ref A: AB513CA98C3140C8B695DAB5072A2C89 Ref B: BLUEDGE2012 Ref C: 2021-06-09T14:04:04Z'
+      Apim-Request-Id:
+      - 6284cbb5-c151-4d65-b378-af6d9901046e
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Csp-Billing-Usage:
+      - CognitiveServices.BingSearchV7.Transaction=1
       Date:
-      - Fri, 27 Apr 2018 16:02:58 GMT
+      - Wed, 09 Jun 2021 14:04:04 GMT
     body:
       encoding: UTF-8
-      string: '{"_type": "SearchResponse", "instrumentation": {"pingUrlBase": "https:\/\/www.bingapis.com\/api\/ping?IG=AA8407C2269C4F358D2B7EEE59B75AAF&CID=3F08A82E2840667819E9A3F029D76794&ID=",
-        "pageLoadPingUrl": "https:\/\/www.bingapis.com\/api\/ping\/pageload?IG=AA8407C2269C4F358D2B7EEE59B75AAF&CID=3F08A82E2840667819E9A3F029D76794&Type=Event.CPT&DATA=0"},
-        "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=foo+bar+(site%3anps.gov)",
-        "webSearchUrlPingSuffix": "DevEx,5395.1", "totalEstimatedMatches": 17, "value":
-        [{"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.0", "name": "CodeMirror
-        2: JavaScript mode - National Park Service", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/mode\/xquery\/index.html",
-        "urlPingSuffix": "DevEx,5076.1", "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/...",
-        "snippet": "Development of the CodeMirror XQuery mode was sponsored by MarkLogic
-        and developed by Mike Brevoort. ...", "dateLastCrawled": "2018-02-01T22:59:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.1", "name": "CodeMirror:
-        Velocity mode - National Park Service", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/mode\/velocity\/index.html",
-        "urlPingSuffix": "DevEx,5090.1", "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/...",
-        "snippet": "CodeMirror: Velocity mode MIME types defined: text\/velocity.
-        ...", "dateLastCrawled": "2018-04-16T01:29:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.2",
-        "name": "CodeMirror: User Manual - National Park Service", "url": "https:\/\/www.nps.gov\/npmap\/slides\/choosing-the-right-tool-for-the-job\/libs\/codemirror\/doc\/manual.html",
-        "urlPingSuffix": "DevEx,5106.1", "displayUrl": "https:\/\/www.nps.gov\/...\/libs\/codemirror\/doc\/manual.html",
-        "snippet": "CodeMirror is a code-editor component ... It is possible to use
-        multiple theming classes at once—for example \"foo bar\" will assign both
-        the cm-s -foo and the ...", "dateLastCrawled": "2018-04-08T15:38:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.3", "name": "Approved
-        Backcountry Roads Temple Area - nps.gov", "url": "https:\/\/www.nps.gov\/lake\/planyourvisit\/upload\/Approved-Backcountry-Roads-Temple-Bar-Area-legal-size-2018.pdf",
-        "urlPingSuffix": "DevEx,5119.1", "displayUrl": "https:\/\/www.nps.gov\/lake\/planyourvisit\/upload\/Approved-Backcountry...",
-        "snippet": "Temple Bar Back Rd Salt Spring Wash Rd Gregg''s Hideout Rd ...
-        restrooms, foo Boat launch US route Maintained - unpaved road Sanitary disposal
-        station", "dateLastCrawled": "2018-04-22T01:37:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.4",
-        "name": "AQUARIUS Publish Service API Manual - nrdata.nps.gov", "url": "https:\/\/nrdata.nps.gov\/Programs\/Water\/Aquarius\/AQUARIUS%203.10%20Publish%20Service%20API%20Manual.pdf",
-        "urlPingSuffix": "DevEx,5131.1", "displayUrl": "https:\/\/nrdata.nps.gov\/Programs\/Water\/Aquarius\/AQUARIUS
-        3.10...", "snippet": "<pattern> is a wildcard string, such as *Foo* For
-        example: Identifier=H25*;Type=Hydrometic; ... 245,244,2012-08-24T14:29:03.210,
-        Foo River at the Bar,Foo River", "dateLastCrawled": "2018-04-02T01:34:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.5", "name": "CodeMirror:
-        Mode Runner Demo - National Park Service", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/demo\/runmode.html",
-        "urlPingSuffix": "DevEx,5145.1", "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/...",
-        "snippet": "Highlight! Running a CodeMirror mode outside of the editor. The
-        CodeMirror.runMode function, defined in lib\/runmode.js takes the following
-        arguments:. text (string) The document to run through the highlighter.", "dateLastCrawled":
-        "2018-02-28T04:10:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.6",
+      string: '{"_type": "SearchResponse", "queryContext": {"originalQuery": "foo
+        bar (site:nps.gov)"}, "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=foo+bar+(site%3anps.gov)",
+        "totalEstimatedMatches": 31, "value": [{"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0",
+        "name": "CodeMirror: User Manual - nps.gov", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/doc\/manual.html",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/doc\/manual.html",
+        "snippet": "It is possible to use multiple theming classes at once—for example
+        \"foo bar\" will assign both the cm-s-foo and the cm-s-bar classes to
+        the editor. indentUnit (integer) How many spaces a block (whatever that means
+        in the edited language) should be indented. The default is 2.", "dateLastCrawled":
+        "2020-03-25T01:15:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1", "name":
+        "Approved Backcountry Roads Temple Area - NPS.gov Homepage ...", "url":
+        "https:\/\/www.nps.gov\/lake\/planyourvisit\/upload\/Approved-Backcountry-Roads-Temple-Bar-Area-legal-size-2018.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/lake\/planyourvisit\/upload\/Approved-Backcountry-Roads-Temple-Bar...",
+        "snippet": "restrooms, foo Boat launch US route Maintained - unpaved road
+        Sanitary disposal station Hiking trail Picnic area Secondary 4WD road Gasoline
+        Campground ... Temple Bar Temple aar Trail oaaa ''apaï O 138 136 Sbtjhg
+        Mount''Wilson Wilderness (BLM) Clam 10 2rni Kingman 142 143 To Dolan Spnngs,
+        AZ and US Mjepost 42 To Dolan Spnngs, AZ", "dateLastCrawled": "2020-07-05T11:09:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2",
         "name": "Mount Vernon Memorial Highway George Washington Memorial ...", "url":
-        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/81000079.pdf", "urlPingSuffix":
-        "DevEx,5159.1", "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/81000079.pdf",
-        "snippet": "a colonial revival restaurant, snack bar, and gift shop; ...
-        foo * ''&& Beveled curbing is used throughout the southern section of the
-        highway for easy", "dateLastCrawled": "2018-04-19T06:46:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.7", "name": "CodeMirror:
-        Rust mode - nps.gov", "url": "https:\/\/www.nps.gov\/npmap\/slides\/status-of-web-map-licensing\/libs\/codemirror\/mode\/rust\/index.html",
-        "urlPingSuffix": "DevEx,5171.1", "displayUrl": "https:\/\/www.nps.gov\/...\/libs\/codemirror\/mode\/rust\/index.html",
-        "snippet": "CodeMirror: Rust mode MIME types defined: text\/x-rustsrc. ...",
-        "dateLastCrawled": "2018-02-11T18:22:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.8",
-        "name": "CodeMirror: Haxe mode - National Park Service", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/mode\/haxe\/index.html",
-        "urlPingSuffix": "DevEx,5186.1", "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/...",
-        "snippet": "CodeMirror: Haxe mode MIME types defined: text\/x-haxe. ...",
-        "dateLastCrawled": "2018-03-18T20:29:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.9",
-        "name": "Coming Home to Salsa: Latino Roots of American Food", "url": "https:\/\/www.nps.gov\/history\/heritageinitiatives\/latino\/latinothemestudy\/food.htm",
-        "urlPingSuffix": "DevEx,5202.1", "displayUrl": "https:\/\/www.nps.gov\/...\/latino\/latinothemestudy\/food.htm",
-        "snippet": "Latino foods are the historical product of encounters between
-        peoples from many lands. Some of these meetings took place in the distant
-        past; for example, Spanish settlers and missionaries were exchanging foodstuffs
-        and recipes with Indian women in New Mexico and Florida decades before the
-        first ...", "dateLastCrawled": "2018-04-20T20:38:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.10",
-        "name": "National Register of Historic Places Continuation Sheet", "url":
-        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/91001527.pdf", "urlPingSuffix":
-        "DevEx,5216.1", "about": [{"name": "Virgin Valley Heritage Museum"}], "displayUrl":
-        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/91001527.pdf",
-        "snippet": "replacement of the original doors, and the addition of bars
-        to the windows have not significantly altered the building''s historic ...
-        No. 67-0 * fOO * 001 .14-", "dateLastCrawled": "2018-04-12T00:29:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.11", "name": "MONTANA
-        HISTORICAL AND ARCHITECTURAL INVENTORY", "url": "https:\/\/npgallery.nps.gov\/GetAsset\/4d70febf-50b4-474e-b76b-fde0c370c683",
-        "urlPingSuffix": "DevEx,5228.1", "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/4d70febf-50b4-474e-b76b-fde0c...",
-        "snippet": "MONTANA HISTORICAL AND ARCHITECTURAL INVENTORY Legal Description:.
-        ... Foo,no«.sources: ... and the bar occupies the entire ground floor
-        of", "dateLastCrawled": "2018-03-29T11:16:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.12",
-        "name": "Captain John Smith - Historic Jamestowne Part of Colonial ...",
-        "url": "https:\/\/www.nps.gov\/jame\/learn\/historyculture\/life-of-john-smith.htm",
-        "urlPingSuffix": "DevEx,5244.1", "about": [{"name": "John Smith"}], "displayUrl":
-        "https:\/\/www.nps.gov\/jame\/learn\/historyculture\/life-of-john-smith.htm",
-        "snippet": "Captain John Smith was an adventurer, soldier, explorer and author.
-        Through the telling of his early life, we can trace the developments of a
-        man who became a dominate force in the eventual success of Jamestown and the
-        establishment of its legacy as the first permanent English settlement in North
-        ...", "dateLastCrawled": "2018-04-21T17:31:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.13",
-        "name": "UNITED STATES DEPARTMENT OF THE INTERIOR NATIONAL PARK ...", "url":
-        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/79001341.pdf", "urlPingSuffix":
-        "DevEx,5257.1", "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/79001341.pdf",
-        "snippet": "The north and south waiting rooms were made into a bar and ...
-        DESCRIPTION &>Cl ,q -foo>MAi ... REGISTER OF HISTORIC PLACES INVENTORY -
-        NOMINATION FORM", "dateLastCrawled": "2018-04-04T22:04:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14", "name": "Site* - NPGallery
-        Search", "url": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/86002767.pdf",
-        "urlPingSuffix": "DevEx,5270.1", "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/86002767.pdf",
+        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/81000079.pdf", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/81000079.pdf",
+        "snippet": "foo * ''&& Beveled curbing is used throughout the southern section
+        of the highway for easy pull-off onto the\" attjacyrit grass. '' Guard rails
+        where needed are of treated, unpainted wood to blend with the natural1 landscape.
+        ! The\"''Original plantings here are most fully intact at the Mount Vernon
+        terminus and at Belle Haven, a short distance", "dateLastCrawled": "2021-05-25T13:39:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3",
+        "name": "MONTANA HISTORICAL AND ARCHITECTURAL INVENTORY", "url": "https:\/\/npgallery.nps.gov\/NRHP\/GetAsset\/4d70febf-50b4-474e-b76b-fde0c370c683",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/NRHP\/GetAsset\/4d70febf-50b4-474e-b76b-fde0c370c683",
+        "snippet": "Foo,no«.sources: p< 570; ^^.^^ PP. 544, 558; 1917-18, pp. 554,
+        562. Interview with Rich Wollaston by John Lazuk. Interview with Louis LaRock
+        by John Lazuk. INTEGRITY: Assess the degree to which the structure\/site,
+        and surrounding area accurately convey the historical associations of the
+        property.", "dateLastCrawled": "2021-04-24T08:45:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/lewi\/learn\/photosmultimedia\/upload\/bonus06_musicyellipt&g''bye.mp3",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/lewi\/learn\/photosmultimedia\/upload\/bonus06_musicyellipt&g''bye.mp3",
+        "snippet": "Ã Z»è¨h¤DôÅoÜ’Ú6)Qvi¨ A „Û–€#cØ¨,è=K ÊÅòÓ³Ý§''­ùïœ¡ÉJ ï ‚Çaç@Ã
+        ¹Ì 4bŠzc ©éÁtŸ§hô–:É`ç vmÔˆÕ ¾F#d ~ ? •YõaUK «§‹ —aV1› R\\s ›vëlÛì¸a DÛŸ¯¶Ï-“žÑ
+        Áo5‘. u 6Áæ ?,æ:½\/šiþ_ •Eˆ ÎDt5C)Ÿ0õ}ÞXÉ^]r¢òŸ¦Ë wÛæ¸åÞï[Ö©^õ´. ÔÓ»®Cªà ...",
+        "dateLastCrawled": "2020-07-05T18:37:00.0000000Z", "language": "fr", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/home.nps.gov\/mono\/learn\/photosmultimedia\/upload\/Welcome%20to%20Monocacy-%20An%20Introduction.m4v",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/mono\/learn\/photosmultimedia\/upload\/Welcome
+        to Monocacy- An...", "snippet": "ftypM4V M4V M4A mp42isom–öCmdat gBÀ št Ø
+        € € GŠ P hÎÙŸx%¦ Î†ýÜÓæ$ Fï : cƒ NA3‘ˆ^4 øÍ\/lûöý N G­ ý„©ÛM\/à >Z²çÒñÿäO
+        @g é1¼ ® …Ø=»•ü;B· ¿BÜv ¹AW¦«™öÒƒƒ Â^ °­œâ.^?®_ ! K¸ÿøYT&ÏË ÆõYT ê¼& öØF-F
+        ³ ¹Ï öÞÍ =,Ü š|š Í©§’›tú~¡Œ ‡\\ žÔÓ´µ¯6 ...", "dateLastCrawled": "2020-12-31T07:04:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6",
+        "name": "Site*", "url": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/86002767.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/86002767.pdf",
         "snippet": "Historic Name: fl\/M Sa.foo t i Common Name: A\/AfM Atfc rwfs
-        Date of Construction: Architect: A\/M Builder: ... two public baths and a
-        bar\/restaurant on the", "dateLastCrawled": "2018-03-22T14:19:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15", "name": "—FAIR",
-        "url": "https:\/\/npgallery.nps.gov\/GetAsset\/250d648d-c809-47dc-8599-fcbd50405bc7\/",
-        "urlPingSuffix": "DevEx,5283.1", "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/250d648d-c809-47dc-8599-fcbd...",
-        "snippet": "description condition —excellent _good —fair ^.deteriorated —ruins
-        _unexposed check one —unaltered x-altered check one x-originalsite —moved
-        date.", "dateLastCrawled": "2018-04-17T19:53:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16",
-        "name": "PowerPoint Presentation", "url": "https:\/\/science.nature.nps.gov\/im\/monitor\/meetings\/GWS_2011\/docs\/8_Philippi.pptx",
-        "urlPingSuffix": "DevEx,5296.1", "displayUrl": "https:\/\/science.nature.nps.gov\/im\/monitor\/meetings\/GWS_2011\/docs\/8...",
-        "snippet": "Boxplot() not histogram() to get horizontal bars. Species-specific
-        cutpoints. Copper rockfish 2007. Sebastes. caurinus. Count (0,5] ... Source
-        foo.R as appendix in ...", "dateLastCrawled": "2018-04-08T20:05:00.0000000Z"}]},
-        "rankingResponse": {"mainline": {"items": [{"answerType": "WebPages", "resultIndex":
-        0, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.0"}}, {"answerType":
-        "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.1"}},
-        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.2"}},
-        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.3"}},
-        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.4"}},
-        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.5"}},
-        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.6"}},
-        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.7"}},
-        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.8"}},
-        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.9"}},
-        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.10"}},
-        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.11"}},
-        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.12"}},
-        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.13"}},
-        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14"}},
-        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15"}},
-        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16"}}]}}}'
-    http_version: 
-  recorded_at: Fri, 27 Apr 2018 16:02:59 GMT
+        Date of Construction: Architect: A\/M Builder: 1914 D estimated Kl documented
+        Uri tA Original Owner: John SanfaCOH Original Use: sal oon\/of f ice rentals
+        Present Use: motor parts store RESEARCH SOURCES: Note all records consulted
+        to determine dates", "dateLastCrawled": "2021-05-31T00:36:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7",
+        "name": "National Register of Historic Places Continuation Sheet", "url":
+        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/91001527.pdf", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/91001527.pdf",
+        "snippet": "removal of the original doors, and metal bars placed over some
+        of the windows - the alternations do not impair the integrity of this historic
+        structure. The museum is located on the north side of the only major street
+        through town, Mesquite Boulevard, and is surrounded by various residential
+        and commercial structures. The south and east", "dateLastCrawled": "2021-05-20T22:14:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8",
+        "name": "National Park Service National Register of Historic Places ...",
+        "url": "https:\/\/npgallery.nps.gov\/GetAsset\/b666d54c-df55-4e70-a12d-942c7b6bfb52",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/b666d54c-df55-4e70-a12d-942c7b6bfb52",
+        "snippet": "wheel base twenty ton caboose leaf spring arch bar trucks with
+        26\" diameter wheels. These new cars were the first D&RG cabooses to ride
+        on four-wheel trucks. One of the benefits of the increased length and wheel
+        modification of these types over the old 9-foot wheel-base Bobber style arrangement
+        was", "dateLastCrawled": "2021-06-05T19:17:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9",
+        "name": "UNITED STATES DEPARTMENT OF THE INTERIOR NATIONAL PARK ...", "url":
+        "https:\/\/npgallery.nps.gov\/GetAsset\/654dc60c-2e86-4398-a410-2396cd7f1b0e\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/654dc60c-2e86-4398-a410-2396cd7f1b0e",
+        "snippet": "1979). .The north and south waiting rooms were made into a bar
+        and^restaurant. En­ closure of the passenger waiting porch provided additional
+        dining and kitchen space. The second floor was renovated for General Services
+        Administration offices, and the third floor for retail use. An elevator was
+        installed at the center of the structure", "dateLastCrawled": "2021-05-23T10:13:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10",
+        "name": "National Park Service", "url": "http:\/\/home.nps.gov\/archeology\/npsGuide\/outreach\/RackArtifactsVisitors_final.indd",
+        "isFamilyFriendly": true, "displayUrl": "home.nps.gov\/archeology\/npsGuide\/outreach\/RackArtifactsVisitors_final.indd",
+        "snippet": "íõØ Få½1ïçþt· DOCUMENT p \\h‘ ¥ j ö +=N ;ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ
+        ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ", "dateLastCrawled": "2020-12-12T01:40:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11",
+        "name": "—FAIR", "url": "http:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/78000731.pdf",
+        "isFamilyFriendly": true, "displayUrl": "npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/78000731.pdf",
+        "snippet": "significance period —prehistoric —1400-1499 —1500-1599 —1600-1699
+        —1700-1799 —-1800-1899 —1900-areas of significance -- check and justify below",
+        "dateLastCrawled": "2021-06-05T18:00:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12",
+        "name": "At Em Arizona", "url": "http:\/\/home.nps.gov\/valr\/learn\/historyculture\/upload\/Atem-Sep15-1923-pdf.pdf",
+        "isFamilyFriendly": true, "displayUrl": "home.nps.gov\/valr\/learn\/historyculture\/upload\/Atem-Sep15-1923-pdf.pdf",
+        "snippet": "this sam~ fil?~?d lasting for four foo, China, and proceeded
+        at . full . ho.i:n was p1:obally the most spe:-speed to Yokohama. The destro;v-
+        ...", "dateLastCrawled": "2021-04-09T10:56:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13",
+        "name": "home.nps.gov", "url": "https:\/\/home.nps.gov\/timu\/learn\/photosmultimedia\/loader.cfm?csModule=security\/getfile&PageID=973968",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/timu\/learn\/photosmultimedia\/loader.cfm?csModule=security\/getfile&...",
+        "snippet": "d”ò_gaoWQÉö q;&eÔe cßëï^ú ›:*ëKqÑù Žž ²«#ð»ëüí;Ú ž$Ýnò Ý¡ ÿJ§·ç¢¿Wê•zÅ–úr
+        sc4 ÌŸÿú8ÀÆL õ]# ˜K { e™— ( †´T ...", "dateLastCrawled": "2021-03-21T18:49:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14",
+        "name": "National Park Service", "url": "http:\/\/home.nps.gov\/kemo\/upload\/KMNBP-2.kmz",
+        "isFamilyFriendly": true, "displayUrl": "home.nps.gov\/kemo\/upload\/KMNBP-2.kmz",
+        "snippet": "PK Zë %’ qÞ& doc.kmlì½ys\\Ç•\/ø·ûSÔÓÄÌ›‰ ÈÜ 7Í ²üÜîn»ÛÑROÿÑÑ¡(
+        E O Eó}ú9çÖ=™¿ÌªÂv« ,¤- 8yoÞ\\Ï¾¼ù ûp6ûeqyuº¿úÝW ...", "dateLastCrawled":
+        "2021-02-01T04:50:00.0000000Z", "language": "fr", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15", "name":
+        "ATIONAL REGISTER OF HISTORIC PLACES INVENTORY ...", "url": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/80003258.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/80003258.pdf",
+        "snippet": "hardware imbedded in the floor for the horizontal bar. Also
+        in the ceiling: the original light fixtures and 8 fans. The hall has some
+        90 tables and about 375 chairs of varying vintage - and some of the original
+        member-made benches from the first hall, This original hall stood just to
+        the north of the present hall", "dateLastCrawled": "2021-02-19T01:43:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16",
+        "name": "home.nps.gov", "url": "https:\/\/home.nps.gov\/features\/yell\/slidefile\/plants\/figwortfamily\/Images\/08310.jpg",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/features\/yell\/slidefile\/plants\/figwortfamily\/Images\/08310.jpg",
+        "snippet": "JFIF Photoshop 3.08BIM 1 x%Dwarf Monkeyflower; RG Johnsson; 19648BIM
+        8BIM x8BIM 8BIM 8BIM 8BIM'' 8BIM H\/ff lff \/ff 2 Z 5 - 8BIM p 8BIM @ @8BIM
+        8BIM u 0 Untitled-4 ...", "dateLastCrawled": "2021-01-22T11:00:00.0000000Z",
+        "language": "cs", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17",
+        "name": "home.nps.gov", "url": "https:\/\/home.nps.gov\/orpi\/learn\/photosmultimedia\/loader.cfm?csModule=security\/getfile&PageID=2185942",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/orpi\/learn\/photosmultimedia\/loader.cfm?csModule=security\/getfile&...",
+        "snippet": "0&²uŽfÏ ¦ÙªbÎlâ @¤ÐÒ ãÒ —ð É^¨Pî AspectRatioX AspectRatioY WMFSDKVersion
+        11.0.5721.5251 WMFSDKNeeded 0.0.0.0000 IsVBR ¡Ü«ŒG©Ï ŽäÀ Seh§!›C", "dateLastCrawled":
+        "2021-04-19T23:32:00.0000000Z", "language": "fr", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18", "name":
+        "NPS.gov Homepage (U.S. National Park Service)", "url": "http:\/\/home.nps.gov\/ever\/planyourvisit\/upload\/EVER_GMP_marinelayers_KML_v5-2.kmz",
+        "isFamilyFriendly": true, "displayUrl": "home.nps.gov\/ever\/planyourvisit\/upload\/EVER_GMP_marinelayers_KML_v5-2.kmz",
+        "snippet": "ÀÄ½”78 ì îÞ¿}õËh8~}v å£ gÿ'' 8š ?¿ 0Œî ãñ`øó›Ñ¥Úú~t1)å†o\/Çòödüû»‘Ú6¹
+        ¼ ÝŸ ÆƒÉÕë?²Õý.4—øæcäböž&CJ(ÓÀÄ½ ...", "dateLastCrawled": "2021-01-30T16:09:00.0000000Z",
+        "language": "pt", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19",
+        "name": "Better Lives, Bitter Lies (U.S. National Park Service)", "url": "https:\/\/home.nps.gov\/podcasts\/better-lives-bitter-lies.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/podcasts\/better-lives-bitter-lies.htm",
+        "snippet": "The constitution has a sec, a section titled Chinese and basically
+        bars them from living in cities, but it was unenforceable, unconstitutional
+        based on the American constitution. And Chinese American leaders, the Chinese
+        merchants and the Chinese Six Companies were kind of at the forefront of fighting
+        these different local attempts to get rid ...", "dateLastCrawled": "2021-04-16T00:36:00.0000000Z",
+        "language": "en", "isNavigational": false}]}, "rankingResponse": {"mainline":
+        {"items": [{"answerType": "WebPages", "resultIndex": 0, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0"}},
+        {"answerType": "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1"}},
+        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2"}},
+        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3"}},
+        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4"}},
+        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5"}},
+        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6"}},
+        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7"}},
+        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8"}},
+        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9"}},
+        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10"}},
+        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11"}},
+        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12"}},
+        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13"}},
+        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14"}},
+        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15"}},
+        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16"}},
+        {"answerType": "WebPages", "resultIndex": 17, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17"}},
+        {"answerType": "WebPages", "resultIndex": 18, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18"}},
+        {"answerType": "WebPages", "resultIndex": 19, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19"}}]}}}'
+    http_version:
+  recorded_at: Wed, 09 Jun 2021 14:04:05 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/searches_controller/searching_on_a_routed_keyword_referrer_matches_redirect_url_when_the_match_is_exact_except_that_the_referring_url_is_http_and_the_routed_query_url_is_https_it_should_behave_like_a_routed_query_that_matches_the_referrer.yml
+++ b/spec/vcr_cassettes/searches_controller/searching_on_a_routed_keyword_referrer_matches_redirect_url_when_the_match_is_exact_except_that_the_referring_url_is_http_and_the_routed_query_url_is_https_it_should_behave_like_a_routed_query_that_matches_the_referrer.yml
@@ -2,136 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.googleapis.com/customsearch/v1?alt=json&cx=<GOOGLE_SEARCH_CX>&key=<GOOGLE_API_KEY>&lr=lang_en&q=foo%20bar&quotaUser=USASearch&safe=medium
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - USASearch
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      Connection:
-      - keep-alive
-      Keep-Alive:
-      - '30'
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 22 Mar 2018 23:02:01 GMT
-      Expires:
-      - Thu, 22 Mar 2018 23:02:01 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303432; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="42,41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "usageLimits",
-            "reason": "keyInvalid",
-            "message": "Bad Request"
-           }
-          ],
-          "code": 400,
-          "message": "Bad Request"
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 22 Mar 2018 23:02:01 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/customsearch/v1?alt=json&cx=<GOOGLE_SEARCH_CX>&key=<GOOGLE_API_KEY>&lr=lang_en&q=foo%20bar%20site:nps.gov&quotaUser=USASearch&safe=medium
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - USASearch
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      Connection:
-      - keep-alive
-      Keep-Alive:
-      - '30'
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 26 Apr 2018 23:29:11 GMT
-      Expires:
-      - Thu, 26 Apr 2018 23:29:11 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303433; quic=51303432; quic=51303431; quic=51303339;
-        quic=51303335,quic=":443"; ma=2592000; v="43,42,41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "usageLimits",
-            "reason": "accessNotConfigured",
-            "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
-            "extendedHelp": "https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333"
-           }
-          ],
-          "code": 403,
-          "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 26 Apr 2018 23:29:11 GMT
-- request:
-    method: get
-    uri: https://www.bingapis.com/api/v6/search?AppId=<BING_V6_APP_ID>&count=20&mkt=en-US&offset=0&q=foo%20bar%20(site:nps.gov)&responseFilter=WebPages,SpellSuggestions&safeSearch=moderate&textDecorations=true&traffictype=test
+    uri: https://api.cognitive.microsoft.com/bing/v7.0/search?count=20&mkt=en-US&offset=0&q=foo%20bar%20(site:nps.gov)&responseFilter=WebPages&safeSearch=moderate&textDecorations=true&traffictype=test
     body:
       encoding: US-ASCII
       string: ''
@@ -139,7 +10,7 @@ http_interactions:
       User-Agent:
       - USASearch
       Ocp-Apim-Subscription-Key:
-      - "<BING_V6_APP_ID>"
+      - "<BING_V7_SUBSCRIPTION_ID>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -155,167 +26,222 @@ http_interactions:
     headers:
       Cache-Control:
       - private, max-age=0
-      Content-Length:
-      - '3441'
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
-      - Fri, 27 Apr 2018 16:01:59 GMT
+      - Wed, 09 Jun 2021 14:03:04 GMT
       Vary:
       - Accept-Encoding
       P3p:
       - CP="NON UNI COM NAV STA LOC CURa DEVa PSAa PSDa OUR IND"
-      Set-Cookie:
-      - MUID=3EEC595657926489078F528856056544; path=/; expires=Wed, 22-May-2019 16:03:00
-        GMT; domain=bingapis.com
-      - MUIDB=3EEC595657926489078F528856056544; path=/; httponly; expires=Wed, 22-May-2019
-        16:03:00 GMT
-      - SRCHD=AF=NOFORM; domain=.bingapis.com; expires=Mon, 27-Apr-2020 16:02:59 GMT;
-        path=/
-      - SRCHUID=V=2&GUID=EB52EFE21E714985AB89F6FD043BB18A&dmnchg=1; domain=.bingapis.com;
-        expires=Mon, 27-Apr-2020 16:02:59 GMT; path=/
-      - SRCHUSR=DOB=20180427; domain=.bingapis.com; expires=Mon, 27-Apr-2020 16:02:59
-        GMT; path=/
-      - _EDGE_S=mkt=en-us&F=1&SID=072D11758C346E063D7E1AAB8DA36FFB; path=/; httponly;
-        domain=bingapis.com
-      - _EDGE_V=1; path=/; httponly; expires=Wed, 22-May-2019 16:03:00 GMT; domain=bingapis.com
-      - _SS=SID=072D11758C346E063D7E1AAB8DA36FFB; domain=.bingapis.com; path=/
+      X-Snr-Routing:
+      - '1'
       Bingapis-Traceid:
-      - 25377BE3EDA54A0486D6E349047C0521
+      - 604A7E7023FB438CB2F6899842DEE17D
+      Bingapis-Sessionid:
+      - 51F13178B3CC43A4A126EC77FBE5D5E4
       X-Msedge-Clientid:
-      - 3EEC595657926489078F528856056544
+      - 2D2849197A046E7A2A4E59487BF96F90
       X-Msapi-Userstate:
-      - c108
+      - a4fb
       Bingapis-Market:
       - en-US
+      X-Search-Responseinfo:
+      - InternalResponseTime=298,MSDatacenter=BN2B
+      X-Cache:
+      - CONFIG_NOCACHE
       X-Msedge-Ref:
-      - 'Ref A: 25377BE3EDA54A0486D6E349047C0521 Ref B: CO1EDGE0416 Ref C: 2018-04-27T16:03:00Z'
+      - 'Ref A: 604A7E7023FB438CB2F6899842DEE17D Ref B: BLUEDGE0808 Ref C: 2021-06-09T14:04:04Z'
+      Apim-Request-Id:
+      - e93f6a83-c1c1-4660-8f36-8beb11b7344a
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Csp-Billing-Usage:
+      - CognitiveServices.BingSearchV7.Transaction=1
       Date:
-      - Fri, 27 Apr 2018 16:02:59 GMT
+      - Wed, 09 Jun 2021 14:04:04 GMT
     body:
       encoding: UTF-8
-      string: '{"_type": "SearchResponse", "instrumentation": {"pingUrlBase": "https:\/\/www.bingapis.com\/api\/ping?IG=355EE64339CB44648AEAF52FEDF38823&CID=3EEC595657926489078F528856056544&ID=",
-        "pageLoadPingUrl": "https:\/\/www.bingapis.com\/api\/ping\/pageload?IG=355EE64339CB44648AEAF52FEDF38823&CID=3EEC595657926489078F528856056544&Type=Event.CPT&DATA=0"},
-        "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=foo+bar+(site%3anps.gov)",
-        "webSearchUrlPingSuffix": "DevEx,5395.1", "totalEstimatedMatches": 17, "value":
-        [{"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.0", "name": "CodeMirror
-        2: JavaScript mode - National Park Service", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/mode\/xquery\/index.html",
-        "urlPingSuffix": "DevEx,5076.1", "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/...",
-        "snippet": "Development of the CodeMirror XQuery mode was sponsored by MarkLogic
-        and developed by Mike Brevoort. ...", "dateLastCrawled": "2018-02-01T22:59:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.1", "name": "CodeMirror:
-        Velocity mode - National Park Service", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/mode\/velocity\/index.html",
-        "urlPingSuffix": "DevEx,5090.1", "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/...",
-        "snippet": "CodeMirror: Velocity mode MIME types defined: text\/velocity.
-        ...", "dateLastCrawled": "2018-04-16T01:29:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.2",
-        "name": "CodeMirror: User Manual - National Park Service", "url": "https:\/\/www.nps.gov\/npmap\/slides\/choosing-the-right-tool-for-the-job\/libs\/codemirror\/doc\/manual.html",
-        "urlPingSuffix": "DevEx,5106.1", "displayUrl": "https:\/\/www.nps.gov\/...\/libs\/codemirror\/doc\/manual.html",
-        "snippet": "CodeMirror is a code-editor component ... It is possible to use
-        multiple theming classes at once—for example \"foo bar\" will assign both
-        the cm-s -foo and the ...", "dateLastCrawled": "2018-04-08T15:38:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.3", "name": "Approved
-        Backcountry Roads Temple Area - nps.gov", "url": "https:\/\/www.nps.gov\/lake\/planyourvisit\/upload\/Approved-Backcountry-Roads-Temple-Bar-Area-legal-size-2018.pdf",
-        "urlPingSuffix": "DevEx,5119.1", "displayUrl": "https:\/\/www.nps.gov\/lake\/planyourvisit\/upload\/Approved-Backcountry...",
-        "snippet": "Temple Bar Back Rd Salt Spring Wash Rd Gregg''s Hideout Rd ...
-        restrooms, foo Boat launch US route Maintained - unpaved road Sanitary disposal
-        station", "dateLastCrawled": "2018-04-22T01:37:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.4",
-        "name": "AQUARIUS Publish Service API Manual - nrdata.nps.gov", "url": "https:\/\/nrdata.nps.gov\/Programs\/Water\/Aquarius\/AQUARIUS%203.10%20Publish%20Service%20API%20Manual.pdf",
-        "urlPingSuffix": "DevEx,5131.1", "displayUrl": "https:\/\/nrdata.nps.gov\/Programs\/Water\/Aquarius\/AQUARIUS
-        3.10...", "snippet": "<pattern> is a wildcard string, such as *Foo* For
-        example: Identifier=H25*;Type=Hydrometic; ... 245,244,2012-08-24T14:29:03.210,
-        Foo River at the Bar,Foo River", "dateLastCrawled": "2018-04-02T01:34:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.5", "name": "CodeMirror:
-        Mode Runner Demo - National Park Service", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/demo\/runmode.html",
-        "urlPingSuffix": "DevEx,5145.1", "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/...",
-        "snippet": "Highlight! Running a CodeMirror mode outside of the editor. The
-        CodeMirror.runMode function, defined in lib\/runmode.js takes the following
-        arguments:. text (string) The document to run through the highlighter.", "dateLastCrawled":
-        "2018-02-28T04:10:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.6",
+      string: '{"_type": "SearchResponse", "queryContext": {"originalQuery": "foo
+        bar (site:nps.gov)"}, "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=foo+bar+(site%3anps.gov)",
+        "totalEstimatedMatches": 26, "value": [{"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0",
+        "name": "CodeMirror: User Manual - nps.gov", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/doc\/manual.html",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/doc\/manual.html",
+        "snippet": "It is possible to use multiple theming classes at once—for example
+        \"foo bar\" will assign both the cm-s-foo and the cm-s-bar classes to
+        the editor. indentUnit (integer) How many spaces a block (whatever that means
+        in the edited language) should be indented. The default is 2.", "dateLastCrawled":
+        "2020-03-25T01:15:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1", "name":
+        "Approved Backcountry Roads Temple Area - NPS.gov Homepage ...", "url":
+        "https:\/\/www.nps.gov\/lake\/planyourvisit\/upload\/Approved-Backcountry-Roads-Temple-Bar-Area-legal-size-2018.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/lake\/planyourvisit\/upload\/Approved-Backcountry-Roads-Temple-Bar...",
+        "snippet": "restrooms, foo Boat launch US route Maintained - unpaved road
+        Sanitary disposal station Hiking trail Picnic area Secondary 4WD road Gasoline
+        Campground ... Temple Bar Temple aar Trail oaaa ''apaï O 138 136 Sbtjhg
+        Mount''Wilson Wilderness (BLM) Clam 10 2rni Kingman 142 143 To Dolan Spnngs,
+        AZ and US Mjepost 42 To Dolan Spnngs, AZ", "dateLastCrawled": "2020-07-05T11:09:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2",
         "name": "Mount Vernon Memorial Highway George Washington Memorial ...", "url":
-        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/81000079.pdf", "urlPingSuffix":
-        "DevEx,5159.1", "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/81000079.pdf",
-        "snippet": "a colonial revival restaurant, snack bar, and gift shop; ...
-        foo * ''&& Beveled curbing is used throughout the southern section of the
-        highway for easy", "dateLastCrawled": "2018-04-19T06:46:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.7", "name": "CodeMirror:
-        Rust mode - nps.gov", "url": "https:\/\/www.nps.gov\/npmap\/slides\/status-of-web-map-licensing\/libs\/codemirror\/mode\/rust\/index.html",
-        "urlPingSuffix": "DevEx,5171.1", "displayUrl": "https:\/\/www.nps.gov\/...\/libs\/codemirror\/mode\/rust\/index.html",
-        "snippet": "CodeMirror: Rust mode MIME types defined: text\/x-rustsrc. ...",
-        "dateLastCrawled": "2018-02-11T18:22:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.8",
-        "name": "CodeMirror: Haxe mode - National Park Service", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/mode\/haxe\/index.html",
-        "urlPingSuffix": "DevEx,5186.1", "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/...",
-        "snippet": "CodeMirror: Haxe mode MIME types defined: text\/x-haxe. ...",
-        "dateLastCrawled": "2018-03-18T20:29:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.9",
-        "name": "Coming Home to Salsa: Latino Roots of American Food", "url": "https:\/\/www.nps.gov\/history\/heritageinitiatives\/latino\/latinothemestudy\/food.htm",
-        "urlPingSuffix": "DevEx,5202.1", "displayUrl": "https:\/\/www.nps.gov\/...\/latino\/latinothemestudy\/food.htm",
-        "snippet": "Latino foods are the historical product of encounters between
-        peoples from many lands. Some of these meetings took place in the distant
-        past; for example, Spanish settlers and missionaries were exchanging foodstuffs
-        and recipes with Indian women in New Mexico and Florida decades before the
-        first ...", "dateLastCrawled": "2018-04-20T20:38:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.10",
-        "name": "National Register of Historic Places Continuation Sheet", "url":
-        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/91001527.pdf", "urlPingSuffix":
-        "DevEx,5216.1", "about": [{"name": "Virgin Valley Heritage Museum"}], "displayUrl":
-        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/91001527.pdf",
-        "snippet": "replacement of the original doors, and the addition of bars
-        to the windows have not significantly altered the building''s historic ...
-        No. 67-0 * fOO * 001 .14-", "dateLastCrawled": "2018-04-12T00:29:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.11", "name": "MONTANA
-        HISTORICAL AND ARCHITECTURAL INVENTORY", "url": "https:\/\/npgallery.nps.gov\/GetAsset\/4d70febf-50b4-474e-b76b-fde0c370c683",
-        "urlPingSuffix": "DevEx,5228.1", "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/4d70febf-50b4-474e-b76b-fde0c...",
-        "snippet": "MONTANA HISTORICAL AND ARCHITECTURAL INVENTORY Legal Description:.
-        ... Foo,no«.sources: ... and the bar occupies the entire ground floor
-        of", "dateLastCrawled": "2018-03-29T11:16:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.12",
-        "name": "Captain John Smith - Historic Jamestowne Part of Colonial ...",
-        "url": "https:\/\/www.nps.gov\/jame\/learn\/historyculture\/life-of-john-smith.htm",
-        "urlPingSuffix": "DevEx,5244.1", "about": [{"name": "John Smith"}], "displayUrl":
-        "https:\/\/www.nps.gov\/jame\/learn\/historyculture\/life-of-john-smith.htm",
-        "snippet": "Captain John Smith was an adventurer, soldier, explorer and author.
-        Through the telling of his early life, we can trace the developments of a
-        man who became a dominate force in the eventual success of Jamestown and the
-        establishment of its legacy as the first permanent English settlement in North
-        ...", "dateLastCrawled": "2018-04-21T17:31:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.13",
+        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/81000079.pdf", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/81000079.pdf",
+        "snippet": "foo * ''&& Beveled curbing is used throughout the southern section
+        of the highway for easy pull-off onto the\" attjacyrit grass. '' Guard rails
+        where needed are of treated, unpainted wood to blend with the natural1 landscape.
+        ! The\"''Original plantings here are most fully intact at the Mount Vernon
+        terminus and at Belle Haven, a short distance", "dateLastCrawled": "2021-05-25T13:39:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3",
+        "name": "MONTANA HISTORICAL AND ARCHITECTURAL INVENTORY", "url": "https:\/\/npgallery.nps.gov\/NRHP\/GetAsset\/4d70febf-50b4-474e-b76b-fde0c370c683",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/NRHP\/GetAsset\/4d70febf-50b4-474e-b76b-fde0c370c683",
+        "snippet": "Foo,no«.sources: p< 570; ^^.^^ PP. 544, 558; 1917-18, pp. 554,
+        562. Interview with Rich Wollaston by John Lazuk. Interview with Louis LaRock
+        by John Lazuk. INTEGRITY: Assess the degree to which the structure\/site,
+        and surrounding area accurately convey the historical associations of the
+        property.", "dateLastCrawled": "2021-04-24T08:45:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/caco\/learn\/photosmultimedia\/upload\/Pamet%20Area%20Trails,%20revised%20credit-2.wmv",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/caco\/learn\/photosmultimedia\/upload\/Pamet
+        Area Trails, revised...", "snippet": "þ„wN·.¡:¤ ˜&IÁËi9w%:jØ…$€€ É)›~q t ª`
+        nÆ ú ðù ,''[tuZI š ”ã©ã·Ì¶L UZŒÎØÍ$áMû™3#{\/Œì i ’v öL „’oÎ~tÐ Šjp s’ ,Æ @EB#
+        f†10 I0 Ã ç6 Šgû 6«Æ Ì‘Ól 1³ûZ’ c 8 hXB†\"c 32 ßL,} $š 0°‡Ð=“c) u·²ÁC%m¥U´€Ø`oÐæ¸€
+        S¾)#•âÂ œÃ TÕ -¦—° uV 0Q ...", "dateLastCrawled": "2018-05-26T23:36:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/lewi\/learn\/photosmultimedia\/upload\/bonus06_musicyellipt&g''bye.mp3",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/lewi\/learn\/photosmultimedia\/upload\/bonus06_musicyellipt&g''bye.mp3",
+        "snippet": "Ã Z»è¨h¤DôÅoÜ’Ú6)Qvi¨ A „Û–€#cØ¨,è=K ÊÅòÓ³Ý§''­ùïœ¡ÉJ ï ‚Çaç@Ã
+        ¹Ì 4bŠzc ©éÁtŸ§hô–:É`ç vmÔˆÕ ¾F#d ~ ? •YõaUK «§‹ —aV1› R\\s ›vëlÛì¸a DÛŸ¯¶Ï-“žÑ
+        Áo5‘. u 6Áæ ?,æ:½\/šiþ_ •Eˆ ÎDt5C)Ÿ0õ}ÞXÉ^]r¢òŸ¦Ë wÛæ¸åÞï[Ö©^õ´. ÔÓ»®Cªà ...",
+        "dateLastCrawled": "2020-07-05T18:37:00.0000000Z", "language": "fr", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/nebe\/upload\/Journey-Through-New-Bedford-RF.epub",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/nebe\/upload\/Journey-Through-New-Bedford-RF.epub",
+        "snippet": "PUM–WÓC Tk„­¥j¼¤ƒ¶$¾•‡b¼¥¢ÉG #+ä^y£}cq ¼Û@|•} Å(¯r Ð¦V $¯ î›â
+        obÂ}ƒ&z£y '' Wi6ÄUÔ[ â>¡C … ö cô£PtTóV¨ pE=à3­t$·&Áˆ†Xcµö îúô(4H§5û&ÓSÎÂ‰Tyl@ÂŠ5Ø8ç§ßkûŠí€
+        E Ú² ¦wé_&R¥†€ôRTÜJ¨¸E‹)Ï ´ÕœkÁ ãj¤Õ »Ý´m˜nÜ¶ ] n(;«Äo`p« „ H»\" ¸U°mU ...",
+        "dateLastCrawled": "2020-05-27T11:30:00.0000000Z", "language": "fr", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/home.nps.gov\/mono\/learn\/photosmultimedia\/upload\/Welcome%20to%20Monocacy-%20An%20Introduction.m4v",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/mono\/learn\/photosmultimedia\/upload\/Welcome
+        to Monocacy- An...", "snippet": "ftypM4V M4V M4A mp42isom–öCmdat gBÀ št Ø
+        € € GŠ P hÎÙŸx%¦ Î†ýÜÓæ$ Fï : cƒ NA3‘ˆ^4 øÍ\/lûöý N G­ ý„©ÛM\/à >Z²çÒñÿäO
+        @g é1¼ ® …Ø=»•ü;B· ¿BÜv ¹AW¦«™öÒƒƒ Â^ °­œâ.^?®_ ! K¸ÿøYT&ÏË ÆõYT ê¼& öØF-F
+        ³ ¹Ï öÞÍ =,Ü š|š Í©§’›tú~¡Œ ‡\\ žÔÓ´µ¯6 ...", "dateLastCrawled": "2020-12-31T07:04:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8",
+        "name": "National Park Service National Register of Historic Places ...",
+        "url": "https:\/\/npgallery.nps.gov\/GetAsset\/b666d54c-df55-4e70-a12d-942c7b6bfb52",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/b666d54c-df55-4e70-a12d-942c7b6bfb52",
+        "snippet": "wheel base twenty ton caboose leaf spring arch bar trucks with
+        26\" diameter wheels. These new cars were the first D&RG cabooses to ride
+        on four-wheel trucks. One of the benefits of the increased length and wheel
+        modification of these types over the old 9-foot wheel-base Bobber style arrangement
+        was", "dateLastCrawled": "2021-06-05T19:17:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9",
         "name": "UNITED STATES DEPARTMENT OF THE INTERIOR NATIONAL PARK ...", "url":
-        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/79001341.pdf", "urlPingSuffix":
-        "DevEx,5257.1", "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/79001341.pdf",
-        "snippet": "The north and south waiting rooms were made into a bar and ...
-        DESCRIPTION &>Cl ,q -foo>MAi ... REGISTER OF HISTORIC PLACES INVENTORY -
-        NOMINATION FORM", "dateLastCrawled": "2018-04-04T22:04:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14", "name": "Site* - NPGallery
-        Search", "url": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/86002767.pdf",
-        "urlPingSuffix": "DevEx,5270.1", "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/86002767.pdf",
-        "snippet": "Historic Name: fl\/M Sa.foo t i Common Name: A\/AfM Atfc rwfs
-        Date of Construction: Architect: A\/M Builder: ... two public baths and a
-        bar\/restaurant on the", "dateLastCrawled": "2018-03-22T14:19:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15", "name": "—FAIR",
-        "url": "https:\/\/npgallery.nps.gov\/GetAsset\/250d648d-c809-47dc-8599-fcbd50405bc7\/",
-        "urlPingSuffix": "DevEx,5283.1", "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/250d648d-c809-47dc-8599-fcbd...",
-        "snippet": "description condition —excellent _good —fair ^.deteriorated —ruins
-        _unexposed check one —unaltered x-altered check one x-originalsite —moved
-        date.", "dateLastCrawled": "2018-04-17T19:53:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16",
-        "name": "PowerPoint Presentation", "url": "https:\/\/science.nature.nps.gov\/im\/monitor\/meetings\/GWS_2011\/docs\/8_Philippi.pptx",
-        "urlPingSuffix": "DevEx,5296.1", "displayUrl": "https:\/\/science.nature.nps.gov\/im\/monitor\/meetings\/GWS_2011\/docs\/8...",
-        "snippet": "Boxplot() not histogram() to get horizontal bars. Species-specific
-        cutpoints. Copper rockfish 2007. Sebastes. caurinus. Count (0,5] ... Source
-        foo.R as appendix in ...", "dateLastCrawled": "2018-04-08T20:05:00.0000000Z"}]},
-        "rankingResponse": {"mainline": {"items": [{"answerType": "WebPages", "resultIndex":
-        0, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.0"}}, {"answerType":
-        "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.1"}},
-        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.2"}},
-        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.3"}},
-        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.4"}},
-        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.5"}},
-        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.6"}},
-        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.7"}},
-        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.8"}},
-        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.9"}},
-        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.10"}},
-        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.11"}},
-        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.12"}},
-        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.13"}},
-        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14"}},
-        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15"}},
-        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16"}}]}}}'
-    http_version: 
-  recorded_at: Fri, 27 Apr 2018 16:03:00 GMT
+        "https:\/\/npgallery.nps.gov\/GetAsset\/654dc60c-2e86-4398-a410-2396cd7f1b0e\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/654dc60c-2e86-4398-a410-2396cd7f1b0e",
+        "snippet": "1979). .The north and south waiting rooms were made into a bar
+        and^restaurant. En­ closure of the passenger waiting porch provided additional
+        dining and kitchen space. The second floor was renovated for General Services
+        Administration offices, and the third floor for retail use. An elevator was
+        installed at the center of the structure", "dateLastCrawled": "2021-05-23T10:13:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10",
+        "name": "ATIONAL REGISTER OF HISTORIC PLACES INVENTORY ...", "url": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/80003258.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/80003258.pdf",
+        "snippet": "hardware imbedded in the floor for the horizontal bar. Also
+        in the ceiling: the original light fixtures and 8 fans. The hall has some
+        90 tables and about 375 chairs of varying vintage - and some of the original
+        member-made benches from the first hall, This original hall stood just to
+        the north of the present hall", "dateLastCrawled": "2021-02-19T01:43:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11",
+        "name": "home.nps.gov", "url": "https:\/\/home.nps.gov\/archeology\/npsGuide\/outreach\/RackArtifactsRangers_final.indd",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/archeology\/npsGuide\/outreach\/RackArtifactsRangers_final.indd",
+        "snippet": "íõØ Få½1ïçþt· DOCUMENT p gx‘ „ e Ü û¥ +]G 0ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ
+        ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ", "dateLastCrawled": "2020-11-29T15:17:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12",
+        "name": "National Register of Historic Places Continuation Sheet", "url":
+        "https:\/\/npgallery.nps.gov\/GetAsset\/203362ae-08c1-4f85-9184-b26ee52a2063\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/203362ae-08c1-4f85-9184-b26ee52a2063",
+        "snippet": "removal of the original doors, and metal bars placed over some
+        of the windows - the alternations do not impair the integrity of this historic
+        structure. The museum is located on the north side of the only major street
+        through town, Mesquite Boulevard, and is surrounded by various residential
+        and commercial structures. The south and east", "dateLastCrawled": "2021-05-31T17:41:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13",
+        "name": "NPGallery Search", "url": "https:\/\/npgallery.nps.gov\/GetAsset\/8b1a4118-8b4d-4b06-a317-e7592f80a5db\/original",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/8b1a4118-8b4d-4b06-a317-e7592f80a5db\/original",
+        "snippet": "Ž! „`§øKõ¢7ÐÆ!{@Æ›ª\\¢é( ~š Ñ(!ˆ ÄPIa ƒ.“(²£s Ú.£ªóÓ›œÄËØ§x le0áÛª½!È9:MÃÿÆ&+—|Þ¥{þ^øwiÇYhç”ì†L
+        ‹xg¼·¦ï ...", "dateLastCrawled": "2021-05-23T20:18:00.0000000Z", "language":
+        "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14",
+        "name": "Season 1 Episode 1: A Love of the Mountains with Kathy ...", "url":
+        "https:\/\/www.nps.gov\/romo\/blogs\/season-1-episode-1-a-love-of-the-mountains-with-kathy-brazelton.htm?result=true",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/romo\/blogs\/season-1-episode-1-a-love-of-the-mountains-with-kathy...",
+        "snippet": "I’m happy to appreciate the good work of dr Sam omijie Spell caster
+        For saving my lost relationship I never believe there will Be a way To get
+        my lover back but dr Sam omijie saved my relationship through his-spell and
+        after 15 hours my love I return to me and asked for forgiveness I’m very happy
+        because I never thought There is A great man like this You can also reach
+        him on his email at ...", "dateLastCrawled": "2021-01-09T05:59:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/goga\/learn\/nature\/upload\/GGNRA-Climate-Change-Project_FINAL.kmz",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/goga\/learn\/nature\/upload\/GGNRA-Climate-Change-Project_FINAL.kmz",
+        "snippet": "PK è~¢«fuhO ª doc.kmlì½_s Ç‘ö{íý k6+ÿV ƒæ \\Ù^+^ÙRXônœ½qÀ Lâ $
+        d¯öÓŸÌ I ÔtOƒ ‡M‹& Ì ººë©z²*ë— ÿÏÿ¼8ýìŸÇç¯NÎ^þös ÊçŸ ¿|zöÝÉËg¿ýü¯Oþp¯}þ ýÛÃïãUñÊ—¯~ûùó‹‹
+        Ü¿ÿ¯ ýk8ûáøå³“WÃËã‹ûñŠûµ NþçøôU|õÝ ß pÿ üæìô ...", "dateLastCrawled": "2020-04-04T00:05:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16",
+        "name": "Better Lives, Bitter Lies (U.S. National Park Service)", "url": "https:\/\/home.nps.gov\/podcasts\/better-lives-bitter-lies.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/podcasts\/better-lives-bitter-lies.htm",
+        "snippet": "The constitution has a sec, a section titled Chinese and basically
+        bars them from living in cities, but it was unenforceable, unconstitutional
+        based on the American constitution. And Chinese American leaders, the Chinese
+        merchants and the Chinese Six Companies were kind of at the forefront of fighting
+        these different local attempts to get rid ...", "dateLastCrawled": "2021-04-16T00:36:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17",
+        "name": "CodeMirror 2: JavaScript mode", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/mode\/xquery\/index.html",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/mode\/xquery\/index.html",
+        "snippet": "MIME types defined: application\/xquery. Development of the CodeMirror
+        XQuery mode was sponsored by MarkLogic and developed by Mike Brevoort.MarkLogic
+        and developed by Mike Brevoort.", "dateLastCrawled": "2020-04-08T18:26:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18",
+        "name": "Site*", "url": "https:\/\/npgallery.nps.gov\/GetAsset?assetID=9741b365-5c1d-4b21-a9ec-5b65d84e8243",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset?assetID=9741b365-5c1d-4b21-a9ec-5b65d84e8243",
+        "snippet": "two pool tables, two public baths and a bar\/restaurant on the
+        first floor. The second level had eight rooms which were used as rental offices
+        for a variety of downtown businesses. During prohibition, the barber shop
+        and a cigar a n d c a n d y s t o r e remained open for business. In the mid-to-late
+        1930s, t he b u i1d i nq served", "dateLastCrawled": "2021-05-27T21:55:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/home.nps.gov\/lewi\/learn\/photosmultimedia\/upload\/Ms.%20Nelson''s%20Sixth%20Grade%20Girls,%20SP%20April%2013,%202009%20.mp3",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/lewi\/learn\/photosmultimedia\/upload\/Ms.
+        Nelson''s Sixth Grade Girls...", "snippet": "ID3 vTYER 2009TXXX2EngineerLewis
+        and Clark National Historical ParkTCON OtherGEOBÃSfMarkers d †.ÖD Walking
+        Sound | \/« Walking Sound ^ \/« Walking Soundÿû’ ‹ Êù‰1°Qaù_1&6 AIæ fá ˆ)!ëÄðµ
+        ˆ qZëìîW€ A 8 .\/å…LŠ †å s;Wd³ 4é§ÿ®Ê¨ü¨ÂH è™¹—äª °Y ¦ . u ~‡$Ò»ú¯cz¸VÅÿû’É€
+        ¾ ...", "dateLastCrawled": "2021-02-01T09:31:00.0000000Z", "language": "vi",
+        "isNavigational": false}]}, "rankingResponse": {"mainline": {"items": [{"answerType":
+        "WebPages", "resultIndex": 0, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0"}},
+        {"answerType": "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1"}},
+        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2"}},
+        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3"}},
+        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4"}},
+        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5"}},
+        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6"}},
+        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7"}},
+        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8"}},
+        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9"}},
+        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10"}},
+        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11"}},
+        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12"}},
+        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13"}},
+        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14"}},
+        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15"}},
+        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16"}},
+        {"answerType": "WebPages", "resultIndex": 17, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17"}},
+        {"answerType": "WebPages", "resultIndex": 18, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18"}},
+        {"answerType": "WebPages", "resultIndex": 19, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19"}}]}}}'
+    http_version:
+  recorded_at: Wed, 09 Jun 2021 14:04:04 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/searches_controller/searching_on_a_routed_keyword_referrer_matches_redirect_url_when_the_match_is_exact_except_that_the_referring_url_is_https_and_the_routed_query_url_is_http_it_should_behave_like_a_routed_query_that_matches_the_referrer.yml
+++ b/spec/vcr_cassettes/searches_controller/searching_on_a_routed_keyword_referrer_matches_redirect_url_when_the_match_is_exact_except_that_the_referring_url_is_https_and_the_routed_query_url_is_http_it_should_behave_like_a_routed_query_that_matches_the_referrer.yml
@@ -62,7 +62,7 @@ http_interactions:
           "message": "Bad Request"
          }
         }
-    http_version: 
+    http_version:
   recorded_at: Thu, 22 Mar 2018 23:02:02 GMT
 - request:
     method: get
@@ -127,7 +127,7 @@ http_interactions:
           "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
          }
         }
-    http_version: 
+    http_version:
   recorded_at: Thu, 26 Apr 2018 23:29:11 GMT
 - request:
     method: get
@@ -316,6 +316,248 @@ http_interactions:
         {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14"}},
         {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15"}},
         {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16"}}]}}}'
-    http_version: 
+    http_version:
   recorded_at: Fri, 27 Apr 2018 16:03:00 GMT
+- request:
+    method: get
+    uri: https://api.cognitive.microsoft.com/bing/v7.0/search?count=20&mkt=en-US&offset=0&q=foo%20bar%20(site:nps.gov)&responseFilter=WebPages&safeSearch=moderate&textDecorations=true&traffictype=test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - USASearch
+      Ocp-Apim-Subscription-Key:
+      - "<BING_V7_SUBSCRIPTION_ID>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Cache-Control:
+      - private, max-age=0
+      Transfer-Encoding:
+      - chunked
+      Content-Type:
+      - application/json; charset=utf-8
+      Expires:
+      - Wed, 09 Jun 2021 13:22:13 GMT
+      Vary:
+      - Accept-Encoding
+      P3p:
+      - CP="NON UNI COM NAV STA LOC CURa DEVa PSAa PSDa OUR IND"
+      X-Snr-Routing:
+      - '1'
+      Bingapis-Traceid:
+      - FB1578D5F1004FACBFE8C6FD0F448F62
+      Bingapis-Sessionid:
+      - 68A408BC05C744E5AD5700D348F6935C
+      X-Msedge-Clientid:
+      - '09EE0AB9EB5B6A5033851AE8EAA66BEF'
+      X-Msapi-Userstate:
+      - fd99
+      Bingapis-Market:
+      - en-US
+      X-Search-Responseinfo:
+      - InternalResponseTime=261,MSDatacenter=BN2B
+      X-Cache:
+      - CONFIG_NOCACHE
+      X-Msedge-Ref:
+      - 'Ref A: FB1578D5F1004FACBFE8C6FD0F448F62 Ref B: BLUEDGE0319 Ref C: 2021-06-09T13:23:13Z'
+      Apim-Request-Id:
+      - 2352d203-e6bf-4005-9027-4000273a8b1f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Csp-Billing-Usage:
+      - CognitiveServices.BingSearchV7.Transaction=1
+      Date:
+      - Wed, 09 Jun 2021 13:23:13 GMT
+    body:
+      encoding: UTF-8
+      string: '{"_type": "SearchResponse", "queryContext": {"originalQuery": "foo
+        bar (site:nps.gov)"}, "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=foo+bar+(site%3anps.gov)",
+        "totalEstimatedMatches": 27, "value": [{"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0",
+        "name": "CodeMirror: User Manual - nps.gov", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/doc\/manual.html",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/doc\/manual.html",
+        "snippet": "It is possible to use multiple theming classes at once—for example
+        \"foo bar\" will assign both the cm-s-foo and the cm-s-bar classes to
+        the editor. indentUnit (integer) How many spaces a block (whatever that means
+        in the edited language) should be indented. The default is 2.", "dateLastCrawled":
+        "2020-03-25T01:15:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1", "name":
+        "Approved Backcountry Roads Temple Area - NPS.gov Homepage ...", "url":
+        "https:\/\/www.nps.gov\/lake\/planyourvisit\/upload\/Approved-Backcountry-Roads-Temple-Bar-Area-legal-size-2018.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/lake\/planyourvisit\/upload\/Approved-Backcountry-Roads-Temple-Bar...",
+        "snippet": "restrooms, foo Boat launch US route Maintained - unpaved road
+        Sanitary disposal station Hiking trail Picnic area Secondary 4WD road Gasoline
+        Campground ... Temple Bar Temple aar Trail oaaa ''apaï O 138 136 Sbtjhg
+        Mount''Wilson Wilderness (BLM) Clam 10 2rni Kingman 142 143 To Dolan Spnngs,
+        AZ and US Mjepost 42 To Dolan Spnngs, AZ", "dateLastCrawled": "2020-07-05T11:09:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2",
+        "name": "Mount Vernon Memorial Highway George Washington Memorial ...", "url":
+        "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/81000079.pdf", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/npgallery.nps.gov\/pdfhost\/docs\/NRHP\/Text\/81000079.pdf",
+        "snippet": "foo * ''&& Beveled curbing is used throughout the southern section
+        of the highway for easy pull-off onto the\" attjacyrit grass. '' Guard rails
+        where needed are of treated, unpainted wood to blend with the natural1 landscape.
+        ! The\"''Original plantings here are most fully intact at the Mount Vernon
+        terminus and at Belle Haven, a short distance", "dateLastCrawled": "2021-05-25T13:39:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3",
+        "name": "MONTANA HISTORICAL AND ARCHITECTURAL INVENTORY", "url": "https:\/\/npgallery.nps.gov\/NRHP\/GetAsset\/NRHP\/86002765_text",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/NRHP\/GetAsset\/NRHP\/86002765_text",
+        "snippet": "Foo,no«.sources: p< 570; ^^.^^ PP. 544, 558; 1917-18, pp. 554,
+        562. Interview with Rich Wollaston by John Lazuk. Interview with Louis LaRock
+        by John Lazuk. INTEGRITY: Assess the degree to which the structure\/site,
+        and surrounding area accurately convey the historical associations of the
+        property.", "dateLastCrawled": "2020-11-12T22:05:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/caco\/learn\/photosmultimedia\/upload\/Pamet%20Area%20Trails,%20revised%20credit-2.wmv",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/caco\/learn\/photosmultimedia\/upload\/Pamet
+        Area Trails, revised...", "snippet": "þ„wN·.¡:¤ ˜&IÁËi9w%:jØ…$€€ É)›~q t ª`
+        nÆ ú ðù ,''[tuZI š ”ã©ã·Ì¶L UZŒÎØÍ$áMû™3#{\/Œì i ’v öL „’oÎ~tÐ Šjp s’ ,Æ @EB#
+        f†10 I0 Ã ç6 Šgû 6«Æ Ì‘Ól 1³ûZ’ c 8 hXB†\"c 32 ßL,} $š 0°‡Ð=“c) u·²ÁC%m¥U´€Ø`oÐæ¸€
+        S¾)#•âÂ œÃ TÕ -¦—° uV 0Q ...", "dateLastCrawled": "2018-05-26T23:36:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/lewi\/learn\/photosmultimedia\/upload\/bonus06_musicyellipt&g''bye.mp3",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/lewi\/learn\/photosmultimedia\/upload\/bonus06_musicyellipt&g''bye.mp3",
+        "snippet": "Ã Z»è¨h¤DôÅoÜ’Ú6)Qvi¨ A „Û–€#cØ¨,è=K ÊÅòÓ³Ý§''­ùïœ¡ÉJ ï ‚Çaç@Ã
+        ¹Ì 4bŠzc ©éÁtŸ§hô–:É`ç vmÔˆÕ ¾F#d ~ ? •YõaUK «§‹ —aV1› R\\s ›vëlÛì¸a DÛŸ¯¶Ï-“žÑ
+        Áo5‘. u 6Áæ ?,æ:½\/šiþ_ •Eˆ ÎDt5C)Ÿ0õ}ÞXÉ^]r¢òŸ¦Ë wÛæ¸åÞï[Ö©^õ´. ÔÓ»®Cªà ...",
+        "dateLastCrawled": "2020-07-05T18:37:00.0000000Z", "language": "fr", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/nebe\/upload\/Journey-Through-New-Bedford-RF.epub",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/nebe\/upload\/Journey-Through-New-Bedford-RF.epub",
+        "snippet": "PUM–WÓC Tk„­¥j¼¤ƒ¶$¾•‡b¼¥¢ÉG #+ä^y£}cq ¼Û@|•} Å(¯r Ð¦V $¯ î›â
+        obÂ}ƒ&z£y '' Wi6ÄUÔ[ â>¡C … ö cô£PtTóV¨ pE=à3­t$·&Áˆ†Xcµö îúô(4H§5û&ÓSÎÂ‰Tyl@ÂŠ5Ø8ç§ßkûŠí€
+        E Ú² ¦wé_&R¥†€ôRTÜJ¨¸E‹)Ï ´ÕœkÁ ãj¤Õ »Ý´m˜nÜ¶ ] n(;«Äo`p« „ H»\" ¸U°mU ...",
+        "dateLastCrawled": "2020-05-27T11:30:00.0000000Z", "language": "fr", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/home.nps.gov\/mono\/learn\/photosmultimedia\/upload\/Welcome%20to%20Monocacy-%20An%20Introduction.m4v",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/mono\/learn\/photosmultimedia\/upload\/Welcome
+        to Monocacy- An...", "snippet": "ftypM4V M4V M4A mp42isom–öCmdat gBÀ št Ø
+        € € GŠ P hÎÙŸx%¦ Î†ýÜÓæ$ Fï : cƒ NA3‘ˆ^4 øÍ\/lûöý N G­ ý„©ÛM\/à >Z²çÒñÿäO
+        @g é1¼ ® …Ø=»•ü;B· ¿BÜv ¹AW¦«™öÒƒƒ Â^ °­œâ.^?®_ ! K¸ÿøYT&ÏË ÆõYT ê¼& öØF-F
+        ³ ¹Ï öÞÍ =,Ü š|š Í©§’›tú~¡Œ ‡\\ žÔÓ´µ¯6 ...", "dateLastCrawled": "2020-12-31T07:04:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8",
+        "name": "UNITED STATES DEPARTMENT OF THE INTERIOR NATIONAL PARK ...", "url":
+        "https:\/\/npgallery.nps.gov\/GetAsset\/654dc60c-2e86-4398-a410-2396cd7f1b0e\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/654dc60c-2e86-4398-a410-2396cd7f1b0e",
+        "snippet": "1979). .The north and south waiting rooms were made into a bar
+        and^restaurant. En­ closure of the passenger waiting porch provided additional
+        dining and kitchen space. The second floor was renovated for General Services
+        Administration offices, and the third floor for retail use. An elevator was
+        installed at the center of the structure", "dateLastCrawled": "2021-05-23T10:13:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9",
+        "name": "National Park Service National Register of Historic Places ...",
+        "url": "https:\/\/npgallery.nps.gov\/GetAsset\/b666d54c-df55-4e70-a12d-942c7b6bfb52",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/b666d54c-df55-4e70-a12d-942c7b6bfb52",
+        "snippet": "wheel base twenty ton caboose leaf spring arch bar trucks with
+        26\" diameter wheels. These new cars were the first D&RG cabooses to ride
+        on four-wheel trucks. One of the benefits of the increased length and wheel
+        modification of these types over the old 9-foot wheel-base Bobber style arrangement
+        was", "dateLastCrawled": "2021-06-05T19:17:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10",
+        "name": "home.nps.gov", "url": "https:\/\/home.nps.gov\/archeology\/npsGuide\/outreach\/RackArtifactsRangers_final.indd",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/archeology\/npsGuide\/outreach\/RackArtifactsRangers_final.indd",
+        "snippet": "íõØ Få½1ïçþt· DOCUMENT p gx‘ „ e Ü û¥ +]G 0ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ
+        ÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿÿ", "dateLastCrawled": "2020-11-29T15:17:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11",
+        "name": "NPGallery Search", "url": "https:\/\/npgallery.nps.gov\/GetAsset\/8b1a4118-8b4d-4b06-a317-e7592f80a5db\/original",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/8b1a4118-8b4d-4b06-a317-e7592f80a5db\/original",
+        "snippet": "Ž! „`§øKõ¢7ÐÆ!{@Æ›ª\\¢é( ~š Ñ(!ˆ ÄPIa ƒ.“(²£s Ú.£ªóÓ›œÄËØ§x le0áÛª½!È9:MÃÿÆ&+—|Þ¥{þ^øwiÇYhç”ì†L
+        ‹xg¼·¦ï ...", "dateLastCrawled": "2021-05-23T20:18:00.0000000Z", "language":
+        "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12",
+        "name": "National Register of Historic Places Continuation Sheet", "url":
+        "https:\/\/npgallery.nps.gov\/GetAsset\/203362ae-08c1-4f85-9184-b26ee52a2063\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/203362ae-08c1-4f85-9184-b26ee52a2063",
+        "snippet": "removal of the original doors, and metal bars placed over some
+        of the windows - the alternations do not impair the integrity of this historic
+        structure. The museum is located on the north side of the only major street
+        through town, Mesquite Boulevard, and is surrounded by various residential
+        and commercial structures. The south and east", "dateLastCrawled": "2021-05-31T17:41:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13",
+        "name": "Season 1 Episode 1: A Love of the Mountains with Kathy ...", "url":
+        "https:\/\/www.nps.gov\/romo\/blogs\/season-1-episode-1-a-love-of-the-mountains-with-kathy-brazelton.htm?result=true",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/romo\/blogs\/season-1-episode-1-a-love-of-the-mountains-with-kathy...",
+        "snippet": "I’m happy to appreciate the good work of dr Sam omijie Spell caster
+        For saving my lost relationship I never believe there will Be a way To get
+        my lover back but dr Sam omijie saved my relationship through his-spell and
+        after 15 hours my love I return to me and asked for forgiveness I’m very happy
+        because I never thought There is A great man like this You can also reach
+        him on his email at ...", "dateLastCrawled": "2021-01-09T05:59:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/goga\/learn\/nature\/upload\/GGNRA-Climate-Change-Project_FINAL.kmz",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/goga\/learn\/nature\/upload\/GGNRA-Climate-Change-Project_FINAL.kmz",
+        "snippet": "PK è~¢«fuhO ª doc.kmlì½_s Ç‘ö{íý k6+ÿV ƒæ \\Ù^+^ÙRXônœ½qÀ Lâ $
+        d¯öÓŸÌ I ÔtOƒ ‡M‹& Ì ººë©z²*ë— ÿÏÿ¼8ýìŸÇç¯NÎ^þös ÊçŸ ¿|zöÝÉËg¿ýü¯Oþp¯}þ ýÛÃïãUñÊ—¯~ûùó‹‹
+        Ü¿ÿ¯ ýk8ûáøå³“WÃËã‹ûñŠûµ NþçøôU|õÝ ß pÿ üæìô ...", "dateLastCrawled": "2020-04-04T00:05:00.0000000Z",
+        "language": "fr", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15",
+        "name": "ATIONAL REGISTER OF HISTORIC PLACES INVENTORY ...", "url": "https:\/\/npgallery.nps.gov\/GetAsset\/dae50824-9644-4739-9e86-22286747f8c4\/",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset\/dae50824-9644-4739-9e86-22286747f8c4",
+        "snippet": "hardware imbedded in the floor for the horizontal bar. Also
+        in the ceiling: the original light fixtures and 8 fans. The hall has some
+        90 tables and about 375 chairs of varying vintage - and some of the original
+        member-made benches from the first hall, This original hall stood just to
+        the north of the present hall", "dateLastCrawled": "2021-04-04T12:07:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16",
+        "name": "Better Lives, Bitter Lies (U.S. National Park Service)", "url": "https:\/\/home.nps.gov\/podcasts\/better-lives-bitter-lies.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/home.nps.gov\/podcasts\/better-lives-bitter-lies.htm",
+        "snippet": "The constitution has a sec, a section titled Chinese and basically
+        bars them from living in cities, but it was unenforceable, unconstitutional
+        based on the American constitution. And Chinese American leaders, the Chinese
+        merchants and the Chinese Six Companies were kind of at the forefront of fighting
+        these different local attempts to get rid ...", "dateLastCrawled": "2021-04-16T00:36:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17",
+        "name": "CodeMirror 2: JavaScript mode - NPS", "url": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/mode\/xquery\/index.html",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/npmap\/slides\/overview-of-npmap\/libs\/codemirror\/mode\/xquery\/index.html",
+        "snippet": "on Angie''s List for 6 years. Contact KEUKER TAX SVC. Phone Number.
+        (941) 766-0635. Address. 1931 TAMIAMI TRL. Port Charlotte , FL. 33948. Map.",
+        "dateLastCrawled": "2020-04-08T18:26:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18",
+        "name": "Site*", "url": "https:\/\/npgallery.nps.gov\/GetAsset?assetID=9741b365-5c1d-4b21-a9ec-5b65d84e8243",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/npgallery.nps.gov\/GetAsset?assetID=9741b365-5c1d-4b21-a9ec-5b65d84e8243",
+        "snippet": "two pool tables, two public baths and a bar\/restaurant on the
+        first floor. The second level had eight rooms which were used as rental offices
+        for a variety of downtown businesses. During prohibition, the barber shop
+        and a cigar a n d c a n d y s t o r e remained open for business. In the mid-to-late
+        1930s, t he b u i1d i nq served", "dateLastCrawled": "2021-05-27T21:55:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19",
+        "name": "National Park Service", "url": "http:\/\/home.nps.gov\/kemo\/upload\/KMNBP-2.kmz",
+        "isFamilyFriendly": true, "displayUrl": "home.nps.gov\/kemo\/upload\/KMNBP-2.kmz",
+        "snippet": "PK Zë %’ qÞ& doc.kmlì½ys\\Ç•\/ø·ûSÔÓÄÌ›‰ ÈÜ 7Í ²üÜîn»ÛÑROÿÑÑ¡(
+        E O Eó}ú9çÖ=™¿ÌªÂv« ,¤- 8yoÞ\\Ï¾¼ù ûp6ûeqyuº¿úÝW ...", "dateLastCrawled":
+        "2021-02-01T04:50:00.0000000Z", "language": "fr", "isNavigational": false}]},
+        "rankingResponse": {"mainline": {"items": [{"answerType": "WebPages", "resultIndex":
+        0, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0"}},
+        {"answerType": "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1"}},
+        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2"}},
+        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3"}},
+        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4"}},
+        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5"}},
+        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6"}},
+        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7"}},
+        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8"}},
+        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9"}},
+        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10"}},
+        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11"}},
+        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12"}},
+        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13"}},
+        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14"}},
+        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15"}},
+        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16"}},
+        {"answerType": "WebPages", "resultIndex": 17, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17"}},
+        {"answerType": "WebPages", "resultIndex": 18, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18"}},
+        {"answerType": "WebPages", "resultIndex": 19, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19"}}]}}}'
+    http_version:
+  recorded_at: Wed, 09 Jun 2021 13:23:13 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/searches_controller/when_affiliate/force_mobile_format_true.yml
+++ b/spec/vcr_cassettes/searches_controller/when_affiliate/force_mobile_format_true.yml
@@ -2,136 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.googleapis.com/customsearch/v1?alt=json&cx=<GOOGLE_SEARCH_CX>&key=<GOOGLE_API_KEY>&lr=lang_en&q=gov&quotaUser=USASearch&safe=medium
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - USASearch
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      Connection:
-      - keep-alive
-      Keep-Alive:
-      - '30'
-  response:
-    status:
-      code: 400
-      message: Bad Request
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 22 Mar 2018 23:02:22 GMT
-      Expires:
-      - Thu, 22 Mar 2018 23:02:22 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303432; quic=51303431; quic=51303339; quic=51303335,quic=":443";
-        ma=2592000; v="42,41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "usageLimits",
-            "reason": "keyInvalid",
-            "message": "Bad Request"
-           }
-          ],
-          "code": 400,
-          "message": "Bad Request"
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 22 Mar 2018 23:02:22 GMT
-- request:
-    method: get
-    uri: https://www.googleapis.com/customsearch/v1?alt=json&cx=<GOOGLE_SEARCH_CX>&key=<GOOGLE_API_KEY>&lr=lang_en&q=gov%20site:nps.gov&quotaUser=USASearch&safe=medium
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - USASearch
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      Connection:
-      - keep-alive
-      Keep-Alive:
-      - '30'
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 26 Apr 2018 23:29:21 GMT
-      Expires:
-      - Thu, 26 Apr 2018 23:29:21 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303433; quic=51303432; quic=51303431; quic=51303339;
-        quic=51303335,quic=":443"; ma=2592000; v="43,42,41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "usageLimits",
-            "reason": "accessNotConfigured",
-            "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
-            "extendedHelp": "https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333"
-           }
-          ],
-          "code": 403,
-          "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 26 Apr 2018 23:29:21 GMT
-- request:
-    method: get
-    uri: https://www.bingapis.com/api/v6/search?AppId=<BING_V6_APP_ID>&count=20&mkt=en-US&offset=0&q=gov%20(site:nps.gov)&responseFilter=WebPages,SpellSuggestions&safeSearch=moderate&textDecorations=true&traffictype=test
+    uri: https://api.cognitive.microsoft.com/bing/v7.0/search?count=20&mkt=en-US&offset=0&q=gov%20(site:nps.gov)&responseFilter=WebPages&safeSearch=moderate&textDecorations=true&traffictype=test
     body:
       encoding: US-ASCII
       string: ''
@@ -139,7 +10,7 @@ http_interactions:
       User-Agent:
       - USASearch
       Ocp-Apim-Subscription-Key:
-      - "<BING_V6_APP_ID>"
+      - "<BING_V7_SUBSCRIPTION_ID>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -155,213 +26,227 @@ http_interactions:
     headers:
       Cache-Control:
       - private, max-age=0
-      Content-Length:
-      - '3378'
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
-      - Fri, 27 Apr 2018 16:02:04 GMT
+      - Wed, 09 Jun 2021 14:03:05 GMT
       Vary:
       - Accept-Encoding
       P3p:
       - CP="NON UNI COM NAV STA LOC CURa DEVa PSAa PSDa OUR IND"
-      Set-Cookie:
-      - MUID=3B1199E3559262C53758923D54056368; path=/; expires=Wed, 22-May-2019 16:03:04
-        GMT; domain=bingapis.com
-      - MUIDB=3B1199E3559262C53758923D54056368; path=/; httponly; expires=Wed, 22-May-2019
-        16:03:04 GMT
-      - SRCHD=AF=NOFORM; domain=.bingapis.com; expires=Mon, 27-Apr-2020 16:03:04 GMT;
-        path=/
-      - SRCHUID=V=2&GUID=240518F84152473884A0ADD309EBD189&dmnchg=1; domain=.bingapis.com;
-        expires=Mon, 27-Apr-2020 16:03:04 GMT; path=/
-      - SRCHUSR=DOB=20180427; domain=.bingapis.com; expires=Mon, 27-Apr-2020 16:03:04
-        GMT; path=/
-      - _EDGE_S=mkt=en-us&F=1&SID=272D68440C5769BB333B639A0DC06888; path=/; httponly;
-        domain=bingapis.com
-      - _EDGE_V=1; path=/; httponly; expires=Wed, 22-May-2019 16:03:04 GMT; domain=bingapis.com
-      - _SS=SID=272D68440C5769BB333B639A0DC06888; domain=.bingapis.com; path=/
+      X-Snr-Routing:
+      - '1'
       Bingapis-Traceid:
-      - 22A737D3B31640838C41AFC75F42E297
+      - '0080BE02002C4899B3B5EFBDE5577A1D'
+      Bingapis-Sessionid:
+      - ECA1248543B0445DBE8899A1F3313E52
       X-Msedge-Clientid:
-      - 3B1199E3559262C53758923D54056368
+      - 325CF34D286F6F0D2010E31C29926E92
       X-Msapi-Userstate:
-      - 706a
+      - 3d73
       Bingapis-Market:
       - en-US
+      X-Search-Responseinfo:
+      - InternalResponseTime=326,MSDatacenter=BN2B
+      X-Cache:
+      - CONFIG_NOCACHE
       X-Msedge-Ref:
-      - 'Ref A: 22A737D3B31640838C41AFC75F42E297 Ref B: CO1EDGE0209 Ref C: 2018-04-27T16:03:04Z'
+      - 'Ref A: 0080BE02002C4899B3B5EFBDE5577A1D Ref B: BLUEDGE1022 Ref C: 2021-06-09T14:04:05Z'
+      Apim-Request-Id:
+      - 0ba68f0b-f49c-430f-9c6d-7dd541472c18
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Csp-Billing-Usage:
+      - CognitiveServices.BingSearchV7.Transaction=1
       Date:
-      - Fri, 27 Apr 2018 16:03:03 GMT
+      - Wed, 09 Jun 2021 14:04:05 GMT
     body:
       encoding: UTF-8
-      string: '{"_type": "SearchResponse", "instrumentation": {"pingUrlBase": "https:\/\/www.bingapis.com\/api\/ping?IG=76A0819AE7E44DC6A2AEB083566070D2&CID=3B1199E3559262C53758923D54056368&ID=",
-        "pageLoadPingUrl": "https:\/\/www.bingapis.com\/api\/ping\/pageload?IG=76A0819AE7E44DC6A2AEB083566070D2&CID=3B1199E3559262C53758923D54056368&Type=Event.CPT&DATA=0"},
-        "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=gov+(site%3anps.gov)",
-        "webSearchUrlPingSuffix": "DevEx,5584.1", "totalEstimatedMatches": 4860000,
-        "value": [{"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.0", "name":
-        "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/index.htm",
-        "urlPingSuffix": "DevEx,5100.1", "about": [{"name": "Everglades National Park"},
-        {"name": "Sequoia National Park"}, {"name": "Muir Woods National Monument"},
-        {"name": "National Park Service"}], "displayUrl": "https:\/\/www.nps.gov",
-        "snippet": "The National Park Service cares for special places saved by the
-        American people so that all may experience our heritage.", "deepLinks": [{"name":
-        "Find a Park", "url": "https:\/\/www.nps.gov\/findapark\/index.htm", "urlPingSuffix":
-        "DevEx,5087.1"}, {"name": "National Park Passes", "url": "https:\/\/www.nps.gov\/planyourvisit\/passes.htm",
-        "urlPingSuffix": "DevEx,5088.1"}, {"name": "Work With Us", "url": "https:\/\/www.nps.gov\/aboutus\/workwithus.htm",
-        "urlPingSuffix": "DevEx,5089.1"}, {"name": "California", "url": "https:\/\/www.nps.gov\/state\/ca\/index.htm",
-        "urlPingSuffix": "DevEx,5090.1"}, {"name": "Contact Us", "url": "https:\/\/www.nps.gov\/aboutus\/contactus.htm",
-        "urlPingSuffix": "DevEx,5091.1"}], "dateLastCrawled": "2018-04-20T19:02:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.1", "name": "Path
-        of Progress National Heritage Tour Route - nps.gov", "url": "https:\/\/www.nps.gov\/PAPR\/index.htm",
-        "urlPingSuffix": "DevEx,5114.1", "displayUrl": "https:\/\/www.nps.gov\/PAPR",
-        "snippet": "Moved Permanently. The document has moved here.", "dateLastCrawled":
-        "2018-04-19T11:52:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.2",
-        "name": "Find a Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/findapark\/index.htm",
-        "urlPingSuffix": "DevEx,5139.1", "about": [{"name": "National Park Service"}],
-        "displayUrl": "https:\/\/www.nps.gov\/findapark", "snippet": "Find a national
-        park by selecting from a list or choosing a state on the map.", "dateLastCrawled":
-        "2018-04-22T09:11:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.3",
-        "name": "Work with Us - NPS.gov Homepage (U.S. National Park Service)",
-        "url": "https:\/\/www.nps.gov\/personnel\/", "urlPingSuffix": "DevEx,5155.1",
-        "about": [{"name": "National Park Service"}], "displayUrl": "https:\/\/www.nps.gov\/personnel",
-        "snippet": "Explore opportunities to work for the National Park Service, from
-        paid employment to student positions to volunteer positions.", "dateLastCrawled":
-        "2018-04-20T19:18:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.4",
-        "name": "What We Do (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/aboutus\/index.htm",
-        "urlPingSuffix": "DevEx,5171.1", "about": [{"name": "National Park Service"}],
-        "displayUrl": "https:\/\/www.nps.gov\/aboutus", "snippet": "The National
-        Park Service is a bureau of the U.S. Department of the Interior and is led
-        by a Director nominated by the ... USA.gov; Facebook Facebook; ...", "dateLastCrawled":
-        "2018-04-22T03:04:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.5",
-        "name": "Management (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/aboutus\/management.htm",
-        "urlPingSuffix": "DevEx,5187.1", "displayUrl": "https:\/\/www.nps.gov\/aboutus\/management.htm",
-        "snippet": "Management. The National Park ... USA.gov; Facebook Facebook;
-        Youtube Youtube; Twitter Twitter; Instagram Instagram; Flickr Flickr iTunes
-        iTunes ...", "dateLastCrawled": "2018-04-22T07:04:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.6",
-        "name": "National News Release Archive (U.S. National Park Service)",
-        "url": "https:\/\/www.nps.gov\/aboutus\/news\/listing.htm", "urlPingSuffix":
-        "DevEx,5203.1", "about": [{"name": "National Park Service"}], "displayUrl":
-        "https:\/\/www.nps.gov\/aboutus\/news\/listing.htm", "snippet": "Listing
-        of National Park Service news releases from the national Office of Communications",
-        "dateLastCrawled": "2018-04-18T20:21:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.7",
-        "name": "Laws, Policies & Regulations (U.S. National Park Service)", "url":
-        "https:\/\/www.nps.gov\/aboutus\/lawsandpolicies.htm", "urlPingSuffix": "DevEx,5219.1",
-        "displayUrl": "https:\/\/www.nps.gov\/aboutus\/lawsandpolicies.htm", "snippet":
-        "Laws, Policies & Regulations. ... USA.gov; Facebook Facebook; Youtube
-        Youtube; Twitter Twitter; Instagram Instagram; Flickr Flickr; iTunes ...",
-        "dateLastCrawled": "2018-04-22T12:39:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.8",
-        "name": "Maritime Heritage Program | National Park Service", "url": "https:\/\/www.nps.gov\/maritime\/",
-        "urlPingSuffix": "DevEx,5234.1", "about": [{"name": "Cana Island Light"},
-        {"name": "United States Life-Saving Service"}, {"name": "South Buffalo North
-        Side Light"}, {"name": "Execution Rocks Light"}, {"name": "Grosse Point Light"},
-        {"name": "Cana Island Light"}, {"name": "United States Life-Saving Service"},
-        {"name": "South Buffalo North Side Light"}, {"name": "Execution Rocks Light"},
-        {"name": "Grosse Point Light"}], "displayUrl": "https:\/\/www.nps.gov\/maritime",
-        "snippet": "The Maritime Heritage Program (NPS) helps interpret and preserve
-        diverse facets of America''s maritime heritage.", "dateLastCrawled": "2018-04-21T01:25:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.9", "name": "Bryce
-        Canyon NP - Official Site", "url": "https:\/\/www.nps.gov\/brca\/index.htm",
-        "urlPingSuffix": "DevEx,5251.1", "about": [{"name": "Bryce Canyon National
-        Park"}, {"name": "Bryce Canyon National Park"}], "displayUrl": "https:\/\/www.nps.gov\/brca",
-        "snippet": "Bring your sense of wonder and imagination when visiting Bryce
-        Canyon National Park. Read More. Park Once, See it ... USA.gov; Facebook
-        Facebook; Youtube Youtube", "dateLastCrawled": "2018-04-21T06:14:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.10", "name": "Yellowstone
-        National Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/yell\/index.htm",
-        "urlPingSuffix": "DevEx,5268.1", "about": [{"name": "Old Faithful"}, {"name":
-        "Yellowstone National Park"}, {"name": "Yellowstone National Park"}], "displayUrl":
-        "https:\/\/nps.gov\/yell", "snippet": "Marvel, explore, discover: visit
-        Yellowstone and experience the world''s first national park.", "dateLastCrawled":
-        "2018-04-23T02:20:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.11",
-        "name": "Zion National Park - Official Site", "url": "https:\/\/www.nps.gov\/zion\/index.htm",
-        "urlPingSuffix": "DevEx,5285.1", "about": [{"name": "Zion National Park"},
-        {"name": "Zion National Park"}], "displayUrl": "https:\/\/nps.gov\/zion",
-        "snippet": "Enjoy this park movie which gives good insight into a Zion National
-        Park visit. ... please email us at zion_park_information@nps.gov. Contact
-        Us. Tools. FAQ; Site ...", "dateLastCrawled": "2018-04-22T17:22:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.12", "name": "Contact
-        Us (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/aboutus\/contactus.htm",
-        "urlPingSuffix": "DevEx,5301.1", "about": [{"name": "National Park Service"}],
-        "displayUrl": "https:\/\/www.nps.gov\/aboutus\/contactus.htm", "snippet":
-        "Help us help you by directing your question to the right people! Before you
-        send an email, check out frequently asked questions, which includes information
-        about the National Park Service, visiting parks (including entrance passes),
-        and other topics.", "dateLastCrawled": "2018-04-21T20:19:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.13", "name": "National Historic
-        Landmarks Program | National Park Service", "url": "https:\/\/www.nps.gov\/nhl\/",
-        "urlPingSuffix": "DevEx,5317.1", "about": [{"name": "National Historic Landmark"},
-        {"name": "National Historic Landmark"}], "displayUrl": "https:\/\/www.nps.gov\/nhl",
-        "snippet": "National Historic Landmarks (NHLs) are nationally significant
-        historic places designated by the Secretary of the Interior because they possess
-        exceptional value or quality in illustrating or interpreting the heritage
-        of the United States. Today, just over 2,500 historic places bear this national
-        ...", "dateLastCrawled": "2018-04-20T14:03:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14",
-        "name": "Grand Canyon National Park (U.S. National Park Service)", "url":
-        "https:\/\/www.nps.gov\/grca\/index.htm", "urlPingSuffix": "DevEx,5333.1",
-        "about": [{"name": "Grand Canyon Village"}, {"name": "Grand Canyon National
-        Park"}, {"name": "Grand Canyon Caverns"}, {"name": "Grand Canyon National
-        Park"}, {"name": "Grand Canyon"}], "displayUrl": "https:\/\/www.nps.gov\/grca",
-        "snippet": "Grand Canyon National Park. ... Grand Canyon overwhelms our senses
-        through its immense size. ... USA.gov; Facebook Facebook; ...", "dateLastCrawled":
-        "2018-04-22T05:41:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15",
-        "name": "Tumacácori National Historical Park (U.S. National Park ...", "url":
-        "https:\/\/www.nps.gov\/tuma\/index.htm", "urlPingSuffix": "DevEx,5350.1",
-        "about": [{"name": "Tumacacori National Historical Park"}, {"name": "Tumacacori
-        National Historical Park"}], "displayUrl": "https:\/\/www.nps.gov\/tuma",
-        "snippet": "Welcome to the 2018 Art in the Park exhibit! View art inspired
-        by Tumacácori and follow the exhibit on social media. All 4th graders in America
-        are entitled to a free annual pass to their national parks. Go online to print
-        your voucher, then visit a park ...", "dateLastCrawled": "2018-04-23T01:54:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16", "name": "Yosemite
-        National Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/yose\/index.htm",
-        "urlPingSuffix": "DevEx,5367.1", "about": [{"name": "Yosemite National Park"},
-        {"name": "Oxon Cove Park and Oxon Hill Farm"}, {"name": "El Capitan"}, {"name":
-        "Bridalveil Creek Campground"}, {"name": "Yosemite National Park"}], "displayUrl":
-        "https:\/\/www.nps.gov\/yose", "snippet": "Recreation.gov Help ; Make
-        a Campground Reservation ; ... Yosemite National Park is best known for its
-        waterfalls, but within its nearly 1,200 square miles, ...", "dateLastCrawled":
-        "2018-04-22T11:44:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.17",
-        "name": "Plan Your Visit - Valles Caldera National Preserve (U.S ...",
-        "url": "https:\/\/www.nps.gov\/vall\/planyourvisit\/index.htm", "urlPingSuffix":
-        "DevEx,5384.1", "about": [{"name": "Valles Caldera"}], "displayUrl": "https:\/\/www.nps.gov\/vall\/planyourvisit",
-        "snippet": "Each year thousands of visitors come to Valles Caldera National
-        Preserve to explore the supervolcano, view elk, and learn about the historic
-        cabins and prehistoric sites.", "dateLastCrawled": "2018-04-22T13:59:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.18", "name": "Augusta
-        Canal National Heritage Area (U.S. National Park ...", "url": "https:\/\/www.nps.gov\/auca\/index.htm",
-        "urlPingSuffix": "DevEx,5401.1", "about": [{"name": "Augusta Canal"}], "displayUrl":
-        "https:\/\/www.nps.gov\/auca", "snippet": "The Augusta Canal helped usher
-        the Industrial Revolution into the American South. Built in 1845 as a source
-        of power, water, and transportation, the canal today is the only fully intact
-        American industrial canal in continuous operation. By 1847 the first mills
-        opened, followed by the massive Civil ...", "dateLastCrawled": "2018-04-23T02:07:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.19", "name": "State,
-        Tribal, and Local Plans & Grants", "url": "https:\/\/www.nps.gov\/preservation-grants\/sat\/index.html",
-        "urlPingSuffix": "DevEx,5417.1", "displayUrl": "https:\/\/www.nps.gov\/preservation-grants\/sat\/index.html",
-        "snippet": "The Federal Save America''s Treasures grants program began in
-        1999 and helps preserve ... it will be announced here and applications will
-        be available on grants.gov.", "dateLastCrawled": "2018-04-22T11:36:00.0000000Z"}]},
-        "rankingResponse": {"mainline": {"items": [{"answerType": "WebPages", "resultIndex":
-        0, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.0"}}, {"answerType":
-        "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.1"}},
-        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.2"}},
-        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.3"}},
-        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.4"}},
-        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.5"}},
-        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.6"}},
-        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.7"}},
-        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.8"}},
-        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.9"}},
-        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.10"}},
-        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.11"}},
-        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.12"}},
-        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.13"}},
-        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14"}},
-        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15"}},
-        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16"}},
-        {"answerType": "WebPages", "resultIndex": 17, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.17"}},
-        {"answerType": "WebPages", "resultIndex": 18, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.18"}},
-        {"answerType": "WebPages", "resultIndex": 19, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.19"}}]}}}'
-    http_version: 
-  recorded_at: Fri, 27 Apr 2018 16:03:04 GMT
+      string: '{"_type": "SearchResponse", "queryContext": {"originalQuery": "gov
+        (site:nps.gov)"}, "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=gov+(site%3anps.gov)",
+        "totalEstimatedMatches": 1780000, "value": [{"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0",
+        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/index.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov", "snippet":
+        "The National Park Service cares for special places saved by the American
+        people so that all may experience our heritage.", "dateLastCrawled": "2021-06-03T11:29:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1",
+        "name": "Find a Park (U.S. National Park Service) - NPS", "url": "https:\/\/www.nps.gov\/findapark\/index.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/findapark",
+        "snippet": "Chinese immigrants in the mid-19th century played an important
+        part in mining communities and shaping the eventual national park. Tule Lake
+        National Monument tells the stories of 30,000 Japanese Americans who were
+        forced to relocate to the camp far from their homes. Find your adventure on
+        the ...", "dateLastCrawled": "2021-06-01T16:44:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2",
+        "name": "Entrance Passes (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/planyourvisit\/passes.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/planyourvisit\/passes.htm",
+        "snippet": "2021 Interagency Annual Pass - Military . Sam Jezak, 2019 Share
+        the Experience Photo Contest Grand Prize Winner. Military Pass. Cost: Free
+        annual pass Available for: Current U.S. military members and their dependents
+        in the Army, Navy, Air Force, Marines, Coast Guard, and Space Force, as well
+        as Reserve and National Guard members. How to obtain: In person at a federal
+        recreation site by ...", "dateLastCrawled": "2021-05-20T22:55:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3",
+        "name": "NPS Celebrates! (U.S. National Park Service) - nps.gov", "url":
+        "https:\/\/www.nps.gov\/subjects\/npscelebrates\/index.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/subjects\/npscelebrates", "snippet":
+        "Join us in celebrating and commemorating the stories, places, and people
+        of the National Park Service! Each year parks and programs across the country
+        work together to observe annual events, significant anniversaries, and other
+        celebrations.", "dateLastCrawled": "2021-06-01T14:35:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4",
+        "name": "Yellowstone National Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/yell\/index.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/nps.gov\/yell", "snippet":
+        "On March 1, 1872, Yellowstone became the first national park for all to enjoy
+        the unique hydrothermal and geologic wonders. The broad array of habitat types
+        found within Yellowstone contributes to a high diversity of bird species,
+        including many whose migratory travels bring them back to the park ...", "dateLastCrawled":
+        "2021-05-19T18:29:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5", "name":
+        "Grand Canyon National Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/grca\/index.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/grca", "snippet":
+        "Considering a visit? South Rim has RV Trailer Village, Mather, and Desert
+        View Campgrounds. The North Rim Campground is open for the season. Download
+        and read our Trip Planner before you visit the park. Contains useful information
+        and essential maps for both North and South Rims ...", "dateLastCrawled":
+        "2021-06-06T21:02:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6", "name":
+        "Denali National Park & Preserve (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/dena\/index.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/dena\/index.htm",
+        "snippet": "Look for wildlife and wilderness during a bus trip in Denali.
+        Most of the sole road is open only to buses during summer (May 20—mid-Sept.).
+        At just over 9 miles, Triple Lakes is the longest trail in Denali, with a
+        trailhead near the Denali Visitor Center and another on Highway 3. A ranger
+        is ...", "dateLastCrawled": "2021-05-20T15:49:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7",
+        "name": "Bryce Canyon National Park (U.S. National Park Service)", "url":
+        "https:\/\/www.nps.gov\/brca\/index.htm", "isFamilyFriendly": true, "displayUrl":
+        "https:\/\/www.nps.gov\/brca", "snippet": "Red Rocks, Pink Cliffs, and Endless
+        Vistas. Hoodoos (irregular columns of rock) exist on every continent, but
+        here is the largest concentration found anywhere on Earth.", "dateLastCrawled":
+        "2021-06-01T20:48:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8", "name":
+        "Rocky Mountain National Park (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/romo\/index.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/romo", "snippet":
+        "Feel Like You’re On Top of the World! Rocky Mountain National Park’s 415
+        square miles encompass and protect spectacular mountain environments.", "dateLastCrawled":
+        "2021-05-15T01:24:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9", "name":
+        "Sequoia & Kings Canyon National Parks (U.S. National Park ...", "url": "https:\/\/www.nps.gov\/seki\/index.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/nps.gov\/seki", "snippet":
+        "This dramatic landscape testifies to nature''s size, beauty, and diversity—huge
+        mountains, rugged foothills, deep canyons, vast caverns, and the world''s
+        largest trees. The parks lie side by side in the southern Sierra Nevada east
+        of the San Joaquin Valley. Weather varies a lot by season and ...", "dateLastCrawled":
+        "2021-06-03T18:05:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10", "name":
+        "Free Access for 5th Graders (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/kids\/fifthgrade.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/kids\/fifthgrade.htm",
+        "snippet": "The voucher is for U.S. fifth-grade (or home-school equivalent)
+        students. The 5th grade voucher is only valid on Department of the Interior
+        lands, which include sites managed by the National Park Service, Fish and
+        Wildlife Service, Bureau of Land Management, and Bureau of Reclamation.",
+        "dateLastCrawled": "2021-03-13T21:40:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11",
+        "name": "Sojourner Truth: Ain''t I A Woman? (U.S. National Park Service)",
+        "url": "https:\/\/www.nps.gov\/articles\/sojourner-truth.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/articles\/sojourner-truth.htm",
+        "snippet": "Well, children, where there is so much racket there must be something
+        out of kilter. I think that ''twixt the negroes of the South and the women
+        at the North, all talking about rights, the white men will be in a fix pretty
+        soon.", "dateLastCrawled": "2021-06-07T02:53:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12",
+        "name": "Vehicle Reservations - NPS.gov Homepage (U.S. National ...", "url":
+        "https:\/\/www.nps.gov\/acad\/planyourvisit\/vehicle_reservations.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/acad\/planyourvisit\/vehicle_reservations.htm",
+        "snippet": "To make a vehicle reservation, visit Recreation.gov. Learn more
+        at nps.gov\/acadia . Visit our keyboard shortcuts docs for details Duration:
+        52.01 seconds. Driving your car to one of the most popular destinations in
+        Acadia National Park requires a vehicle reservation. The system helps to reduce
+        congestion, increase safety, and make finding a ...", "dateLastCrawled": "2021-06-05T10:32:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13",
+        "name": "Going-to-the-Sun Road Ticketed Entry - NPS.gov Homepage (U ...",
+        "url": "https:\/\/www.nps.gov\/glac\/planyourvisit\/gtsrticketedentry.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/glac\/planyourvisit\/gtsrticketedentry.htm",
+        "snippet": "In addition to the passes listed above, entry to the Going-to-the-Sun
+        Road at West Glacier or St. Mary, or via the Camas Road, will require a $2.00
+        Entry Reservation Ticket or a Service Reservation, as described in the detailed
+        information on this page and on the map above.Please read through this information
+        carefully. Entry into Glacier National Park at Many Glacier, Two Medicine,
+        or ...", "dateLastCrawled": "2021-06-05T15:15:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14",
+        "name": "The Turning Point - NPS.gov Homepage (U.S. National Park ...",
+        "url": "https:\/\/www.nps.gov\/sara\/index.htm", "isFamilyFriendly": true,
+        "displayUrl": "https:\/\/www.nps.gov\/sara", "snippet": "The Turning Point.
+        Here, in 1777, during the American War for Independence, American troops battled
+        and beat a British invasion force, marking the first time in world history
+        that a British Army ever surrendered.", "dateLastCrawled": "2021-05-16T00:02:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15",
+        "name": "Your Benefits (U.S. National Park Service) - nps.gov", "url": "https:\/\/www.nps.gov\/aboutus\/benefits.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/aboutus\/benefits.htm",
+        "snippet": "To find out more about Social Security, please go to www.ssa.gov.
+        Thrift Savings Plan Visit The TSP website for detailed information The Thrift
+        Savings Plan (TSP) is a Defined Contribution Plan and a long term savings
+        plan that allows for the employee to take control of how much and where your
+        money is being invested. It offers federal civilian ...", "dateLastCrawled":
+        "2021-06-05T04:12:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16", "name":
+        "Underground Railroad (U.S. National Park Service) - nps.gov", "url": "https:\/\/www.nps.gov\/ugrr\/index.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/ugrr", "snippet":
+        "Beginning in the 17 th century and continuing through the mid-19 th century
+        in the United States, enslaved African Americans resisted bondage to gain
+        their freedom through acts of self-emancipation. The individuals who sought
+        this freedom from enslavement, known as freedom seekers, and those who assisted
+        along the way, united together to become what is known as the Underground
+        Railroad.", "dateLastCrawled": "2020-02-27T18:15:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17",
+        "name": "Free Entrance to National Parks for Veterans and Gold Star ...",
+        "url": "https:\/\/www.nps.gov\/planyourvisit\/veterans-and-gold-star-families-free-access.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/planyourvisit\/veterans-and-gold-star-families-free-access.htm",
+        "snippet": "Since Veterans Day 2020, Gold Star Families and US military veterans
+        are eligible to receive free access to more than 2,000 federal recreation
+        areas, including national parks, wildlife refuges, and forests.", "dateLastCrawled":
+        "2021-06-05T21:18:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18", "name":
+        "Sacred Space - nps.gov", "url": "https:\/\/www.nps.gov\/efmo\/index.htm",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/efmo", "snippet":
+        "Sacred Space. The mounds preserved here are considered sacred by many Americans,
+        especially the Monument''s 20 culturally associated American Indian tribes.",
+        "dateLastCrawled": "2021-02-27T17:33:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19",
+        "name": "Changes to the Senior Pass (U.S. National Park Service)", "url":
+        "https:\/\/www.nps.gov\/planyourvisit\/senior-pass-changes.htm", "isFamilyFriendly":
+        true, "displayUrl": "https:\/\/www.nps.gov\/planyourvisit\/senior-pass-changes.htm",
+        "snippet": "On August 28, 2017, the price of the America the Beautiful – The
+        National Parks and Federal Recreational Lands Senior Pass increased for the
+        first time since 1994.The additional revenue will be used to enhance the visitor
+        experience in parks. Learn more about the changes, what they mean for you,
+        and how the additional funds will be used.", "dateLastCrawled": "2021-03-25T22:24:00.0000000Z",
+        "language": "en", "isNavigational": false}]}, "rankingResponse": {"mainline":
+        {"items": [{"answerType": "WebPages", "resultIndex": 0, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0"}},
+        {"answerType": "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1"}},
+        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2"}},
+        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3"}},
+        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4"}},
+        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5"}},
+        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6"}},
+        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7"}},
+        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8"}},
+        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9"}},
+        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10"}},
+        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11"}},
+        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12"}},
+        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13"}},
+        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14"}},
+        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15"}},
+        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16"}},
+        {"answerType": "WebPages", "resultIndex": 17, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17"}},
+        {"answerType": "WebPages", "resultIndex": 18, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18"}},
+        {"answerType": "WebPages", "resultIndex": 19, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19"}}]}}}'
+    http_version:
+  recorded_at: Wed, 09 Jun 2021 14:04:06 GMT
 recorded_with: VCR 4.0.0

--- a/spec/vcr_cassettes/searches_controller_docs/when_the_request_is_from_a_mobile_device.yml
+++ b/spec/vcr_cassettes/searches_controller_docs/when_the_request_is_from_a_mobile_device.yml
@@ -2,72 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: https://www.googleapis.com/customsearch/v1?alt=json&cx=<GOOGLE_SEARCH_CX>&key=<GOOGLE_API_KEY>&lr=lang_en&q=pdf%20site:nps.gov&quotaUser=USASearch&safe=medium
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      User-Agent:
-      - USASearch
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-      Accept:
-      - "*/*"
-      Connection:
-      - keep-alive
-      Keep-Alive:
-      - '30'
-  response:
-    status:
-      code: 403
-      message: Forbidden
-    headers:
-      Vary:
-      - Origin
-      - X-Origin
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Thu, 26 Apr 2018 23:56:51 GMT
-      Expires:
-      - Thu, 26 Apr 2018 23:56:51 GMT
-      Cache-Control:
-      - private, max-age=0
-      X-Content-Type-Options:
-      - nosniff
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Xss-Protection:
-      - 1; mode=block
-      Server:
-      - GSE
-      Alt-Svc:
-      - hq=":443"; ma=2592000; quic=51303433; quic=51303432; quic=51303431; quic=51303339;
-        quic=51303335,quic=":443"; ma=2592000; v="43,42,41,39,35"
-      Transfer-Encoding:
-      - chunked
-    body:
-      encoding: UTF-8
-      string: |
-        {
-         "error": {
-          "errors": [
-           {
-            "domain": "usageLimits",
-            "reason": "accessNotConfigured",
-            "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry.",
-            "extendedHelp": "https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333"
-           }
-          ],
-          "code": 403,
-          "message": "Access Not Configured. CustomSearch API has not been used in project 913155601333 before or it is disabled. Enable it by visiting https://console.developers.google.com/apis/api/customsearch.googleapis.com/overview?project=913155601333 then retry. If you enabled this API recently, wait a few minutes for the action to propagate to our systems and retry."
-         }
-        }
-    http_version: 
-  recorded_at: Thu, 26 Apr 2018 23:56:51 GMT
-- request:
-    method: get
-    uri: https://www.bingapis.com/api/v6/search?AppId=<BING_V6_APP_ID>&count=20&mkt=en-US&offset=0&q=pdf%20(site:nps.gov)&responseFilter=WebPages,SpellSuggestions&safeSearch=moderate&textDecorations=true&traffictype=test
+    uri: https://api.cognitive.microsoft.com/bing/v7.0/search?count=20&mkt=en-US&offset=0&q=pdf%20(site:nps.gov)&responseFilter=WebPages&safeSearch=moderate&textDecorations=true&traffictype=test
     body:
       encoding: US-ASCII
       string: ''
@@ -75,7 +10,7 @@ http_interactions:
       User-Agent:
       - USASearch
       Ocp-Apim-Subscription-Key:
-      - "<BING_V6_APP_ID>"
+      - "<BING_V7_SUBSCRIPTION_ID>"
       Accept-Encoding:
       - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
       Accept:
@@ -91,185 +26,198 @@ http_interactions:
     headers:
       Cache-Control:
       - private, max-age=0
-      Content-Length:
-      - '2998'
+      Transfer-Encoding:
+      - chunked
       Content-Type:
       - application/json; charset=utf-8
       Expires:
-      - Fri, 27 Apr 2018 16:06:14 GMT
+      - Wed, 09 Jun 2021 14:05:36 GMT
       Vary:
       - Accept-Encoding
       P3p:
       - CP="NON UNI COM NAV STA LOC CURa DEVa PSAa PSDa OUR IND"
-      Set-Cookie:
-      - MUID=1A61BB564CA26824024DB0884D3569E8; path=/; expires=Wed, 22-May-2019 16:07:14
-        GMT; domain=bingapis.com
-      - MUIDB=1A61BB564CA26824024DB0884D3569E8; path=/; httponly; expires=Wed, 22-May-2019
-        16:07:14 GMT
-      - SRCHD=AF=NOFORM; domain=.bingapis.com; expires=Mon, 27-Apr-2020 16:07:14 GMT;
-        path=/
-      - SRCHUID=V=2&GUID=DAD357A2181F41AEAF1992BB0924DA26&dmnchg=1; domain=.bingapis.com;
-        expires=Mon, 27-Apr-2020 16:07:14 GMT; path=/
-      - SRCHUSR=DOB=20180427; domain=.bingapis.com; expires=Mon, 27-Apr-2020 16:07:14
-        GMT; path=/
-      - _EDGE_S=mkt=en-us&F=1&SID=1C1884F797B86F5107738F29962F6E97; path=/; httponly;
-        domain=bingapis.com
-      - _EDGE_V=1; path=/; httponly; expires=Wed, 22-May-2019 16:07:14 GMT; domain=bingapis.com
-      - _SS=SID=1C1884F797B86F5107738F29962F6E97; domain=.bingapis.com; path=/
+      X-Snr-Routing:
+      - '1'
       Bingapis-Traceid:
-      - B08C50697E854D39A5B9BC50D761FF9B
+      - 317150EEFD4A4F1E95FB15D164BEDEEB
+      Bingapis-Sessionid:
+      - 41AD08A546474DDA99B69095E365D66B
       X-Msedge-Clientid:
-      - 1A61BB564CA26824024DB0884D3569E8
+      - 1531E5CBA1856A301A24F59AA0976B7F
       X-Msapi-Userstate:
-      - f484
+      - '4641'
       Bingapis-Market:
       - en-US
+      X-Search-Responseinfo:
+      - InternalResponseTime=265,MSDatacenter=BN2B
+      X-Cache:
+      - CONFIG_NOCACHE
       X-Msedge-Ref:
-      - 'Ref A: B08C50697E854D39A5B9BC50D761FF9B Ref B: CO1EDGE0208 Ref C: 2018-04-27T16:07:14Z'
+      - 'Ref A: 317150EEFD4A4F1E95FB15D164BEDEEB Ref B: BLUEDGE1609 Ref C: 2021-06-09T14:06:36Z'
+      Apim-Request-Id:
+      - 997e49b3-7824-4845-81c6-e5be38465589
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      Csp-Billing-Usage:
+      - CognitiveServices.BingSearchV7.Transaction=1
       Date:
-      - Fri, 27 Apr 2018 16:07:13 GMT
+      - Wed, 09 Jun 2021 14:06:36 GMT
     body:
       encoding: UTF-8
-      string: '{"_type": "SearchResponse", "instrumentation": {"pingUrlBase": "https:\/\/www.bingapis.com\/api\/ping?IG=739907940EFE49B19BA204E26E982636&CID=1A61BB564CA26824024DB0884D3569E8&ID=",
-        "pageLoadPingUrl": "https:\/\/www.bingapis.com\/api\/ping\/pageload?IG=739907940EFE49B19BA204E26E982636&CID=1A61BB564CA26824024DB0884D3569E8&Type=Event.CPT&DATA=0"},
-        "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=pdf+(site%3anps.gov)",
-        "webSearchUrlPingSuffix": "DevEx,5449.1", "totalEstimatedMatches": 2040000,
-        "value": [{"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.0", "name":
-        "www.nps.gov", "url": "https:\/\/www.nps.gov\/transportation\/pdfs\/NPS-CMS_Toolkit.pdf",
-        "urlPingSuffix": "DevEx,5087.1", "displayUrl": "https:\/\/www.nps.gov\/transportation\/pdfs\/NPS-CMS_Toolkit.pdf",
-        "snippet": "www.nps.gov", "dateLastCrawled": "2018-04-19T11:54:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.1", "name": "CONNECTICUT",
-        "url": "https:\/\/www.nps.gov\/appa\/planyourvisit\/upload\/APPA%20Map.pdf",
-        "urlPingSuffix": "DevEx,5100.1", "displayUrl": "https:\/\/www.nps.gov\/appa\/planyourvisit\/upload\/APPA
-        Map.pdf", "snippet": "georgia appalachian trail club outdoor club at virginia
-        tech delaware valley chapter appalachian mountain club new york–new jersey
-        trail conference", "dateLastCrawled": "2018-04-20T01:38:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.2", "name": "Interagency National
-        Trails Map (PDF) - National Park Service", "url": "https:\/\/www.nps.gov\/hfc\/carto\/PDF\/TRAILSmap1.pdf",
-        "urlPingSuffix": "DevEx,5112.1", "displayUrl": "https:\/\/www.nps.gov\/hfc\/carto\/PDF\/TRAILSmap1.pdf",
-        "snippet": "Interagency National Trails Map (PDF) - National Park Service",
-        "dateLastCrawled": "2018-04-21T20:39:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.3",
-        "name": "Secretary of the Interior''s Standards for Rehabilitation", "url":
-        "https:\/\/www.nps.gov\/tps\/standards\/treatment-guidelines-2017.pdf", "urlPingSuffix":
-        "DevEx,5124.1", "displayUrl": "https:\/\/www.nps.gov\/tps\/standards\/treatment-guidelines-2017.pdf",
-        "snippet": "Secretary of the Interior''s Standards for Rehabilitation", "dateLastCrawled":
-        "2018-04-21T20:56:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.4",
-        "name": "Low Country Gullah Culture Special Resource Study ...", "url":
-        "https:\/\/www.nps.gov\/ethnography\/research\/docs\/ggsrs_book.pdf", "urlPingSuffix":
-        "DevEx,5136.1", "displayUrl": "https:\/\/www.nps.gov\/ethnography\/research\/docs\/ggsrs_book.pdf",
-        "snippet": "Low Country Gullah Culture Special Resource Study ...", "dateLastCrawled":
-        "2018-04-12T09:43:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.5",
-        "name": "NPS US Map (pdf) - National Park Service", "url": "https:\/\/www.nps.gov\/hfc\/carto\/PDF\/NPSmap1.pdf",
-        "urlPingSuffix": "DevEx,5148.1", "displayUrl": "https:\/\/www.nps.gov\/hfc\/carto\/PDF\/NPSmap1.pdf",
-        "snippet": "NPS US Map (pdf) - National Park Service", "dateLastCrawled":
-        "2018-04-20T05:38:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.6",
-        "name": "CAVE GEOLOGY: Dissolution and decoration", "url": "https:\/\/www.nps.gov\/cave\/planyourvisit\/upload\/cave_geology.pdf",
-        "urlPingSuffix": "DevEx,5160.1", "displayUrl": "https:\/\/www.nps.gov\/cave\/planyourvisit\/upload\/cave_geology.pdf",
-        "snippet": "CAVE GEOLOGY: Dissolution and decoration Carlsbad Caverns National
-        Park was designated a World Heritage Site by the United Nations in 1995,",
-        "dateLastCrawled": "2018-04-21T04:57:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.7",
-        "name": "Brochures - Yellowstone National Park (U.S. National Park ...",
-        "url": "https:\/\/www.nps.gov\/yell\/planyourvisit\/brochures.htm", "urlPingSuffix":
-        "DevEx,5176.1", "about": [{"name": "Yellowstone National Park"}], "displayUrl":
-        "https:\/\/www.nps.gov\/yell\/planyourvisit\/brochures.htm", "snippet":
-        "Below you''ll find a list of publications that will help you plan a safe,
-        enjoyable Yellowstone adventure. Most of these publications are in PDF format
-        and can be viewed or printed using Adobe Acrobat and other PDF readers.",
-        "dateLastCrawled": "2018-04-21T05:55:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.8",
-        "name": "Abraham Lincoln", "url": "https:\/\/www.nps.gov\/saga\/learn\/education\/upload\/Lincoln%20Biography.pdf",
-        "urlPingSuffix": "DevEx,5190.1", "about": [{"name": "Abraham Lincoln"}], "displayUrl":
-        "https:\/\/www.nps.gov\/saga\/learn\/education\/upload\/Lincoln Biography.pdf",
-        "snippet": "Abraham Lincoln . Abraham Lincoln, the 16th president of the United
-        States, guided his country through the most devastating experience in its
-        national history--the CIVIL WAR.", "dateLastCrawled": "2018-04-15T07:54:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.9", "name": "ARCHES
-        NATIONAL PARK", "url": "https:\/\/www.nps.gov\/arch\/planyourvisit\/upload\/archmap.pdf",
-        "urlPingSuffix": "DevEx,5203.1", "about": [{"name": "Arches National Park"}],
-        "displayUrl": "https:\/\/www.nps.gov\/arch\/planyourvisit\/upload\/archmap.pdf",
-        "snippet": "arches national park moab m o a b v a l l e y n e g r o n b i
-        l l ca n y o s a l t v a l l e y cache va ley i g b e n d to dead horse point
-        state park dry mesa m a t ...", "dateLastCrawled": "2018-04-21T04:46:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.10", "name": "Historic
-        Structure Report: Washington Monument", "url": "https:\/\/www.nps.gov\/parkhistory\/online_books\/wamo\/wash_hsr1.pdf",
-        "urlPingSuffix": "DevEx,5215.1", "displayUrl": "https:\/\/www.nps.gov\/parkhistory\/online_books\/wamo\/wash_hsr1.pdf",
-        "snippet": "Historic Structure Report: Washington Monument", "dateLastCrawled":
-        "2018-04-02T16:03:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.11",
-        "name": "NPS.gov Homepage (U.S. National Park Service)", "url": "https:\/\/www.nps.gov\/index.htm",
-        "urlPingSuffix": "DevEx,5230.1", "about": [{"name": "Everglades National Park"},
-        {"name": "Sequoia National Park"}, {"name": "Muir Woods National Monument"},
-        {"name": "National Park Service"}], "displayUrl": "https:\/\/www.nps.gov",
-        "snippet": "The National Park Service cares for special places saved by the
-        American people so that all may experience our heritage.", "dateLastCrawled":
-        "2018-04-20T19:02:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.12",
-        "name": "www.nps.gov", "url": "https:\/\/www.nps.gov\/parkhistory\/online_books\/stli\/ellis_island_legal.pdf",
-        "urlPingSuffix": "DevEx,5243.1", "displayUrl": "https:\/\/www.nps.gov\/...\/online_books\/stli\/ellis_island_legal.pdf",
-        "snippet": "Created Date: 8\/12\/2009 10:57:13 AM", "dateLastCrawled": "2018-04-03T19:42:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.13", "name": "JOSHUA
-        TREE NATIONAL PARK", "url": "https:\/\/www.nps.gov\/hfc\/carto\/PDF\/JOTRmap1.pdf",
-        "urlPingSuffix": "DevEx,5257.1", "about": [{"name": "Joshua Tree National
-        Park"}], "displayUrl": "https:\/\/www.nps.gov\/hfc\/carto\/PDF\/JOTRmap1.pdf",
-        "snippet": "Joshua Tree National Park as wilderness. Most of the park away
-        from road corridors is wilderness. If you plan to venture into these areas,
-        you must be", "dateLastCrawled": "2018-04-20T17:31:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14",
-        "name": "Maps - National Park Service", "url": "https:\/\/www.nps.gov\/grsm\/planyourvisit\/maps.htm",
-        "urlPingSuffix": "DevEx,5273.1", "about": [{"name": "Great Smoky Mountains
-        National Park"}, {"name": "Roaring Fork"}, {"name": "Alum Cave Trail"}, {"name":
-        "Cades Cove"}, {"name": "Great Smoky Mountains National Park"}], "displayUrl":
-        "https:\/\/www.nps.gov\/grsm\/planyourvisit\/maps.htm", "snippet": "(PDF
-        file - 1.0 mb in size.) ... 1:24,000-scale topographic maps of the park are
-        produced in partnership with the United States Geologic Survey and available
-        for free ...", "dateLastCrawled": "2018-04-21T11:59:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15", "name": "Emancipation
-        Proclamation Resource Document", "url": "https:\/\/www.nps.gov\/abli\/learn\/education\/upload\/LessonTwoEmancipationProclamation.pdf",
-        "urlPingSuffix": "DevEx,5287.1", "about": [{"name": "Emancipation Proclamation"}],
-        "displayUrl": "https:\/\/www.nps.gov\/...\/upload\/LessonTwoEmancipationProclamation.pdf",
-        "snippet": "Emancipation Proclamation Resource Document Almost from the beginning
-        of his administration, Lincoln was pressured by abolitionists and radical
-        Republicans to issue an Emancipation Proclamation.", "dateLastCrawled": "2018-04-18T11:34:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16", "name": "REDWmap1
-        4 08", "url": "https:\/\/www.nps.gov\/redw\/planyourvisit\/upload\/REDWmap1.pdf",
-        "urlPingSuffix": "DevEx,5300.1", "displayUrl": "https:\/\/www.nps.gov\/redw\/planyourvisit\/upload\/REDWmap1.pdf",
-        "snippet": "Title: REDWmap1_4_08.pdf Author: National Park Service Subject:
-        Redwood National Park Keywords: Redwood National Park Created Date: 1\/14\/2009
-        2:08:34 PM", "dateLastCrawled": "2018-04-22T23:06:00.0000000Z"}, {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.17",
-        "name": "Charles Pinckney National Historic Site", "url": "https:\/\/www.nps.gov\/chpi\/learn\/historyculture\/upload\/CHPI_HRS.pdf",
-        "urlPingSuffix": "DevEx,5312.1", "about": [{"name": "Charles Pinckney National
-        Historic Site"}], "displayUrl": "https:\/\/www.nps.gov\/chpi\/learn\/historyculture\/upload\/CHPI_HRS.pdf",
-        "snippet": "Charles Pinckney National Historic Site", "dateLastCrawled": "2018-04-21T18:55:00.0000000Z"},
-        {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.18", "name": "re YELLOWSTONE
-        NATIONAL PARK", "url": "https:\/\/www.nps.gov\/hfc\/carto\/PDF\/YELLmap2.pdf",
-        "urlPingSuffix": "DevEx,5325.1", "displayUrl": "https:\/\/www.nps.gov\/hfc\/carto\/PDF\/YELLmap2.pdf",
-        "snippet": "YELLmap2.pdf Author: National Park Service Subject: Yellowstone
-        National Park Keywords: Yellowstone National Park Created Date: 4\/14\/2009
-        3:00:17 PM ...", "dateLastCrawled": "2018-04-19T11:53:00.0000000Z"}, {"id":
-        "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.19", "name": "Brochures
-        - Rocky Mountain National Park (U.S. National ...", "url": "https:\/\/www.nps.gov\/romo\/planyourvisit\/brochures.htm",
-        "urlPingSuffix": "DevEx,5340.1", "about": [{"name": "Rocky Mountain National
-        Park"}], "displayUrl": "https:\/\/www.nps.gov\/romo\/planyourvisit\/brochures.htm",
-        "snippet": "Rocky Mountain National Park publishes several brochures and periodicals.
-        Be sure to have a PDF reader installed (like Adobe Reader) and unblock pop-ups
-        (brochures will open in a separate window).", "dateLastCrawled": "2018-04-22T21:02:00.0000000Z"}]},
-        "rankingResponse": {"mainline": {"items": [{"answerType": "WebPages", "resultIndex":
-        0, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.0"}}, {"answerType":
-        "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.1"}},
-        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.2"}},
-        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.3"}},
-        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.4"}},
-        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.5"}},
-        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.6"}},
-        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.7"}},
-        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.8"}},
-        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.9"}},
-        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.10"}},
-        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.11"}},
-        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.12"}},
-        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.13"}},
-        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.14"}},
-        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.15"}},
-        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.16"}},
-        {"answerType": "WebPages", "resultIndex": 17, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.17"}},
-        {"answerType": "WebPages", "resultIndex": 18, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.18"}},
-        {"answerType": "WebPages", "resultIndex": 19, "value": {"id": "https:\/\/www.bingapis.com\/api\/v6\/#WebPages.19"}}]}}}'
-    http_version: 
-  recorded_at: Fri, 27 Apr 2018 16:07:14 GMT
+      string: '{"_type": "SearchResponse", "queryContext": {"originalQuery": "pdf
+        (site:nps.gov)"}, "webPages": {"webSearchUrl": "https:\/\/www.bing.com\/search?q=pdf+(site%3anps.gov)",
+        "totalEstimatedMatches": 3960000, "value": [{"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0",
+        "name": "Civil Rights in America - nps.gov", "url": "https:\/\/www.nps.gov\/subjects\/tellingallamericansstories\/upload\/CivilRights_Framework.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/subjects\/tellingallamericansstories\/upload\/CivilRights_Framework.pdf",
+        "snippet": "EXECUTIVE SUMMARY Introduction In November 1999, the U.S. Congress
+        passed the National Park System New Area Study Act of 2000 (S. 1349) as contained
+        in Public Law 106-113, Appendix C, “National Park Service Studies", "dateLastCrawled":
+        "2020-11-27T15:38:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1", "name":
+        "The Emancipation Proclamation January 1, 1863", "url": "https:\/\/www.nps.gov\/museum\/tmc\/Antietam\/Lesson3\/The%20Emancipation%20Proclamation%20text%20copy.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/museum\/tmc\/Antietam\/Lesson3\/The
+        Emancipation Proclamation text copy...", "snippet": "The Emancipation Proclamation
+        January 1, 1863. A Transcription. By the President of the United States of
+        America: A Proclamation. Whereas, on the twenty -second day of September,
+        in the year of our Lord one thousand eight hundred", "dateLastCrawled": "2021-06-06T12:03:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2",
+        "name": "GRAND TETON NATIONAL PARK - nps.gov", "url": "https:\/\/www.nps.gov\/carto\/hfc\/carto\/media\/GRTEmap2.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/carto\/hfc\/carto\/media\/GRTEmap2.pdf",
+        "snippet": "33 33 191 287 89 26 287 26 89 22 191 22 26 89 191 North 0 1 0
+        1 5 Miles 5 Kilometers YELLOWSTONE NATIONAL PARK JOHN D. ROCKEFELLER, JR.",
+        "dateLastCrawled": "2021-05-14T21:13:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3",
+        "name": "The SecreTary of The InTerIor’S STandardS for ...", "url": "https:\/\/www.nps.gov\/tps\/standards\/rehabilitation\/sustainability-guidelines.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/tps\/standards\/rehabilitation\/sustainability-guidelines.pdf",
+        "snippet": "v Foreword The Illustrated Guidelines on Sustainability for Rehabilitating
+        Historic Buildings replaces the chapter on “Energy Conservation” in the Illustrated
+        Guidelines for Rehabilitating Historic Buildings published in 1992. (This
+        same guidance is presented in the chapter entitled “Energy Retrofitting” in
+        the unillustrated Guidelines for Rehabilitating Historic Buildings.", "dateLastCrawled":
+        "2021-05-22T03:06:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4", "name":
+        "Chapter 3: Cataloging - NPS", "url": "https:\/\/www.nps.gov\/museum\/publications\/MHII\/mh2ch3.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/museum\/publications\/MHII\/mh2ch3.pdf",
+        "snippet": "NPS Museum Handbook, Part II (2000) 3:1 CHAPTER 3: CATALOGING
+        A. Overview 1. What is cataloging? For National Park Service (NPS) museum
+        collections, cataloging is the process of recording detailed information about
+        individual items or groups of", "dateLastCrawled": "2021-02-19T18:13:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5",
+        "name": "Chapter 7 SIGNS - NPS", "url": "https:\/\/www.nps.gov\/noco\/learn\/management\/upload\/nct_ch7.rev.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/noco\/learn\/management\/upload\/nct_ch7.rev.pdf",
+        "snippet": "Entrance signs should be the standard NPS-type metal signs with
+        white lettering on a brown background and read \"North Country National Scenic
+        Trail,\" with the trail logo on the right hand side.", "dateLastCrawled":
+        "2021-05-26T21:24:00.0000000Z", "language": "en", "isNavigational": false},
+        {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6", "name":
+        "Chapter 11 SPECIALIZED BLASTING TECHNIQUES", "url": "https:\/\/www.nps.gov\/parkhistory\/online_books\/npsg\/explosives\/Chapter11.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/parkhistory\/online_books\/npsg\/explosives\/Chapter11.pdf",
+        "snippet": "172 7. Loop the end of the trunkline to form a continuous loop
+        back to the starting point and attach the line to complete a loop. B. A more
+        efficient blasting scheme is to bury the charges in a row of boreholes.",
+        "dateLastCrawled": "2021-06-02T17:14:00.0000000Z", "language": "en", "isNavigational":
+        false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7",
+        "name": "O LYMP IC NAT PARK - nps.gov", "url": "https:\/\/www.nps.gov\/olym\/planyourvisit\/upload\/olym_map.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/olym\/planyourvisit\/upload\/olym_map.pdf",
+        "snippet": "Ozette Island Garden Island Tivoli Island Spike ORock Father And
+        Son James eIsland Split Rock Kalaloch Rocks Destruction Island Abbey Island
+        Alexander Island", "dateLastCrawled": "2021-03-20T14:50:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8",
+        "name": "ARCHES NATIONAL PARK - NPS", "url": "https:\/\/www.nps.gov\/arch\/planyourvisit\/upload\/archmap.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/arch\/planyourvisit\/upload\/archmap.pdf",
+        "snippet": "North 0 0 1 1 2 2 3 3 4 Miles 4 Kilometers 191 191 279 128 128
+        313 70 191 313 313 313 70 191 128 191 128 191 191 C O L O R A D O S KC Visitor
+        Center R I V E R C o u r ...", "dateLastCrawled": "2021-03-04T15:26:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9",
+        "name": "Management of National Park Service Programs", "url": "https:\/\/www.nps.gov\/policy\/MP_2006.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/policy\/MP_2006.pdf",
+        "snippet": "1.1 The National Park Idea 1.9.5.1 Financial Sus 2.3.1.7 Environmental
+        Analysis 2.3.1.8 Cooperative Planning 2.3.1.10 Wilderness 1.4.7 Decision-making
+        Requirements to", "dateLastCrawled": "2021-01-14T05:39:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10",
+        "name": "JOSHUA TREE NATIONAL PARK - NPS", "url": "https:\/\/www.nps.gov\/carto\/hfc\/carto\/media\/JOTRmap1.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/carto\/hfc\/carto\/media\/JOTRmap1.pdf",
+        "snippet": "10 10 177 111 111 111 247 62 62 86 62 62 Medical facility Drinking
+        water 0 0 5 10 Miles 5 10 Kilometers North Joshua Tree Visitor Center Oasis
+        Visitor Center ...", "dateLastCrawled": "2021-05-15T17:17:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11",
+        "name": "NATIONAL MALL & MEMORIAL PARKS", "url": "https:\/\/www.nps.gov\/state\/dc\/upload\/NPS-Map-Washington-DC.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/state\/dc\/upload\/NPS-Map-Washington-DC.pdf",
+        "snippet": "venue constitution avenue m street m street m street m street
+        i street k street k street e street e street 17th street 17th st 17th street
+        15th street 15th street", "dateLastCrawled": "2021-04-03T05:03:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12",
+        "name": "YOSEMITE NATIONAL PARK - NPS", "url": "https:\/\/www.nps.gov\/yose\/planyourvisit\/upload\/YOSEmap1.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/yose\/planyourvisit\/upload\/YOSEmap1.pdf",
+        "snippet": "120 167 120 140 41 395 Fish Camp Lee Vining Yosemite West Chinquapin
+        El Portal Foresta Mather To Fresno To Merced To Manteca To Carson City, Nev.
+        To Mammoth Lakes", "dateLastCrawled": "2021-04-20T13:42:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13",
+        "name": "Zion Information Guide National Park Service U.S ...", "url": "https:\/\/www.nps.gov\/zion\/planyourvisit\/upload\/July-1-2020-InfoSheet_a.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/zion\/planyourvisit\/upload\/July-1-2020-InfoSheet_a.pdf",
+        "snippet": "North 0.5 Mile 0 0.5 Kilometer Paved road open to Tunnel private
+        vehicles Restrooms Picnic area Wheelchair-accessible Pets (leashed) Hiking
+        Biking Ranger station", "dateLastCrawled": "2021-02-19T17:10:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14",
+        "name": "Glacier National Park Glacier National Park Map", "url": "https:\/\/www.nps.gov\/glac\/planyourvisit\/upload\/orientation-map-revised-7-16.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/glac\/planyourvisit\/upload\/orientation-map-revised-7-16.pdf",
+        "snippet": "WATERTO N LAKES NATI ONAL PARK NATIONAL GLACI ER PARK Unpaved
+        road Paved road Trail Continental Divide Riding stable 0 0 5 10 Miles 5 10
+        Kilometers North Leg end", "dateLastCrawled": "2021-05-19T08:38:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15",
+        "name": "BADLANDS NATIONAL PARK - NPS", "url": "https:\/\/www.nps.gov\/badl\/planyourvisit\/upload\/Official%20Badlands%20National%20Park%20Map.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/badl\/planyourvisit\/upload\/Official
+        Badlands National Park Map.pdf", "snippet": "BADLmap1.pdf Author: National
+        Park Service, Harpers Ferry Center, publications Subject: Badlands National
+        Park Keywords: Badlands National Park Created Date: 10\/31\/2003 10:05:23
+        AM ...", "dateLastCrawled": "2021-05-29T02:21:00.0000000Z", "language": "en",
+        "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16",
+        "name": "Hiking Into Grand Canyon - nps.gov", "url": "https:\/\/www.nps.gov\/grca\/planyourvisit\/upload\/intro-bc-hike.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/grca\/planyourvisit\/upload\/intro-bc-hike.pdf",
+        "snippet": "Hiking Into Grand Canyon Plan Ahead Whether a day or overnight
+        trip, hiking into Grand Canyon on the Bright Angel, North Kaibab, or South
+        Kaibab trails gives an", "dateLastCrawled": "2021-06-02T14:14:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17",
+        "name": "Gettysburg, Pennsylvania November 19, 1863", "url": "https:\/\/www.nps.gov\/abli\/learn\/education\/upload\/UpdatedGettysburgAddress.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/abli\/learn\/education\/upload\/UpdatedGettysburgAddress.pdf",
+        "snippet": "The Gettysburg Address Gettysburg, Pennsylvania November 19,
+        1863 During a three-day Civil War battle at Gettysburg in early July 1863,
+        there were over", "dateLastCrawled": "2021-05-24T12:50:00.0000000Z", "language":
+        "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18",
+        "name": "National Register 16A - NPS", "url": "https:\/\/www.nps.gov\/subjects\/nationalregister\/upload\/NRB16A-Complete.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/subjects\/nationalregister\/upload\/NRB16A-Complete.pdf",
+        "snippet": "The National Register of Historic Places is the official Federal
+        list of dis­ tricts, sites, buildings, structures, and objects significant
+        in American history,", "dateLastCrawled": "2021-06-05T04:05:00.0000000Z",
+        "language": "en", "isNavigational": false}, {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19",
+        "name": "Yosemite Valley Hiking Map - NPS", "url": "https:\/\/www.nps.gov\/yose\/planyourvisit\/upload\/valleyhikes.pdf",
+        "isFamilyFriendly": true, "displayUrl": "https:\/\/www.nps.gov\/yose\/planyourvisit\/upload\/valleyhikes.pdf",
+        "snippet": "P o h o S e n t i n e l D o m e Tr a i l Poh o n o T r a i l I
+        . I m i (I. 7 k m) I.0 mi ( . 6 km) I. 0 m i (I. 6 k m) I. 3 mi (2.9 km) Sentinel
+        Rock 7038 ft 2145 m 3 . 4 m i ( 5", "dateLastCrawled": "2021-05-23T03:06:00.0000000Z",
+        "language": "en", "isNavigational": false}]}, "rankingResponse": {"mainline":
+        {"items": [{"answerType": "WebPages", "resultIndex": 0, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.0"}},
+        {"answerType": "WebPages", "resultIndex": 1, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.1"}},
+        {"answerType": "WebPages", "resultIndex": 2, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.2"}},
+        {"answerType": "WebPages", "resultIndex": 3, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.3"}},
+        {"answerType": "WebPages", "resultIndex": 4, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.4"}},
+        {"answerType": "WebPages", "resultIndex": 5, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.5"}},
+        {"answerType": "WebPages", "resultIndex": 6, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.6"}},
+        {"answerType": "WebPages", "resultIndex": 7, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.7"}},
+        {"answerType": "WebPages", "resultIndex": 8, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.8"}},
+        {"answerType": "WebPages", "resultIndex": 9, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.9"}},
+        {"answerType": "WebPages", "resultIndex": 10, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.10"}},
+        {"answerType": "WebPages", "resultIndex": 11, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.11"}},
+        {"answerType": "WebPages", "resultIndex": 12, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.12"}},
+        {"answerType": "WebPages", "resultIndex": 13, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.13"}},
+        {"answerType": "WebPages", "resultIndex": 14, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.14"}},
+        {"answerType": "WebPages", "resultIndex": 15, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.15"}},
+        {"answerType": "WebPages", "resultIndex": 16, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.16"}},
+        {"answerType": "WebPages", "resultIndex": 17, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.17"}},
+        {"answerType": "WebPages", "resultIndex": 18, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.18"}},
+        {"answerType": "WebPages", "resultIndex": 19, "value": {"id": "https:\/\/api.cognitive.microsoft.com\/api\/v7\/#WebPages.19"}}]}}}'
+    http_version:
+  recorded_at: Wed, 09 Jun 2021 14:06:37 GMT
 recorded_with: VCR 4.0.0


### PR DESCRIPTION
This PR updates the `basic_affiliate` fixture to use the default search engine (currently BingV7) instead of the deprecated Google search engine. It also includes updates to the VCR cassettes and some Rubocop fixes. The remaining Rubocop failures are preexisting issues that I am not refactoring as part of this PR.