### PR TITLE
SRCH-2387 Set the app's maximum upload file size to 4MB (was 10MB)

### DIFF
--- a/app/services/bulk_url_uploader.rb
+++ b/app/services/bulk_url_uploader.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class BulkUrlUploader
-  MAXIMUM_FILE_SIZE = 10.megabytes
+  MAXIMUM_FILE_SIZE = 4.megabytes
   VALID_CONTENT_TYPES = %w[text/plain].freeze
 
   attr_reader :results

--- a/features/bulk-upload.feature
+++ b/features/bulk-upload.feature
@@ -7,7 +7,7 @@ Feature: Bulk Search.gov URL Upload
     Given I am logged in with email "affiliate_admin@fixtures.org"
     When I go to the bulk url upload admin page
     Then I should see "Bulk URL Upload"
-    And I should see "The maximum file size is 10 MB"
+    And I should see "The maximum file size is 4 MB"
 
     When I attach the file "features/support/bulk_upload_urls.txt" to "bulk_upload_urls"
     And I press "Upload"


### PR DESCRIPTION
SRCH-2387 Set the app's maximum upload file size to 4MB (was 10MB)