### PR TITLE
SRCH-2324 update newrelic_rpm

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,7 @@ gem 'flickraw', '~> 0.9.9'
 gem 'active_scaffold', '~> 3.5.0'
 gem 'active_scaffold_export', git: 'https://github.com/naaano/active_scaffold_export'
 gem "recaptcha", '~> 4.6.3', :require => "recaptcha/rails"
-gem 'newrelic_rpm', '~> 5.0.0'
+gem 'newrelic_rpm', '~> 6.15.0'
 gem 'american_date', '~> 1.1.1'
 gem 'sass', '~> 3.3.0'
 gem 'sass-rails', '~> 5.0.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -487,11 +487,11 @@ GEM
     mysql2 (0.4.10)
     naught (1.1.0)
     net-http-persistent (2.9.4)
-    newrelic_rpm (5.0.0.342)
-    nio4r (2.5.8)
-    nokogiri (1.11.7)
+    newrelic_rpm (6.15.0)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nio4r (2.5.8)
+    nokogiri (1.11.7)
     omniauth (1.4.3)
       hashie (>= 1.2, < 4)
       rack (>= 1.6.2, < 3)
@@ -862,7 +862,7 @@ DEPENDENCIES
   medusa!
   mysql2 (~> 0.4.4)
   net-http-persistent (~> 2.9.3)
-  newrelic_rpm (~> 5.0.0)
+  newrelic_rpm (~> 6.15.0)
   nokogiri (~> 1.11.1)
   omniauth-rails_csrf_protection (~> 0.1.2)
   omniauth_login_dot_gov!

--- a/config/newrelic.yml
+++ b/config/newrelic.yml
@@ -6,6 +6,7 @@
   apdex_t: <%= Rails.application.secrets.newrelic[:apdex_t] || 0.5 %>
   capture_params: false
   disable_curb: true
+  backport_fast_active_record_connection_lookup: true
   transaction_tracer:
     enabled: true
     transaction_threshold: apdex_f


### PR DESCRIPTION
- Bumped newrelic_rpm to 6.15.0 and ran `bundle update newrelic_rpm`

- Set backport_fast_active_record_connection_lookup to true.  As of
  6.5, newrelic_rpm defaults this to false, but recommends setting it to
  true unless that causes problems with other gems' monkey-patching of
  ActiveRecord.