### PR TITLE
SRCH-2293 Fix specs that depend on `success?`

### DIFF
--- a/spec/controllers/admin/query_ctrs_controller_spec.rb
+++ b/spec/controllers/admin/query_ctrs_controller_spec.rb
@@ -28,7 +28,7 @@ describe Admin::QueryCtrsController do
       end
 
       it 'should allow the admin to see query CTRs for some search module on a given site' do
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it { is_expected.to assign_to(:query_ctrs).with(%w(first second)) }

--- a/spec/controllers/admin/search_module_ctrs_controller_spec.rb
+++ b/spec/controllers/admin/search_module_ctrs_controller_spec.rb
@@ -26,7 +26,7 @@ describe Admin::SearchModuleCtrsController do
       end
 
       it 'should allow the admin to see search module CTRs' do
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it { is_expected.to assign_to(:search_module_ctrs).with(%w(first second)) }

--- a/spec/controllers/admin/site_ctrs_controller_spec.rb
+++ b/spec/controllers/admin/site_ctrs_controller_spec.rb
@@ -27,7 +27,7 @@ describe Admin::SiteCtrsController do
       end
 
       it 'should allow the admin to see site CTRs for some search module' do
-        expect(response).to be_success
+        expect(response).to be_successful
       end
 
       it { is_expected.to assign_to(:site_ctrs).with(%w(first second)) }

--- a/spec/controllers/admin/superfresh_urls_bulk_upload_controller_spec.rb
+++ b/spec/controllers/admin/superfresh_urls_bulk_upload_controller_spec.rb
@@ -22,7 +22,7 @@ describe Admin::SuperfreshUrlsBulkUploadController do
 
       it 'should allow the admin to manage superfresh urls' do
         get :index
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
   end

--- a/spec/controllers/api/v1/agencies_controller_spec.rb
+++ b/spec/controllers/api/v1/agencies_controller_spec.rb
@@ -18,7 +18,7 @@ describe Api::V1::AgenciesController do
               query: 'the nps'
             },
             format: 'json'
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(response.body).to eq({name: @agency.name, abbreviation: @agency.abbreviation,
                                  organization_code: @agency.agency_organization_codes.first.organization_code }.to_json)
       end
@@ -31,7 +31,7 @@ describe Api::V1::AgenciesController do
               query: 'error',
               format: 'json'
             }
-        expect(response).not_to be_success
+        expect(response).not_to be_successful
         expect(response.body).to match(/No matching agency could be found./)
       end
     end

--- a/spec/controllers/api/v2/agencies_controller_spec.rb
+++ b/spec/controllers/api/v2/agencies_controller_spec.rb
@@ -12,7 +12,7 @@ describe Api::V2::AgenciesController do
 
       it 'should return valid JSON with the organization codes array in alpha order' do
         get :search, params: { query: 'the nps' }, format: 'json'
-        expect(response).to be_success
+        expect(response).to be_successful
         expect(response.body).to eq({name: @agency.name, abbreviation: @agency.abbreviation,
                                  organization_codes: @agency.agency_organization_codes.collect(&:organization_code).sort }.to_json)
       end
@@ -21,7 +21,7 @@ describe Api::V2::AgenciesController do
     context 'when search returns nil or raises an exception' do
       it 'should return error string' do
         get :search, params: { query: 'error' }, format: 'json'
-        expect(response).not_to be_success
+        expect(response).not_to be_successful
         expect(response.body).to match(/No matching agency could be found./)
       end
     end

--- a/spec/controllers/health_checks_controller_spec.rb
+++ b/spec/controllers/health_checks_controller_spec.rb
@@ -5,7 +5,7 @@ describe HealthChecksController do
     context 'when the database is accessible' do
       it 'produces a successful response' do
         get :new
-        expect(response).to be_success
+        expect(response).to be_successful
       end
     end
 


### PR DESCRIPTION
Changed be_success to be_successful in all specs that used it

Rails 6 is removing the success? predicate; successful? is the
recommended replacement. Besides, this way reads better.

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers