### PR TITLE
SRCH-2501 Update our use of #content_type for Rails 6

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,7 +17,8 @@ Bundler.require(*Rails.groups)
 module Usasearch
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
-    config.load_defaults 5.1
+    config.load_defaults 6.0
+    config.autoloader = :classic # To be removed by SRCH-2503
 
     # Rails 4 way of “eager_load with autoload fallback. Note need to revisit better
     # solution. See https://collectiveidea.com/blog/archives/2016/07/22/solutions-to-potential-upgrade-problems-in-rails-5

--- a/spec/controllers/image_searches_controller_spec.rb
+++ b/spec/controllers/image_searches_controller_spec.rb
@@ -59,7 +59,7 @@ describe ImageSearchesController do
         it { is_expected.to respond_with :success }
 
         it 'renders the results in json' do
-          expect(response.content_type).to eq 'application/json'
+          expect(response.media_type).to eq 'application/json'
           expect(response.body).to eq(search_results_json)
         end
       end
@@ -100,7 +100,7 @@ describe ImageSearchesController do
         end
 
         it 'sets the format to json' do
-          expect(response.content_type).to eq('application/json')
+          expect(response.media_type).to eq('application/json')
         end
 
         it 'sanitizes the query term' do

--- a/spec/controllers/sites/click_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/click_drilldowns_controller_spec.rb
@@ -41,7 +41,7 @@ describe Sites::ClickDrilldownsController do
             },
             format: 'csv'
 
-        expect(response.content_type).to eq('text/csv')
+        expect(response.media_type).to eq('text/csv')
         expect(response.headers['Content-Disposition']).to eq('attachment;filename=nps.gov_http://some.gov.url/super_long_so_truncate_at_50/b_2015-02-01_2015-02-05.csv')
         expect(response.body).to eq(read_fixture_file('/csv/click_drilldown.csv'))
       end

--- a/spec/controllers/sites/query_downloads_controller_spec.rb
+++ b/spec/controllers/sites/query_downloads_controller_spec.rb
@@ -66,7 +66,7 @@ describe Sites::QueryDownloadsController do
 
       it 'generates a CSV of human/bot traffic for a date range, sorted by human count' do
         show
-        expect(response.content_type).to eq('text/csv')
+        expect(response.media_type).to eq('text/csv')
         expect(response.headers['Content-Disposition']).to eq('attachment;filename=nps.gov_2014-06-08_2014-06-14.csv')
         expect(response.body).to start_with("Search Term,Real (Humans only) Queries,Real Clicks,Real CTR,Total (Bots + Humans) Queries,Total Clicks,Total CTR\njobs,9,15,166.7%,10,15,150.0%\nchartres,1,20,2000.0%,1,1,100.0%\n")
         expect(response.body).to have_content('filing complaints on us priviate militaires companies,0,0,--,8,12,150.0%')

--- a/spec/controllers/sites/query_drilldowns_controller_spec.rb
+++ b/spec/controllers/sites/query_drilldowns_controller_spec.rb
@@ -38,7 +38,7 @@ describe Sites::QueryDrilldownsController do
             },
             format: 'csv'
 
-        expect(response.content_type).to eq('text/csv')
+        expect(response.media_type).to eq('text/csv')
         expect(response.headers['Content-Disposition']).to eq('attachment;filename=nps.gov_foo_bar_2015-02-01_2015-02-05.csv')
         expect(response.body).to start_with(Sites::QueryDrilldownsController::HEADER_FIELDS.to_csv)
         expect(response.body).to have_content('2015-02-01,04:52:14,https://search.usa.gov/search?utf8=%E2%9C%93&affiliate=usagov&query=fashion+psychology,https://search.usa.gov/search?affiliate=usagov&query=fashion,web,BWEB BOOS,Other,IE,Windows 7,US,MO,204.184.232.180,Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko')

--- a/spec/controllers/superfresh_controller_spec.rb
+++ b/spec/controllers/superfresh_controller_spec.rb
@@ -5,7 +5,7 @@ describe SuperfreshController, '#index' do
   let(:affiliate) { affiliates(:basic_affiliate) }
   it 'should set the request fomat to :rss' do
     get :index
-    expect(response.content_type).to eq('application/rss+xml')
+    expect(response.media_type).to eq('application/rss+xml')
   end
 
   context 'when there are no URLs' do


### PR DESCRIPTION
Set Rails defaults to 6.0 and disabled zeitwerk.

Changed content_type to media_type as necessary.

## Summary
- Brief summary of the changes included in this PR
- Any additional information or context which may help the reviewer
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason: This is Rails 6 work, and goes onto the feature/rails-60 branch
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers