### PR TITLE
SRCH-2671 update specs for Ruby 2.7 compatibility

### DIFF
--- a/spec/jobs/searchgov_domain_destroyer_job_spec.rb
+++ b/spec/jobs/searchgov_domain_destroyer_job_spec.rb
@@ -13,7 +13,7 @@ describe SearchgovDomainDestroyerJob do
   describe '#perform' do
     it 'requires a searchgov_domain as an argument' do
       expect{ described_class.perform_now }.
-        to raise_error(ArgumentError, 'missing keyword: searchgov_domain')
+        to raise_error(ArgumentError, /missing keyword: :?searchgov_domain/)
     end
 
     it 'destroys the searchgov domain' do

--- a/spec/jobs/searchgov_url_fetcher_job_spec.rb
+++ b/spec/jobs/searchgov_url_fetcher_job_spec.rb
@@ -13,7 +13,7 @@ describe SearchgovUrlFetcherJob do
   describe '#perform' do
     it 'requires a searchgov_url' do
       expect { described_class.perform_now }.
-        to raise_error(ArgumentError, 'missing keyword: searchgov_url')
+        to raise_error(ArgumentError, /missing keyword: :?searchgov_url/)
     end
 
     it 'fetches a searchgov_url' do

--- a/spec/support/web_document_behavior.rb
+++ b/spec/support/web_document_behavior.rb
@@ -14,12 +14,12 @@ shared_examples 'a web document' do
   describe 'initialization' do
     it 'requires a document' do
       expect { described_class.new(**valid_attributes.except(:document)) }
-        .to raise_error(ArgumentError, 'missing keyword: document')
+        .to raise_error(ArgumentError, /missing keyword: :?document/)
     end
 
     it 'requires a url' do
       expect { described_class.new(**valid_attributes.except(:url)) }
-        .to raise_error(ArgumentError, 'missing keyword: url')
+        .to raise_error(ArgumentError, /missing keyword: :?url/)
     end
   end
 


### PR DESCRIPTION
## Summary
This PR updates several specs for compatibility with both 2.6 and 2.7, by making the keyword colon optional when matching error messages such as `missing keyword: :searchgov_domain`. This resolves failures such as the following:
```
expected ArgumentError with "missing keyword: :searchgov_domain", got #<ArgumentError: missing keyword: searchgov_domain> with backtrace:
    # ./app/jobs/searchgov_domain_destroyer_job.rb:4:in `perform'
    # ./spec/jobs/searchgov_domain_destroyer_job_spec.rb:15:in `block (4 levels) in <top (required)>'
    # ./spec/jobs/searchgov_domain_destroyer_job_spec.rb:15:in `block (3 levels) in <top (required)>'
    # ./spec/spec_helper.rb:117:in `block (2 levels) in <top (required)>'
./spec/jobs/searchgov_domain_destroyer_job_spec.rb:15:in `block (3 levels) in <top (required)>' 
```
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [ ] Code is functional.

- [ ] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [ ] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 
- [ ] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [ ] If your target branch is NOT `master` or `main`, specify the reason:
 
- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [ ] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [ ] You have specified an "Assignee", and if necessary, additional reviewers