### PR TITLE
SRCH-2655 Resolve non-symbol keys warning in rspec

### DIFF
--- a/lib/external_faraday.rb
+++ b/lib/external_faraday.rb
@@ -7,8 +7,8 @@ module ExternalFaraday
 
   def self.configure_connection(ns, conn)
     config = get_config ns
-    config['options'].each { |key, value| conn.options.send(:"#{key}=", value) }
-    conn.adapter config['adapter']
+    config[:options].each { |key, value| conn.options.send(:"#{key}=", value) }
+    conn.adapter(config[:adapter])
   end
 
   def self.get_config(ns)

--- a/spec/lib/external_faraday_spec.rb
+++ b/spec/lib/external_faraday_spec.rb
@@ -4,8 +4,8 @@ describe ExternalFaraday do
   context '#get_config' do
     context 'when namespaced config is present' do
       it 'contains values for adapter and options' do
-        expect(described_class.get_config('azure_web_api')['adapter']).to eq(:typhoeus)
-        expect(described_class.get_config('azure_web_api')['options']).to be_present
+        expect(described_class.get_config('azure_web_api')[:adapter]).to eq(:typhoeus)
+        expect(described_class.get_config('azure_web_api')[:options]).to be_present
       end
     end
 


### PR DESCRIPTION
## Summary
- Minor changes to remove rspec test suite waning: 

> DEPRECATION WARNING: Accessing hashes returned from config_for by non-symbol keys is deprecated and will be removed in Rails 6.1. Use symbols for access instead.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures: N/A

- [X] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. N/A
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason: N/A
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers