### PR TITLE
SRCH-2656 Resolve inherited scoping warning

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,6 @@ class User < ApplicationRecord
 
   APPROVAL_STATUSES = %w[pending_approval approved not_approved].freeze
 
-  validates :email, presence: true
   validates :approval_status, inclusion: APPROVAL_STATUSES
   validates :first_name, presence: true, on: :update_account
   validates :last_name, presence: true, on: :update_account
@@ -136,7 +135,7 @@ class User < ApplicationRecord
   end
 
   def self.from_omniauth(auth)
-    find_or_create_by(email: auth.info.email).tap do |user|
+    User.default_scoped.find_or_create_by(email: auth.info.email).tap do |user|
       user.update(uid: auth.uid)
     end
   end


### PR DESCRIPTION
## Summary
Resolves the following Rails 6.1 deprecation warning: 

> DEPRECATION WARNING: Class level methods will no longer inherit scoping from `create` in Rails 6.1. To continue using the scoped relation, pass it into the block directly. To instead access the full set of models, as Rails 6.1 will, use `User.default_scoped`. (called from from_omniauth at /Users/Moth/src/GSA/search-gov/app/models/user.rb:139) 

by adding `User.default_scoped` to the `from_omniauth` method.

Also, removes duplicate `validates :email, presence: true` incidentally discovered during the above work.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures: N/A

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. N/A
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason: Ongoing precursor work necessary for Rails 6.1 upgrade is to use the `feature/rails_6_1` branch.
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers