### PR TITLE
SRCH-2716 resolve active_scaffold deprecation warnings

### DIFF
--- a/spec/controllers/admin/affiliates_controller_spec.rb
+++ b/spec/controllers/admin/affiliates_controller_spec.rb
@@ -94,25 +94,25 @@ describe Admin::AffiliatesController do
 
       describe 'Settings subgroup' do
         it 'contains the specified columns' do
-          expect(update_columns.find { |c| c.label == 'Settings' }.names).to match_array(settings_columns)
+          expect(update_columns.find { |c| c.label == 'Settings' }.to_a).to match_array(settings_columns)
         end
       end
 
       describe "'Enable/disable Settings' subgroup" do
         it 'contains the specified columns' do
-          expect(update_columns.find { |c| c.label == 'Enable/disable Settings' }.names).to match_array(enable_disable_columns)
+          expect(update_columns.find { |c| c.label == 'Enable/disable Settings' }.to_a).to match_array(enable_disable_columns)
         end
       end
 
       describe 'Display Settings subgroup' do
         it 'contains the specified columns' do
-          expect(update_columns.find { |c| c.label == 'Display Settings' }.names).to match_array(display_columns)
+          expect(update_columns.find { |c| c.label == 'Display Settings' }.to_a).to match_array(display_columns)
         end
       end
 
       describe 'Analytics-Tracking Code subgroup' do
         it 'contains the specified columns' do
-          expect(update_columns.find { |c| c.label == 'Analytics-Tracking Code' }.names).to match_array(analytics_columns)
+          expect(update_columns.find { |c| c.label == 'Analytics-Tracking Code' }.to_a).to match_array(analytics_columns)
         end
       end
     end


### PR DESCRIPTION
## Summary
This PR resolves the following deprecation warnings from the `active_scaffold` gem:
```
search-gov (master)$ bundle exec rspec spec/controllers/admin/affiliates_controller_spec.rb | grep -i deprec
...
DEPRECATION WARNING: use visible_columns.map(&:name) (called from block (5 levels) in <top (required)> at /Users/Moth/src/GSA/search-gov/spec/controllers/admin/affiliates_controller_spec.rb:97)
DEPRECATION WARNING: use visible_columns.map(&:name) (called from block (5 levels) in <top (required)> at /Users/Moth/src/GSA/search-gov/spec/controllers/admin/affiliates_controller_spec.rb:115)
DEPRECATION WARNING: use visible_columns.map(&:name) (called from block (5 levels) in <top (required)> at /Users/Moth/src/GSA/search-gov/spec/controllers/admin/affiliates_controller_spec.rb:109)
DEPRECATION WARNING: use visible_columns.map(&:name) (called from block (5 levels) in <top (required)> at /Users/Moth/src/GSA/search-gov/spec/controllers/admin/affiliates_controller_spec.rb:103)
```
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional. - N/A, spec changes only

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers