### PR TITLE
SRCH-2725 Encode no results pointer query params

### DIFF
--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -25,7 +25,7 @@ module SearchHelper
   end
 
   def link_to_other_web_results(template, query)
-    cleaned_query = Addressable::URI.encode_component(query, Addressable::URI::CharacterClasses::ALPHA)
+    cleaned_query = URI.encode_www_form_component(query)
     template.sub('{QUERY}', cleaned_query).html_safe
   end
 

--- a/app/helpers/search_helper.rb
+++ b/app/helpers/search_helper.rb
@@ -1,8 +1,8 @@
-# coding: utf-8
-module SearchHelper
+# frozen_string_literal: true
 
+module SearchHelper
   SPECIAL_URL_PATH_EXT_NAMES = %w{doc pdf ppt ps rtf swf txt xls docx pptx xlsx}
-  EMPTY_STRING = ""
+  EMPTY_STRING = ''
 
   def link_to_offer_commercial_image_results(search_url)
     link = link_to t('searches.commercial_results.search_again'), search_url, class: "search-again-link"
@@ -25,7 +25,8 @@ module SearchHelper
   end
 
   def link_to_other_web_results(template, query)
-    template.sub('{QUERY}', query).html_safe
+    cleaned_query = Addressable::URI.encode_component(query, Addressable::URI::CharacterClasses::ALPHA)
+    template.sub('{QUERY}', cleaned_query).html_safe
   end
 
   def display_web_result_extname_prefix(web_result)
@@ -38,10 +39,10 @@ module SearchHelper
       if SPECIAL_URL_PATH_EXT_NAMES.include?( path_extname.downcase )
         extname_span(path_extname)
       else
-        ""
+        ''
       end
     rescue
-      ""
+      ''
     end
   end
 

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -77,8 +77,10 @@ describe SearchHelper do
 
     it 'renders HTML with interpolated and encoded query string' do
       link = helper.link_to_other_web_results(html_template, query)
-      expect(link).to have_link('Try your search again',
-                                href: 'http://www.gov.gov/search?query=Bill%20%26%20Ted%27s%20%28B%26T%29%20Excellent%20%C3%84dventure%21')
+      expect(link).to have_link(
+        'Try your search again',
+        href: 'http://www.gov.gov/search?query=Bill+%26+Ted%27s+%28B%26T%29+Excellent+%C3%84dventure%21'
+      )
     end
   end
 end

--- a/spec/helpers/search_helper_spec.rb
+++ b/spec/helpers/search_helper_spec.rb
@@ -26,40 +26,40 @@ describe SearchHelper do
       @urls_that_dont_need_a_box << 'https://www.usa.gov/faq?q=meaning+of+life'
     end
 
-    it 'should return empty string for most types of URLs' do
+    it 'returns an empty string for most types of URLs' do
       @urls_that_dont_need_a_box.each do |url|
-        expect(helper.display_web_result_extname_prefix({'unescapedUrl' => url})).to eq('')
+        expect(helper.display_web_result_extname_prefix({ 'unescapedUrl' => url })).to eq('')
       end
     end
 
-    it 'should return [TYP] span for some URLs' do
+    it 'returns [TYP] span for some URLs' do
       @urls_that_need_a_box.each do |url|
         path_extname = url.gsub(/.*\//, '').gsub(/\?.*/, '').gsub(/[a-zA-Z0-9_]+\./, '').upcase
         prefix = "<span class=\"uext_type\">[#{path_extname.upcase}]</span> "
-        expect(helper.display_web_result_extname_prefix({'unescapedUrl' => url})).to eq(prefix)
+        expect(helper.display_web_result_extname_prefix({ 'unescapedUrl' => url })).to eq(prefix)
       end
     end
   end
 
   describe '#display_result_description' do
-    it 'should be html safe' do
-      description = <<-DESCRIPTION
-loren & david's excellent™ html "examples" on the <i>tag</i> and <b> too. loren & david's excellent™ html "examples" on the <i>tag</i> and <b> too. loren & david's excellent™ html "examples" on the <i>tag</i> and <b> too. loren & david's excellent™ html truncate me if you want
+    it 'is html safe' do
+      description = <<~DESCRIPTION
+        loren & david's excellent™ html "examples" on the <i>tag</i> and <b> too. loren & david's excellent™ html "examples" on the <i>tag</i> and <b> too. loren & david's excellent™ html "examples" on the <i>tag</i> and <b> too. loren & david's excellent™ html truncate me if you want
       DESCRIPTION
 
-      search = {'content' => description}
+      search = { 'content' => description }
       result = helper.display_result_description(search)
       expect(result).to be_html_safe
       expect(result).to eq("<strong>loren</strong> &amp; david's excellent™ html \"examples\" on the &lt;i&gt;tag&lt;/i&gt; and &lt;b&gt; too. <strong>loren</strong> &amp; david's excellent™ html \"examples\" on the &lt;i&gt;tag&lt;/i&gt; and &lt;b&gt; too. <strong>lo</strong> ...")
     end
 
-    it 'should truncate long description' do
-      description = <<-DESCRIPTION
-The Vietnam War Memorial National Mall Washington, D.C. 2:27 P.M. EDT THE PRESIDENT:  Good afternoon, everybody.
-Chuck, thank you for your words and your friendship and your life of service.
-Veterans of the Vietnam War, families, friends, distinguished guests. I know it is hot.
+    it 'truncates long descriptions' do
+      description = <<~DESCRIPTION
+        The Vietnam War Memorial National Mall Washington, D.C. 2:27 P.M. EDT THE PRESIDENT:  Good afternoon, everybody.
+        Chuck, thank you for your words and your friendship and your life of service.
+        Veterans of the Vietnam War, families, friends, distinguished guests. I know it is hot.
       DESCRIPTION
-      truncated_description = helper.display_result_description({'content' => description})
+      truncated_description = helper.display_result_description({ 'content' => description })
       expect(truncated_description).to match(/and \.\.\.$/)
       expect(truncated_description.length).to be <= 153
     end
@@ -73,10 +73,12 @@ Veterans of the Vietnam War, families, friends, distinguished guests. I know it 
 
   describe '#link_to_other_web_results(template, query)' do
     let(:html_template) { 'The above results are from Wherever. <a href="http://www.gov.gov/search?query={QUERY}">Try your search again</a> to see results from Another Place.' }
-    let(:query) { 'one two' }
+    let(:query) { "Bill & Ted's (B&T) Excellent Ädventure!" }
 
-    it 'should render HTML with interpolated and encoded query string' do
-      expect(helper.link_to_other_web_results(html_template, query)).to have_link('Try your search again', 'http://www.gov.gov/search?query=one%20two')
+    it 'renders HTML with interpolated and encoded query string' do
+      link = helper.link_to_other_web_results(html_template, query)
+      expect(link).to have_link('Try your search again',
+                                href: 'http://www.gov.gov/search?query=Bill%20%26%20Ted%27s%20%28B%26T%29%20Excellent%20%C3%84dventure%21')
     end
   end
 end


### PR DESCRIPTION
## Summary
- Updates `app/helpers/search_helper.rb` to ensure that queries passed to "no results pointer" and/or "page one more results pointer" are properly URI encoded;
- Updates `spec/helpers/search_helper_spec.rb` to confirm that the href attribute of a `link_to_other_web_results` generated link is being checked (instead of silently passing with an unused parameter warning); and,
- Very minor spelling, spacing, indentation, double/single quote changes as identified by my linter/rubocop.

While the use of `Addressable::URI.encode` was recommended in the dev approach, this did not properly % encode ampersands.

```
[1] pry(main)> query = "Bill & Ted's Excellent"
=> "Bill & Ted's Excellent"
[2] pry(main)> Addressable::URI.encode(query)
=> "Bill%20&%20Ted's%20Excellent"
[3] pry(main)> Addressable::URI.encode_component(query, Addressable::URI::CharacterClasses::ALPHA)
=> "Bill%20%26%20Ted%27s%20Excellent"
```

Note: This will improve this test coverage under Capybara 2.x, but is also a necessary prerequisite for [SRCH-2382](https://cm-jira.usa.gov/browse/SRCH-2382) as the Capybara 3.x upgrade will result in these tests failing.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 N/A

- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
Ongoing precursor work necessary for Rails 6.1 upgrade is to use the feature/rails_6_1 branch.
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers