### PR TITLE
SRCH-2382 bump capybara to ~> 3.26

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -149,9 +149,7 @@ group :development, :test do
   gem 'rspec-its', '~> 1.3'
   gem 'email_spec', '~> 2.2'
   gem 'database_cleaner', '~> 2.0'
-  # Capybara 3 includes breaking changes
-  # https://cm-jira.usa.gov/browse/SRCH-2382
-  gem 'capybara', '2.18'
+  gem 'capybara', '~> 3.26'
   gem 'launchy', '~> 2.5'
   gem 'i18n-tasks', '~> 0.9.19'
   gem 'pry-byebug', '~> 3.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -218,13 +218,15 @@ GEM
     buftok (0.2.0)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (2.18.0)
+    capybara (3.36.0)
       addressable
+      matrix
       mini_mime (>= 0.1.3)
-      nokogiri (>= 1.3.3)
-      rack (>= 1.0.0)
-      rack-test (>= 0.5.4)
-      xpath (>= 2.0, < 4.0)
+      nokogiri (~> 1.8)
+      rack (>= 1.6.0)
+      rack-test (>= 0.6.3)
+      regexp_parser (>= 1.5, < 3.0)
+      xpath (~> 3.2)
     capybara-screenshot (1.0.25)
       capybara (>= 1.0, < 4)
       launchy
@@ -511,6 +513,7 @@ GEM
     mail (2.7.1)
       mini_mime (>= 0.1.1)
     marcel (1.0.2)
+    matrix (0.4.2)
     memoist (0.16.2)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -856,7 +859,7 @@ DEPENDENCIES
   authlogic (~> 6.4.1)
   awesome_print
   aws-sdk-s3 (~> 1.102.0)
-  capybara (= 2.18)
+  capybara (~> 3.26)
   capybara-screenshot
   cld3 (~> 3.4.3)
   coffee-rails (~> 5.0.0)

--- a/features/mobile_searches.feature
+++ b/features/mobile_searches.feature
@@ -464,7 +464,7 @@ Feature: Searches using mobile device
     And I press "Buscar"
     Then I should see an image link to "USAJobs.gov" with url for "https://www.usajobs.gov/"
     And I should see "Ninguna oferta de trabajo en su región coincide con su búsqueda"
-    And I should see a link to "​Más trabajos en el gobierno federal en USAJobs.gov" with url for "https://www.usajobs.gov/Search/Results?hp=public"
+    And I should see a link to "Más trabajos en el gobierno federal en USAJobs.gov" with url for "https://www.usajobs.gov/Search/Results?hp=public"
 
   Scenario: Agency job search
     Given the following Agencies exist:

--- a/features/step_definitions/timeline_steps.rb
+++ b/features/step_definitions/timeline_steps.rb
@@ -1,3 +1,3 @@
 Then /^the "([^\"]*)" field should be empty$/ do |field|
-  field_labeled(field).value.should be_blank
+  find_field(field).value.should be_blank
 end

--- a/features/step_definitions/web_ext_steps.rb
+++ b/features/step_definitions/web_ext_steps.rb
@@ -73,7 +73,7 @@ And /^the "([^"]*)" field should be blank$/ do |field|
 end
 
 Then /^the "([^\"]*)" radio button should be checked$/ do |label|
-  field_labeled(label)['checked'].should be_truthy
+  find_field(label)['checked'].should be_truthy
 end
 
 Then /^the "([^\"]*)" radio button should not be checked$/ do |label|

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -118,7 +118,8 @@ end
 
 Then /^(?:|I )should see "([^"]*)"$/ do |text|
   if page.respond_to? :should
-    page.should have_content(text)
+    page.should have_content(text,
+                             normalize_ws: true)
   else
     assert page.has_content?(text)
   end
@@ -220,7 +221,7 @@ When /^(?:|I )follow "([^"]*)" and confirm "([^"]*)"$/ do |link, msg|
 end
 
 Then "I wait for ajax"  do
-  Timeout.timeout(Capybara.default_wait_time) do
+  Timeout.timeout(Capybara.default_max_wait_time) do
     loop do
       active = page.evaluate_script('jQuery.active')
       break if active == 0

--- a/spec/system/admin/bulk_url_upload_spec.rb
+++ b/spec/system/admin/bulk_url_upload_spec.rb
@@ -46,10 +46,7 @@ describe 'Bulk URL upload' do
       it 'shows a confirmation message' do
         do_bulk_upload
         expect(page).to have_text(
-          <<~CONFIRMATION_MESSAGE
-            Successfully uploaded #{upload_filename} for processing.
-            The results will be emailed to you.
-          CONFIRMATION_MESSAGE
+          "Successfully uploaded #{upload_filename} for processing. The results will be emailed to you."
         )
       end
 

--- a/spec/views/admin/query_ctrs/show.html.haml_spec.rb
+++ b/spec/views/admin/query_ctrs/show.html.haml_spec.rb
@@ -20,8 +20,7 @@ describe 'admin/query_ctrs/show.html.haml' do
 
   it 'shows the query CTR stats for some search module on some site' do
     render
-    expect(rendered).to have_content('Query CTRs for Best Bets Text (BOOS) on USA.gov',
-                                     normalize_ws: true)
+    expect(rendered).to have_content('Query CTRs for Best Bets Text (BOOS) on USA.gov')
     expect(rendered).to have_content('query 2 1,000 500 50.0% 105 17 16.2%',
                                      normalize_ws: true)
     expect(rendered).to have_content('query 1 456 123 27.0% 45 12 26.7%',

--- a/spec/views/admin/query_ctrs/show.html.haml_spec.rb
+++ b/spec/views/admin/query_ctrs/show.html.haml_spec.rb
@@ -20,11 +20,16 @@ describe 'admin/query_ctrs/show.html.haml' do
 
   it 'shows the query CTR stats for some search module on some site' do
     render
-    expect(rendered).to have_content 'Query CTRs for Best Bets Text (BOOS) on USA.gov'
-    expect(rendered).to have_content 'query 2 1,000 500 50.0% 105 17 16.2%'
-    expect(rendered).to have_content 'query 1 456 123 27.0% 45 12 26.7%'
-    expect(rendered).to have_content 'query 3 123 10 8.1% 0 12'
-    expect(rendered).to have_content 'All Queries 1,579 633 40.1% 150 41 27.3%'
+    expect(rendered).to have_content('Query CTRs for Best Bets Text (BOOS) on USA.gov',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('query 2 1,000 500 50.0% 105 17 16.2%',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('query 1 456 123 27.0% 45 12 26.7%',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('query 3 123 10 8.1% 0 12',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('All Queries 1,579 633 40.1% 150 41 27.3%',
+                                     normalize_ws: true)
   end
 
 end

--- a/spec/views/admin/search_module_ctrs/show.html.haml_spec.rb
+++ b/spec/views/admin/search_module_ctrs/show.html.haml_spec.rb
@@ -17,11 +17,16 @@ describe 'admin/search_module_ctrs/show.html.haml' do
 
   it 'shows the stats' do
     render
-    expect(rendered).to have_content 'Search Module CTRs'
-    expect(rendered).to have_content 'Module 2 (MOD2) (drill down) 1,000 500 50.0% 105 17 16.2%'
-    expect(rendered).to have_content 'Module 1 (MOD1) (drill down) 456 123 27.0% 45 12 26.7%'
-    expect(rendered).to have_content 'Module 3 (MOD3) (drill down) 123 10 8.1% 0 12'
-    expect(rendered).to have_content 'All Modules 1,579 633 40.1% 150 41 27.3%'
+    expect(rendered).to have_content('Search Module CTRs',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('Module 2 (MOD2) (drill down) 1,000 500 50.0% 105 17 16.2%',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('Module 1 (MOD1) (drill down) 456 123 27.0% 45 12 26.7%',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('Module 3 (MOD3) (drill down) 123 10 8.1% 0 12',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('All Modules 1,579 633 40.1% 150 41 27.3%',
+                                     normalize_ws: true)
   end
 
 end

--- a/spec/views/admin/search_module_ctrs/show.html.haml_spec.rb
+++ b/spec/views/admin/search_module_ctrs/show.html.haml_spec.rb
@@ -17,8 +17,7 @@ describe 'admin/search_module_ctrs/show.html.haml' do
 
   it 'shows the stats' do
     render
-    expect(rendered).to have_content('Search Module CTRs',
-                                     normalize_ws: true)
+    expect(rendered).to have_content('Search Module CTRs')
     expect(rendered).to have_content('Module 2 (MOD2) (drill down) 1,000 500 50.0% 105 17 16.2%',
                                      normalize_ws: true)
     expect(rendered).to have_content('Module 1 (MOD1) (drill down) 456 123 27.0% 45 12 26.7%',

--- a/spec/views/admin/site_ctrs/show.html.haml_spec.rb
+++ b/spec/views/admin/site_ctrs/show.html.haml_spec.rb
@@ -22,11 +22,16 @@ describe 'admin/site_ctrs/show.html.haml' do
 
   it 'shows the site CTR stats for some search module' do
     render
-    expect(rendered).to have_content 'Site CTRs for Best Bets Text (BOOS)'
-    expect(rendered).to have_content 'NPS Site (drill down) 1,000 500 50.0% 105 17 16.2%'
-    expect(rendered).to have_content 'USA.gov (drill down) 456 123 27.0% 45 12 26.7%'
-    expect(rendered).to have_content 'Noaa Site (drill down) 123 10 8.1% 0 12'
-    expect(rendered).to have_content 'All Sites 1,579 633 40.1% 150 41 27.3%'
+    expect(rendered).to have_content('Site CTRs for Best Bets Text (BOOS)',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('NPS Site (drill down) 1,000 500 50.0% 105 17 16.2%',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('USA.gov (drill down) 456 123 27.0% 45 12 26.7%',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('Noaa Site (drill down) 123 10 8.1% 0 12',
+                                     normalize_ws: true)
+    expect(rendered).to have_content('All Sites 1,579 633 40.1% 150 41 27.3%',
+                                     normalize_ws: true)
   end
 
 end

--- a/spec/views/admin/site_ctrs/show.html.haml_spec.rb
+++ b/spec/views/admin/site_ctrs/show.html.haml_spec.rb
@@ -22,8 +22,7 @@ describe 'admin/site_ctrs/show.html.haml' do
 
   it 'shows the site CTR stats for some search module' do
     render
-    expect(rendered).to have_content('Site CTRs for Best Bets Text (BOOS)',
-                                     normalize_ws: true)
+    expect(rendered).to have_content('Site CTRs for Best Bets Text (BOOS)')
     expect(rendered).to have_content('NPS Site (drill down) 1,000 500 50.0% 105 17 16.2%',
                                      normalize_ws: true)
     expect(rendered).to have_content('USA.gov (drill down) 456 123 27.0% 45 12 26.7%',


### PR DESCRIPTION
## Summary
- Bumps Capybara to ~> 3.26 to support Rails 6.1 upgrade.  Tests in a Rails 6.1 upgrade branch throw `LoadError: can't activate capybara (>= 3.26), already activated capybara-2.18.0. Make sure all dependencies are added to Gemfile.` without this change.
- Minor changes to tests to support this upgrade, namely centering on how whitespace is handled in `Node#text` and related matchers.  (For more, see: https://github.com/teamcapybara/capybara/blob/master/UPGRADING.md)
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 Ongoing precursor work necessary for Rails 6.1 upgrade is to use the feature/rails_6_1 branch.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers