### PR TITLE
SRCH-2753 limit dry-configurable to 0.13.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,10 +72,16 @@ gem 'sitelink_generator', git: 'https://github.com/GSA/sitelink_generator', ref:
 gem 'typhoeus', '~> 1.3.0'
 gem 'activerecord-validate_unique_child_attribute',
     require: 'active_record/validate_unique_child_attribute'
-# deprecated - jwt, grape, and grape-entity are only used by Search Consumer
+
+### deprecated - jwt, grape, grape-entity, and dry-configurable are only used by Search Consumer
+# https://cm-jira.usa.gov/browse/SRCH-1080
 gem 'jwt', '~> 1.5.6'
 gem 'grape', '~> 1.1'
 gem 'grape-entity', '~> 0.6.0'
+# temporarily limiting dry-configurable, as versions >= 0.14.0 are incompatible with ruby 2.6
+gem 'dry-configurable', '0.13.0'
+### end Search Consumer gems
+
 gem 'rack-cors', '~> 1.1.0', :require => 'rack/cors'
 gem 'hashie', '~> 3.3.0'
 # retry_block is unsupported - consider replacing with retriable

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -866,6 +866,7 @@ DEPENDENCIES
   curb (~> 0.9.4)
   database_cleaner (~> 1.7.0)
   dogstatsd-ruby (~> 3.2.0)
+  dry-configurable (= 0.13.0)
   elasticsearch (~> 7.4.0)
   elasticsearch-xpack (~> 7.4.0)
   em-http-request (~> 1.1.5)


### PR DESCRIPTION
## Summary
This PR locks `dry-configurable` to `0.13.0`, as `0.14.0`, as `0.14.0` is incompatible with ruby 2.6. 
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A. As this only limits but does not change our gem versions, I plan to merge this to master without manual testing.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers