### PR TITLE
SRCH-2780 add Ruby 2.7.5 Dockerfile

### DIFF
--- a/.circleci/images/primary/Dockerfile.ruby275
+++ b/.circleci/images/primary/Dockerfile.ruby275
@@ -1,0 +1,10 @@
+FROM cimg/ruby:2.7.5-browsers
+
+USER root
+
+RUN apt-get update && apt-get install -y \
+  default-mysql-client \
+  libprotobuf-dev \
+  protobuf-compiler
+
+USER circleci


### PR DESCRIPTION
## Summary
This PR adds a Dockerfile for Ruby 2.7.5 (the image has already been pushed to Docker Hub). Our previous image for 2.7.4 used a legacy ruby image with support for PhantomJS, which we are removing from our repo. This is also based on a newer `cimg/ruby` image, instead of the older `circleci/ruby` images. 
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional. - This will be tested via the ticket to remove PhantomJS/poltergeist.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers