### PR TITLE
SRCH-1831 remove indices_boost from blended query

### DIFF
--- a/app/models/custom_index_queries/elastic_blended_query.rb
+++ b/app/models/custom_index_queries/elastic_blended_query.rb
@@ -14,7 +14,6 @@ class ElasticBlendedQuery < ElasticTextFilterByPublishedAtQuery
 
   def body
     Jbuilder.encode do |json|
-      indices_boost(json)
       query(json)
       highlight(json) if @highlighting
       suggest(json)
@@ -39,16 +38,6 @@ class ElasticBlendedQuery < ElasticTextFilterByPublishedAtQuery
             end
           end
         end unless @sort
-      end
-    end
-  end
-
-  def indices_boost(json)
-    #TODO: use aliases when https://github.com/elasticsearch/elasticsearch/issues/4756 is fixed
-    index_names = Es::CustomIndices.client_reader.indices.get_alias(name: ElasticBlended.reader_alias.join(',')).keys.sort
-    json.indices_boost do
-      index_names.each_with_index do |index_name, idx|
-        json.set! index_name, ElasticBlended::INDEX_BOOSTS[idx]
       end
     end
   end

--- a/app/models/elastic_blended.rb
+++ b/app/models/elastic_blended.rb
@@ -3,7 +3,6 @@
 class ElasticBlended
   #Note: keep these alphabetized
   INDEXES = %w{IndexedDocument NewsItem}
-  INDEX_BOOSTS = [1.0, 1.0]
 
   extend Indexable
 


### PR DESCRIPTION
## Summary
This PR removes the `indices_boost` from the elastic blended query. That code appears to have been left over from a story that boosted the news items index over the indexed documents: https://github.com/GSA/search-gov/commit/bdcca33b7445ec07f459b5407d941b66bfd8006b#diff-06942b1e0c2fc7d4fefe5a523bce273344134fd1bb349fa292fdfd9436a0cabeR4

The boost values were [later changed](https://github.com/GSA/search-gov/commit/fd5a657e2b697422d74cf97591b9bcc4b3af91f9#diff-06942b1e0c2fc7d4fefe5a523bce273344134fd1bb349fa292fdfd9436a0cabeR4) from `[1.0, 1.5]` to `[1.0, 1.0]`. That effectively prevents the boost from doing anything, as each index has the same boost, so I'm removing the code entirely. (I suspect that it was left over as an oversight after the boosts were equalized.)

https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-index-boost.html

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional. - I've tested the before/after results against production data, and confirmed that the boost is not changing the results.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - This will be manually tested, but I'm skipping a bundle update for this story, as the Rails 6.1 code will be in `master` shortly.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers