### PR TITLE
SRCH-1389 Fix flaky user controller tests

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -11,6 +11,8 @@ describe UsersController do
 
   let(:permitted_params) { %i[first_name last_name organization_name email] }
 
+  before { activate_authlogic }
+
   describe '#create' do
     it do
       is_expected.to permit(*permitted_params).
@@ -73,7 +75,6 @@ describe UsersController do
 
   describe '#show' do
     context 'when logged in as affiliate' do
-      before { activate_authlogic }
       include_context 'approved user logged in'
 
       before { get :show, params: { id: current_user.id } }
@@ -84,7 +85,6 @@ describe UsersController do
 
   describe '#edit' do
     context 'when logged in as affiliate' do
-      before { activate_authlogic }
       include_context 'approved user logged in'
 
       before { get :edit, params: { id: current_user.id } }
@@ -107,7 +107,6 @@ describe UsersController do
     end
 
     context 'when logged in as affiliate' do
-      before { activate_authlogic }
       include_context 'approved user logged in'
 
       it do
@@ -117,7 +116,9 @@ describe UsersController do
 
       context 'when account is saved successfully' do
         before do
-          expect(current_user).to receive(:save).
+          # ensure under-the-hood saves, such as by Authlogic, function normally
+          allow(current_user).to receive(:save).and_call_original
+          allow(current_user).to receive(:save).
             with(context: :update_account).and_return(true)
 
           update_account
@@ -128,10 +129,12 @@ describe UsersController do
         it { is_expected.to set_flash.to('Account updated!') }
       end
 
-      context 'when the is not saved successfully' do
+      context 'when account is not saved successfully' do
         before do
-          expect(current_user).to receive(:save).
-            with( context: :update_account ).and_return(false)
+          # ensure under-the-hood saves, such as by Authlogic, function normally
+          allow(current_user).to receive(:save).and_call_original
+          allow(current_user).to receive(:save).
+            with(context: :update_account).and_return(false)
 
           update_account
         end
@@ -154,7 +157,6 @@ describe UsersController do
     end
 
     context 'when logged in as affiliate' do
-      before { activate_authlogic }
       include_context 'approved user logged in'
 
       it do
@@ -191,7 +193,6 @@ describe UsersController do
 
   context 'when logged in as a developer' do
     before do
-      activate_authlogic
       @user = users('non_affiliate_admin')
       UserSession.create(@user)
     end


### PR DESCRIPTION
## Summary
Fix inconsistently failing user controller test by:
- Separating test setup in the before block from test assertions by switching from `expect` to `allow`;
- Moving to one `activate_authlogic` in one top-level before, instead of scattering them in all over the place; and,
- Ensure other saves (e.g. from authlogic) run normally, before stubbing the response we need for `update_account` (credit to: @MothOnMars).

Additional Background:
SRCH-1389 was filed just a couple months after these tests were initially contributed, so I suspect these have always been a bit flaky.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.
Test change only.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 N/A
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers