### PR TITLE
SRCH-2641 remove Ruby 2.6 from CircleCi matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 
 orbs:
-  ruby: circleci/ruby@1.2.0
+  ruby: circleci/ruby@1.4.0
 
 executors:
   test_executor:
@@ -221,7 +221,6 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - 2.6.6
                 - 2.7.4
 
       - rspec:
@@ -231,7 +230,6 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - 2.6.6
                 - 2.7.4
 
       - cucumber:
@@ -241,7 +239,6 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - 2.6.6
                 - 2.7.4
 
       - report_coverage:
@@ -252,5 +249,4 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - 2.6.6
                 - 2.7.4


### PR DESCRIPTION
## Summary
SRCH-2641 remove Ruby 2.6 from CircleCi matrix
- use Ruby orb 1.4.0
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional. - N/A

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers