### PR TITLE
SRCH-528 specify minimum_should_match: 1

### DIFF
--- a/app/models/custom_index_queries/elastic_indexed_document_query.rb
+++ b/app/models/custom_index_queries/elastic_indexed_document_query.rb
@@ -25,12 +25,21 @@ class ElasticIndexedDocumentQuery < ElasticTextFilteredQuery
         json.must do
           json.term { json.affiliate_id @affiliate_id }
         end
-        json.set! :should do |should_json|
-          @document_collection.url_prefixes.each do |url_prefix|
-            should_json.child! { should_json.prefix { json.url url_prefix.prefix } }
-          end
-        end if @document_collection
+
+        collections_filter(json)
       end
     end
+  end
+
+  def collections_filter(json)
+    return unless @document_collection
+
+    json.set! :should do |should_json|
+      @document_collection.url_prefixes.each do |url_prefix|
+        should_json.child! { should_json.prefix { json.url url_prefix.prefix } }
+      end
+    end
+
+    json.minimum_should_match 1
   end
 end


### PR DESCRIPTION
## Summary
This PR resolves the following breaking change in Elasticsearch 7.x:
https://www.elastic.co/guide/en/elasticsearch/reference/7.0/breaking-changes-7.0.html#_the_filter_context_has_been_removed

This change preserves the 6.x behavior by explicitly setting `minimum_should_match: 1`, which ES 7.x will no longer do automatically.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - I suggest we skip manual testing for this change, which is covered by our spec suite.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers