### PR TITLE
SRCH-2845 specify include_type_name when migrating index

### DIFF
--- a/lib/indexable.rb
+++ b/lib/indexable.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Indexable
   attr_accessor :default_sort, :mappings, :settings
 

--- a/lib/indexable.rb
+++ b/lib/indexable.rb
@@ -4,7 +4,7 @@ module Indexable
   attr_accessor :default_sort, :mappings, :settings
 
   DELIMTER = '-'
-  NO_HITS = { 'hits' => { 'total' => 0, 'offset' => 0, 'hits' => [] } }
+  NO_HITS = { 'hits' => { 'total' => 0, 'offset' => 0, 'hits' => [] } }.freeze
 
   def index_name
     @index_name ||= [base_index_name, Time.now.strftime('%Y%m%d%H%M%S%L')].join(DELIMTER)

--- a/lib/indexable.rb
+++ b/lib/indexable.rb
@@ -5,7 +5,7 @@ module Indexable
   NO_HITS = { 'hits' => { 'total' => 0, 'offset' => 0, 'hits' => [] } }
 
   def index_name
-    @index_name ||= [base_index_name, Time.now.strftime("%Y%m%d%H%M%S%L")].join(DELIMTER)
+    @index_name ||= [base_index_name, Time.now.strftime('%Y%m%d%H%M%S%L')].join(DELIMTER)
   end
 
   def reader_alias
@@ -88,7 +88,7 @@ module Indexable
 
   def delete_by_query(options)
     query = options.collect { |key, value| [key, value].join(':') }.join(' ')
-    Es::CustomIndices.client_writers.each { |client| client.delete_by_query index: writer_alias, q: query, default_operator: "AND" }
+    Es::CustomIndices.client_writers.each { |client| client.delete_by_query index: writer_alias, q: query, default_operator: 'AND' }
   end
 
   def bulkify(records)
@@ -108,7 +108,7 @@ module Indexable
 
   def search_for(options)
     query = "#{name}Query".constantize.new options
-    ActiveSupport::Notifications.instrument("elastic_search.usasearch", query: query.body, index: name) do
+    ActiveSupport::Notifications.instrument('elastic_search.usasearch', query: query.body, index: name) do
       search(query)
     end
   rescue Exception => e

--- a/lib/indexable.rb
+++ b/lib/indexable.rb
@@ -9,23 +9,23 @@ module Indexable
   end
 
   def reader_alias
-    self.index_alias :reader
+    index_alias :reader
   end
 
   def writer_alias
-    self.index_alias :writer
+    index_alias :writer
   end
 
   def index_alias(type)
-    [self.base_index_name, type].join(DELIMTER)
+    [base_index_name, type].join(DELIMTER)
   end
 
   def index_type
-    @index_type ||= self.name.underscore
+    @index_type ||= name.underscore
   end
 
   def base_index_name
-    [Es::INDEX_PREFIX, self.name.tableize].join(DELIMTER)
+    [Es::INDEX_PREFIX, name.tableize].join(DELIMTER)
   end
 
   def delete_index
@@ -107,13 +107,13 @@ module Indexable
   end
 
   def search_for(options)
-    query = "#{self.name}Query".constantize.new options
-    ActiveSupport::Notifications.instrument("elastic_search.usasearch", query: query.body, index: self.name) do
+    query = "#{name}Query".constantize.new options
+    ActiveSupport::Notifications.instrument("elastic_search.usasearch", query: query.body, index: name) do
       search(query)
     end
   rescue Exception => e
-    Rails.logger.error "Problem in #{self.name}#search_for(): #{e}"
-    "#{self.name}Results".constantize.new(NO_HITS)
+    Rails.logger.error "Problem in #{name}#search_for(): #{e}"
+    "#{name}Results".constantize.new(NO_HITS)
   end
 
   def commit
@@ -163,13 +163,13 @@ module Indexable
     response = client.bulk(body: body)
     handle_bulk_errors(client, response) if response['errors']
   rescue Exception => e
-    Rails.logger.error "#{Time.now} Client error in #{self.name}#client_bulk(): #{e}; host: #{host_list(client) }; body: #{body}"
+    Rails.logger.error "#{Time.now} Client error in #{name}#client_bulk(): #{e}; host: #{host_list(client) }; body: #{body}"
     nil
   end
 
   def handle_bulk_errors(client, response)
     errors = response['items'].select { |item| item.values.first['status'] >= 400 }
-    Rails.logger.error "#{Time.now} Bulk API error in #{self.name}#client_bulk(): #{errors}; host: #{host_list(client) }"
+    Rails.logger.error "#{Time.now} Bulk API error in #{name}#client_bulk(): #{errors}; host: #{host_list(client) }"
   end
 
   def host_list(client)

--- a/lib/indexable.rb
+++ b/lib/indexable.rb
@@ -113,7 +113,7 @@ module Indexable
     ActiveSupport::Notifications.instrument('elastic_search.usasearch', query: query.body, index: name) do
       search(query)
     end
-  rescue Exception => e
+  rescue StandardError => e
     Rails.logger.error "Problem in #{name}#search_for(): #{e}"
     "#{name}Results".constantize.new(NO_HITS)
   end
@@ -164,7 +164,7 @@ module Indexable
   def client_bulk(client, body)
     response = client.bulk(body: body)
     handle_bulk_errors(client, response) if response['errors']
-  rescue Exception => e
+  rescue StandardError => e
     Rails.logger.error "#{Time.now} Client error in #{name}#client_bulk(): #{e}; host: #{host_list(client) }; body: #{body}"
     nil
   end

--- a/lib/indexable.rb
+++ b/lib/indexable.rb
@@ -152,12 +152,14 @@ module Indexable
   def update_alias(alias_name, new_index = index_name)
     old_index = Es::CustomIndices.client_reader.indices.get_alias(name: alias_name).keys.first
     Es::CustomIndices.client_writers.each do |client|
-      client.indices.update_aliases(body: {
-        actions: [
-          { remove: { index: old_index, alias: alias_name } },
-          { add: { index: new_index, alias: alias_name } }
-        ]
-      })
+      client.indices.update_aliases(
+        body: {
+          actions: [
+            { remove: { index: old_index, alias: alias_name } },
+            { add: { index: new_index, alias: alias_name } }
+          ]
+        }
+      )
     end
   end
 

--- a/lib/indexable.rb
+++ b/lib/indexable.rb
@@ -46,7 +46,13 @@ module Indexable
 
   def migrate_writer
     @index_name = nil
-    Es::CustomIndices.client_writers.each { |client| client.indices.create(index: index_name, body: { settings: settings, mappings: mappings }) }
+    Es::CustomIndices.client_writers.each do |client|
+      client.indices.create(
+        index: index_name,
+        body: { settings: settings, mappings: mappings },
+        include_type_name: true
+      )
+    end
     update_alias(writer_alias)
   end
 


### PR DESCRIPTION
## Summary
This PR adds the `include_type_name: true` parameter to the index creation call during index migration, for compatibility with ES 7. This is similar to https://github.com/GSA/search-gov/pull/866 (there's an opportunity to DRY up the two index creation methods, but I decided to keep the refactoring to a minimum, as I plan to skip manual testing for this change). I've also cleaned up some Rubocop offenses (there are still more to do in this file, but I timeboxed the Rubocop cleanup).
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A. I suggest we skip manual testing.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop) - I made each set of Rubocop changes as a separate commit. Let me know if that makes the review process easier or harder!

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers