### PR TITLE
SRCH-2853 remove sc_search_engine method & specs

### DIFF
--- a/app/models/affiliate.rb
+++ b/app/models/affiliate.rb
@@ -404,10 +404,6 @@ class Affiliate < ApplicationRecord
     dup_instance
   end
 
-  def sc_search_engine
-    search_engine =~ /BingV\d+/ ? 'Bing' : search_engine
-  end
-
   def status
     active? ? 'Active' : 'Inactive'
   end

--- a/spec/models/affiliate_spec.rb
+++ b/spec/models/affiliate_spec.rb
@@ -1009,25 +1009,6 @@ describe Affiliate do
     end
   end
 
-  describe '#sc_search_engine' do
-    subject { described_class.new(valid_create_attributes.merge(search_engine: search_engine)) }
-
-    {
-      'Bing' => 'Bing',
-      'BingV6' => 'Bing',
-      'BingV7' => 'Bing',
-      'Google' => 'Google'
-    }.each do |configured_search_engine, sc_reported_search_engine|
-      context "when an affiliate's search_engine is '#{configured_search_engine}'" do
-        let(:search_engine) { configured_search_engine }
-
-        it "reports sc_search_engine as '#{sc_reported_search_engine}'" do
-          expect(subject.sc_search_engine).to eql(sc_reported_search_engine)
-        end
-      end
-    end
-  end
-
   describe '#status' do
     subject(:status) { affiliate.status }
 


### PR DESCRIPTION
## Summary
- SRCH-2853 remove sc_search_engine method & specs
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - The release branch will be tested manually. I'll do a `bundle update` as part of finalizing that branch.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason: The [GSA:feature/sc_housekeeping_2721](https://github.com/GSA/search-gov/tree/feature/sc_housekeeping_2721) branch will be used for the last round of search consumer cleanup.
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers