### PR TITLE
SRCH-2859 remove the rspec-json_expectations gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -138,7 +138,6 @@ end
 
 group :development, :test do
   gem 'rspec-rails', '~> 5.0'
-  gem 'rspec-json_expectations', '~> 2.2'
   gem 'rspec-its', '~> 1.3'
   gem 'email_spec', '~> 2.2'
   gem 'database_cleaner', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -647,7 +647,6 @@ GEM
     rspec-its (1.3.0)
       rspec-core (>= 3.0.0)
       rspec-expectations (>= 3.0.0)
-    rspec-json_expectations (2.2.0)
     rspec-mocks (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
@@ -893,7 +892,6 @@ DEPENDENCIES
   robots_tag_parser (~> 0.1.0)!
   rspec-activemodel-mocks (~> 1.1)
   rspec-its (~> 1.3)
-  rspec-json_expectations (~> 2.2)
   rspec-rails (~> 5.0)
   rspec_junit_formatter (~> 0.4)
   sass-rails (~> 5.0.7)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,7 +5,6 @@ SimpleCov.command_name 'RSpec'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 require 'rspec/rails'
-require 'rspec/json_expectations'
 require 'email_spec'
 require 'authlogic/test_case'
 require 'paperclip/matchers'


### PR DESCRIPTION
## Summary
This PR removes the `rspec-json_expectations` gem, which was only used in specs that we have removed.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason: The target is `rspec-json_expectations`, as this is part of the search consumer tear-out.
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers