### PR TITLE
SRCH-2861 remove affiliate_notes route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -171,7 +171,6 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :affiliates, concerns: :active_scaffold
-    resources :affiliate_notes, concerns: :active_scaffold
     resources :users, concerns: :active_scaffold
     resources :sayt_filters, concerns: :active_scaffold
     resources :sayt_suggestions, concerns: :active_scaffold


### PR DESCRIPTION
## Summary

This PR removes a route related to the `affiliate_notes` table, which was deprecated/dropped in 2015:
https://github.com/GSA/search-gov/commit/429adb359262ff5f038b94de4409e3e1900c997
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A. Will be tested with the rest of the [feature/sc_housekeeping_2721](https://github.com/GSA/search-gov/tree/feature/sc_housekeeping_2721) branch
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason: Target is [feature/sc_housekeeping_2721](https://github.com/GSA/search-gov/tree/feature/sc_housekeeping_2721)
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers