### PR TITLE
SRCH-2828 Minimum should match in boosted contents

### DIFF
--- a/app/models/custom_index_queries/elastic_boosted_content_query.rb
+++ b/app/models/custom_index_queries/elastic_boosted_content_query.rb
@@ -9,11 +9,14 @@ class ElasticBoostedContentQuery < ElasticBestBetQuery
 
   def filtered_query_filter(json)
     super do
-      json.set! :should do |should_json|
-        @site_limits.each do |site_limit|
-          should_json.child! { should_json.prefix { json.url site_limit } }
+      if @site_limits.present?
+        json.set! :should do |should_json|
+          @site_limits.each do |site_limit|
+            should_json.child! { should_json.prefix { json.url site_limit } }
+          end
         end
-      end if @site_limits.present?
+        json.minimum_should_match 1
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
- Resolves "minimum_should_match" deprecation warnings in boosted contents
- Debugging statements confirm no test queries are changed aside from the test query that throws the warning: `"Should clauses in the filter context will no longer automatically set the minimum should match to 1 in the next major version. You should group them in a [filter] clause or explicitly set [minimum_should_match] to 1 to restore this behavior in the next major version."`
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers