### PR TITLE
SRCH-2897 reload SearchgovDomain record before calling #index_urls

### DIFF
--- a/app/services/sitemap_indexer.rb
+++ b/app/services/sitemap_indexer.rb
@@ -50,7 +50,7 @@ class SitemapIndexer
   rescue => e
     Rails.logger.error("Error processing sitemap entries for #{uri}: #{e}")
   ensure
-    searchgov_domain.index_urls
+    searchgov_domain.reload.index_urls
     set_counter_callbacks
   end
 

--- a/spec/services/sitemap_indexer_spec.rb
+++ b/spec/services/sitemap_indexer_spec.rb
@@ -20,7 +20,7 @@ describe SitemapIndexer do
     stub_request(:get, sitemap_url).
       with(headers: { 'User-Agent' => DEFAULT_USER_AGENT }).
       to_return(body: sitemap_content)
-    allow(searchgov_domain).to receive(:index_urls)
+    allow(searchgov_domain).to receive_message_chain(:reload, :index_urls)
   end
 
   describe '#index' do
@@ -148,7 +148,7 @@ describe SitemapIndexer do
       allow(SearchgovDomain).to receive(:find_by).
         with(domain: 'agency.gov').
         and_return(searchgov_domain)
-      expect(searchgov_domain).to receive(:index_urls)
+      expect(searchgov_domain).to receive_message_chain(:reload, :index_urls)
       index
     end
 
@@ -193,7 +193,7 @@ describe SitemapIndexer do
       it 'kicks off indexing' do
         allow(SearchgovDomain).to receive(:find_by).
           with(domain: 'agency.gov').and_return(searchgov_domain)
-        expect(searchgov_domain).to receive(:index_urls)
+        expect(searchgov_domain).to receive_message_chain(:reload, :index_urls)
         index
       end
     end


### PR DESCRIPTION
## Summary
This PR reloads the relevant `SearchgovDomain` record before calling `#index_urls`. This prevents `SitemapIndexer` jobs running in parallel from enqueuing duplicate `SearchgovDomainIndexer` jobs for the same domain, as a domain with an `indexing` status won't trigger a new `SearchgovDomainIndexer` job. Currently, two `SitemapIndexer` jobs for the same domain each try to call `#index_urls`, and succeed in enqueuing duplicate `SearchgovDomainIndexer` jobs. This change ensures that one of them will detect that the domain has an `indexing` status, and will not enqueue the indexer job.

There is still the possibility of a race condition if they are reloading and calling `index_urls` simultaneously, but it will be much less likely than it is now. This fix is a bit of a band-aid on a larger problem with duplicate `SearchgovDomainIndexer` jobs, but it will resolve the most common scenario. A follow-up ticket will prevent duplicate jobs from being enqueued under any conditions.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A. This change is minor, safe and covered by automated tests.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers