### PR TITLE
SRCH-2849 Fix flaky UsersController#create tests

### DIFF
--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -14,6 +14,12 @@ describe UsersController do
   before { activate_authlogic }
 
   describe '#create' do
+    # SRCH-2849 For some reason verify_recaptcha returns false on UsersController#create if, and only
+    # if, these tests run after the js tests in `spec/system/admin/user_spec.rb`. By default, reCAPTCHA
+    # *should* be skipped in the 'test' env (https://github.com/ambethia/recaptcha#testing), so
+    # we're just explicitly returning a true here to guard against sporadic failures.
+    before { allow(controller).to receive(:verify_recaptcha).and_return(true) }
+
     it do
       is_expected.to permit(*permitted_params).
         for(:create, params: { user: user_params })


### PR DESCRIPTION
## Summary
- After a lot of trial and effort, it seems the intermittent failures with the UsersController#create tests stem from the `verify_recaptcha` at https://github.com/GSA/search-gov/blob/master/app/controllers/users_controller.rb#L18 returning false **only** when these tests are run after https://github.com/GSA/search-gov/blob/master/spec/system/admin/user_spec.rb
- `verify_recaptcha` should never run in a test environment (https://github.com/ambethia/recaptcha#testing)
- Ultimately the fix is just to ensure that verify_recaptcha returns true no matter what in the UsersController tests

To replicate a failing scenario against master, `rspec spec/controllers/users_controller_spec.rb spec/system/admin/user_spec.rb --seed 23764 --format documentation`.  Note the system spec will throw a deprecation warning which can be ignored for now (see: https://github.com/teamcapybara/capybara/issues/2511)
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.
N/A

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:
As discussed, code climate failures are unrelated to this change.  Please accept as is and an interruption ticket will be filed to investigate those cc failures.

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 N/A, test changes only

- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers