### PR TITLE
SRCH-2924 use next-gen MySQL image in CircleCi

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,8 +5,8 @@
 version: 2.1
 
 orbs:
-  ruby: circleci/ruby@1.4.0
-  browser-tools: circleci/browser-tools@1.2.4
+  ruby: circleci/ruby@1.6.0
+  browser-tools: circleci/browser-tools@1.2.5
 
 executors:
   test_executor:
@@ -18,7 +18,7 @@ executors:
         environment:
           RAILS_ENV: test
 
-      - image: circleci/mysql:5.7
+      - image: cimg/mysql:5.7
         environment:
           MYSQL_ALLOW_EMPTY_PASSWORD: true
           MYSQL_ROOT_HOST: "%"
@@ -54,7 +54,9 @@ commands:
   install_chrome:
     description: 'Install latest Chrome and ChromeDriver'
     steps:
-      - browser-tools/install-chrome
+      - browser-tools/install-chrome:
+          # Workaround for https://github.com/CircleCI-Public/browser-tools-orb/issues/33
+          chrome-version: 100.0.4896.60
       - browser-tools/install-chromedriver
       - run:
           command: |


### PR DESCRIPTION
## Summary
This PR resolves the following warning in CircleCi:

> You’re using a [deprecated Docker convenience image.](https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034) Upgrade to a next-gen Docker convenience image.

I've also bumped the orbs, and added a workaround to prevent the Chrome installation from failing.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional. - N/A

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers