### PR TITLE
SRCH-2920 specify rubocop version & channel

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -31,7 +31,7 @@ plugins:
     enabled: true
   rubocop:
     enabled: true
-    channel: rubocop-1-9-1
+    channel: rubocop-1-23-0
 exclude_patterns:
 - config/
 - db/

--- a/Gemfile
+++ b/Gemfile
@@ -131,9 +131,10 @@ gem 'execjs', '~> 2.7.0'
 group :development do
   gem 'spring', '~> 3.1'
   gem 'listen', '~> 3.7'
-  # Bumping searchgov_style? Be sure to update the Rubocop channel in .codeclimate.yml
-  # to match the channel in searchgov_style
+  # Bumping searchgov_style? Be sure to update rubocop, if possible,
+  # and the Rubocop channel in .codeclimate.yml to match the updated rubocop version
   gem 'searchgov_style', '~> 0.1', require: false
+  gem 'rubocop', '1.23.0', require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -894,6 +894,7 @@ DEPENDENCIES
   rspec-its (~> 1.3)
   rspec-rails (~> 5.0)
   rspec_junit_formatter (~> 0.4)
+  rubocop (= 1.23.0)
   sass-rails (~> 5.0.7)
   saxerator (~> 0.9.9)
   searchgov_style (~> 0.1)


### PR DESCRIPTION
## Summary
This PR clarifies the instructions on upgrading `searchgov_style` and `rubocop`, and locks the `rubocop` version and channel to `1.23.0`.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures: Several cops were added between Rubocop versions 1.9.1 and 1.23.0: https://github.com/rubocop/rubocop/blob/master/CHANGELOG.md. Code Climate is now reporting 1141 new issues, which I suggest we "Approve" as-is.

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers