### PR TITLE
SRCH-2862 resolve deprecation warnings re. year format

### DIFF
--- a/app/models/logstash_queries/module_sparkline_query.rb
+++ b/app/models/logstash_queries/module_sparkline_query.rb
@@ -42,7 +42,7 @@ class ModuleSparklineQuery
         json.date_histogram do
           json.field '@timestamp'
           json.interval 'day'
-          json.format 'yyyy-MM-dd'
+          json.format '8yyyy-MM-dd'
           json.min_doc_count 0
         end
         json.aggs do

--- a/app/models/logstash_queries/monthly_histogram_query.rb
+++ b/app/models/logstash_queries/monthly_histogram_query.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class MonthlyHistogramQuery
   include AnalyticsDsl
   RTU_START_DATE = '2014-06-01'
@@ -18,9 +20,9 @@ class MonthlyHistogramQuery
     json.aggs do
       json.agg do
         json.date_histogram do
-          json.field "@timestamp"
+          json.field '@timestamp'
           json.interval 'month'
-          json.format 'yyyy-MM'
+          json.format '8yyyy-MM'
           json.min_doc_count 0
         end
       end
@@ -35,5 +37,4 @@ class MonthlyHistogramQuery
     end
     must_not_spider(json)
   end
-
 end

--- a/spec/models/logstash_queries/module_sparkline_query_spec.rb
+++ b/spec/models/logstash_queries/module_sparkline_query_spec.rb
@@ -48,7 +48,7 @@ describe ModuleSparklineQuery do
               "date_histogram": {
                 "field": '@timestamp',
                 "interval": 'day',
-                "format": 'yyyy-MM-dd',
+                "format": '8yyyy-MM-dd',
                 "min_doc_count": 0
               },
               "aggs": {

--- a/spec/models/logstash_queries/monthly_histogram_query_spec.rb
+++ b/spec/models/logstash_queries/monthly_histogram_query_spec.rb
@@ -37,7 +37,7 @@ describe MonthlyHistogramQuery do
           "date_histogram": {
             "field": '@timestamp',
             "interval": 'month',
-            "format": 'yyyy-MM',
+            "format": '8yyyy-MM',
             "min_doc_count": 0
           }
         }

--- a/spec/models/logstash_queries/overall_sparkline_query_spec.rb
+++ b/spec/models/logstash_queries/overall_sparkline_query_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe OverallSparklineQuery do
   let(:query) { described_class.new('affiliate_name') }
@@ -42,7 +42,7 @@ describe OverallSparklineQuery do
           "date_histogram": {
             "field": '@timestamp',
             "interval": 'day',
-            "format": 'yyyy-MM-dd',
+            "format": '8yyyy-MM-dd',
             "min_doc_count": 0
           },
           "aggs": {


### PR DESCRIPTION
## Summary
This PR resolves the following deprecation warning:

> 'y' year should be replaced with 'u'. Use 'y' for year-of-era. Prefix your date format with '8' to use the new specifier.

https://www.elastic.co/guide/en/elasticsearch/reference/7.17/breaking-changes-7.0.html#_joda_based_date_formatters_are_replaced_with_java_ones

This change is analogous to https://github.com/GSA/search-gov/pull/865.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [x] Code is functional.

- [x] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [x] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock. - N/A. I recommend that we skip manual testing for this change.
 
- [x] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [x] If your target branch is NOT `master` or `main`, specify the reason:
 
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [x] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [x] You have specified an "Assignee", and if necessary, additional reviewers