### PR TITLE
Buckets 1838

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,6 +30,8 @@ Metrics/BlockLength:
   Exclude:
     # Exclude ActiveScaffold-based controllers
     - app/controllers/admin/**/*
+    # Logstash query specs include lengthy JSON queries
+    - spec/models/logstash_queries/**/*
 
 RSpec/DescribeClass:
   Exclude:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -30,7 +30,8 @@ Metrics/BlockLength:
   Exclude:
     # Exclude ActiveScaffold-based controllers
     - app/controllers/admin/**/*
-    # Logstash query specs include lengthy JSON queries
+    # Logstash query specs include lengthy, raw JSON queries
+    # for easier side-to-side comparison, copy/pasting, etc.
     - spec/models/logstash_queries/**/*
 
 RSpec/DescribeClass:

--- a/app/models/logstash_queries/low_ctr_query.rb
+++ b/app/models/logstash_queries/low_ctr_query.rb
@@ -7,7 +7,7 @@ class LowCtrQuery < DateRangeTopNExistsQuery
           start_date,
           end_date,
           agg_options.reverse_merge(min_doc_count: 20,
-                                    size: 100_000,
+                                    size: 1_000,
                                     field: 'params.query.raw'))
   end
 

--- a/app/models/logstash_queries/low_ctr_query.rb
+++ b/app/models/logstash_queries/low_ctr_query.rb
@@ -7,7 +7,7 @@ class LowCtrQuery < DateRangeTopNExistsQuery
           start_date,
           end_date,
           agg_options.reverse_merge(min_doc_count: 20,
-                                    size: 1_000,
+                                    size: 5_000,
                                     field: 'params.query.raw'))
   end
 

--- a/spec/fixtures/json/watcher/low_query_ctr_watcher_body.json
+++ b/spec/fixtures/json/watcher/low_query_ctr_watcher_body.json
@@ -78,7 +78,7 @@
             "agg": {
               "terms": {
                 "min_doc_count": 101,
-                "size": 1000,
+                "size": 5000,
                 "field": "params.query.raw"
               },
               "aggs": {

--- a/spec/fixtures/json/watcher/low_query_ctr_watcher_body.json
+++ b/spec/fixtures/json/watcher/low_query_ctr_watcher_body.json
@@ -78,7 +78,7 @@
             "agg": {
               "terms": {
                 "min_doc_count": 101,
-                "size": 100000,
+                "size": 1000,
                 "field": "params.query.raw"
               },
               "aggs": {

--- a/spec/models/logstash_queries/low_ctr_query_spec.rb
+++ b/spec/models/logstash_queries/low_ctr_query_spec.rb
@@ -73,7 +73,7 @@ describe LowCtrQuery do
         "agg": {
           "terms": {
             "min_doc_count": 20,
-            "size": 1_000,
+            "size": 1000,
             "field": "params.query.raw"
           },
           "aggs": {

--- a/spec/models/logstash_queries/low_ctr_query_spec.rb
+++ b/spec/models/logstash_queries/low_ctr_query_spec.rb
@@ -73,7 +73,7 @@ describe LowCtrQuery do
         "agg": {
           "terms": {
             "min_doc_count": 20,
-            "size": 1000,
+            "size": 5000,
             "field": "params.query.raw"
           },
           "aggs": {

--- a/spec/models/logstash_queries/low_ctr_query_spec.rb
+++ b/spec/models/logstash_queries/low_ctr_query_spec.rb
@@ -73,7 +73,7 @@ describe LowCtrQuery do
         "agg": {
           "terms": {
             "min_doc_count": 20,
-            "size": 100_000,
+            "size": 1_000,
             "field": "params.query.raw"
           },
           "aggs": {

--- a/spec/models/logstash_queries/watcher_low_ctr_query_spec.rb
+++ b/spec/models/logstash_queries/watcher_low_ctr_query_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe WatcherLowCtrQuery do
   let(:query_args) do
@@ -28,24 +28,24 @@ describe WatcherLowCtrQuery do
           "filter": [
             {
               "term": {
-                "params.affiliate": 'affiliate_name'
+                "params.affiliate": "affiliate_name"
               }
             },
             {
               "terms": {
-                "type": ['search','click']
+                "type": ["search", "click"]
               }
             },
             {
               "exists": {
-                "field": 'modules'
+                "field": "modules"
               }
             },
             {
               "range": {
                 "@timestamp": {
-                  "gte": '{{ctx.trigger.scheduled_time}}||-1w',
-                  "lte": '{{ctx.trigger.scheduled_time}}'
+                  "gte": "{{ctx.trigger.scheduled_time}}||-1w",
+                  "lte": "{{ctx.trigger.scheduled_time}}"
                 }
               }
             }
@@ -53,25 +53,25 @@ describe WatcherLowCtrQuery do
           "must_not": [
             {
               "term": {
-                "useragent.device": 'Spider'
+                "useragent.device": "Spider"
               }
             },
             {
               "term": {
-                "params.query.raw": ''
+                "params.query.raw": ""
               }
             },
             {
               "term": {
-                "modules": 'QRTD'
+                "modules": "QRTD"
               }
             },
             {
               "terms": {
                 "params.query.raw": [
-                  'foo',
-                  'bar',
-                  'baz biz'
+                  "foo",
+                  "bar",
+                  "baz biz"
                 ]
               }
             }
@@ -82,8 +82,8 @@ describe WatcherLowCtrQuery do
         "agg": {
           "terms": {
             "min_doc_count": 50,
-            "size": 1_000,
-            "field": 'params.query.raw'
+            "size": 1000,
+            "field": "params.query.raw"
           },
           "aggs": {
             "ctr": {
@@ -108,4 +108,3 @@ describe WatcherLowCtrQuery do
 
   it_behaves_like 'a watcher query'
 end
-

--- a/spec/models/logstash_queries/watcher_low_ctr_query_spec.rb
+++ b/spec/models/logstash_queries/watcher_low_ctr_query_spec.rb
@@ -82,7 +82,7 @@ describe WatcherLowCtrQuery do
         "agg": {
           "terms": {
             "min_doc_count": 50,
-            "size": 100_000,
+            "size": 1_000,
             "field": 'params.query.raw'
           },
           "aggs": {

--- a/spec/models/logstash_queries/watcher_low_ctr_query_spec.rb
+++ b/spec/models/logstash_queries/watcher_low_ctr_query_spec.rb
@@ -82,7 +82,7 @@ describe WatcherLowCtrQuery do
         "agg": {
           "terms": {
             "min_doc_count": 50,
-            "size": 1000,
+            "size": 5000,
             "field": "params.query.raw"
           },
           "aggs": {


### PR DESCRIPTION
## Summary
This PR reduces the `size` of the `LowCtrQuery` aggregation to resolve the following deprecation warning:

> This aggregation creates too many buckets (10001) and will throw an error in future versions. You should update the [search.max_buckets] cluster setting or use the [composite] aggregation to paginate all buckets in multiple requests.

The current `size` setting of 100,000 buckets is much larger than we need for that query, which is used to display analytics data. I'm dialing it down to 5000, which should be more than enough for the purposes of this query.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [ ] Code is functional.

- [ ] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [ ] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 
- [ ] You have merged the latest changes from the target branch (usually `master` or `main`) into your branch.
 
- [ ] If your target branch is NOT `master` or `main`, specify the reason:
 
- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [ ] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [ ] You have specified an "Assignee", and if necessary, additional reviewers