### PR TITLE
SRCH-3182 fix syntax in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The required services (MySQL, Elasticsearch, etc.) can be run using Docker. Plea
 
 The Elasticsearch service provided by `searchgov-services` is configured to run on the default port, [9200](http://localhost:9200/). To use a different host (with or without port) or set of hosts, set the `ES_HOSTS` environment variable. For example, use following command to run the specs using Elasticsearch running on `localhost:9207`:
 
-    ES_HOSTS=localhost:9207 bin/rspec spec
+    ES_HOSTS=localhost:9207 bundle exec rspec spec
 
 Verify that Elasticsearch 6.8.x is running on the expected port (port 9200 by default):
 


### PR DESCRIPTION
## Summary
- Corrected syntax to be `ES_HOSTS=localhost:9207 bundle exec rspec spec` on readme.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review:

#### Functionality Checks

- [ ] Code is functional.

- [ ] Automated checks pass, if applicable. If Code Climate checks do not pass, explain reason for failures:

- [ ] If your changes will be tested manually, you have run `bundle update` and committed your changes to Gemfile.lock.
 
- [ ] You have merged the latest changes from the target branch (usually `main`) into your branch.
 
- [ ] If your target branch is NOT `main`, specify the reason:
 
- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release #.#.#** matching the release number
 
- [ ] You have squashed your commits into a single commit (exception: your PR includes commits with formatting-only changes, such as required by Rubocop)

- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
 
#### Process Checks

- [ ] You have specified an "Assignee", and if necessary, additional reviewers