### PR TITLE
SRCH-3154 searchgov_domain.check_status should not raise errors

### DIFF
--- a/app/models/searchgov_domain.rb
+++ b/app/models/searchgov_domain.rb
@@ -42,7 +42,7 @@ class SearchgovDomain < ApplicationRecord
   end
 
   def available?
-    !!((status || check_status) =~ /^200\b/)
+    (status || check_status) == OK_STATUS
   end
 
   def check_status
@@ -90,7 +90,7 @@ class SearchgovDomain < ApplicationRecord
 
   def failed_response(err)
     update(status: err.message.strip)
-    Rails.logger.warn "#{domain} response error url: #{url} error: #{status}"
+    Rails.logger.error "#{domain} response error url: #{url} error: #{status}"
     nil
   end
 

--- a/spec/jobs/searchgov_domain_indexer_job_spec.rb
+++ b/spec/jobs/searchgov_domain_indexer_job_spec.rb
@@ -8,6 +8,7 @@ describe SearchgovDomainIndexerJob do
   let!(:searchgov_domain) do
     searchgov_domain = SearchgovDomain.find_by(domain: 'agency.gov')
     searchgov_domain.update(status: '200 OK', activity: 'indexing')
+
     searchgov_domain
   end
 

--- a/spec/jobs/searchgov_domain_indexer_job_spec.rb
+++ b/spec/jobs/searchgov_domain_indexer_job_spec.rb
@@ -8,7 +8,6 @@ describe SearchgovDomainIndexerJob do
   let!(:searchgov_domain) do
     searchgov_domain = SearchgovDomain.find_by(domain: 'agency.gov')
     searchgov_domain.update(status: '200 OK', activity: 'indexing')
-
     searchgov_domain
   end
 

--- a/spec/jobs/searchgov_domain_indexer_job_spec.rb
+++ b/spec/jobs/searchgov_domain_indexer_job_spec.rb
@@ -7,7 +7,7 @@ describe SearchgovDomainIndexerJob do
 
   let!(:searchgov_domain) do
     searchgov_domain = SearchgovDomain.find_by(domain: 'agency.gov')
-    searchgov_domain.update(status: '200', activity: 'indexing')
+    searchgov_domain.update(status: '200 OK', activity: 'indexing')
     searchgov_domain
   end
 

--- a/spec/models/searchgov_domain_spec.rb
+++ b/spec/models/searchgov_domain_spec.rb
@@ -262,7 +262,7 @@ describe SearchgovDomain do
     end
 
     context 'when the status is 200' do
-      let(:searchgov_domain) { described_class.new(domain: domain, status: '200') }
+      let(:searchgov_domain) { described_class.new(domain: domain, status: '200 OK') }
 
       it { is_expected.to eq true }
     end
@@ -310,9 +310,9 @@ describe SearchgovDomain do
       end
 
       it 'logs a message containing that error' do
-        allow(Rails.logger).to receive(:warn)
+        allow(Rails.logger).to receive(:error)
         check_status
-        expect(Rails.logger).to have_received(:warn).with(/kaboom/)
+        expect(Rails.logger).to have_received(:error).with(/kaboom/)
       end
 
       context 'when the error is transient' do


### PR DESCRIPTION
## Summary
- SearchgovDomain#check_status now returns a non-OK_STATUS rather than raising an exception when its domain is unreachable.
- Logic is still a bit tortured; I'm open to suggestions for improvement.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks

- :warning: You have run `bundle update` and committed your changes to Gemfile.lock; depending on this operation having been done by the recently merged [SRCH-3224](https://cm-jira.usa.gov/browse/SRCH-3224)
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
 
- [x] You have squashed your commits into a single commit (exceptions: your PR includes commits with formatting-only changes, such as required by Rubocop or Cookstyle, or if this is a feature branch that includes multiple commits).
 
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".