### PR TITLE
SRCH-3158 update parsing logic for tags field

### DIFF
--- a/app/models/html_document.rb
+++ b/app/models/html_document.rb
@@ -97,9 +97,9 @@ class HtmlDocument < WebDocument
     [dublin_core_data['dc.subject'],
      dcterms_data['dcterms.subject'],
      dcterms_data['dcterms.keywords'],
-     metadata['keywords']&.join(', '),
-     metadata['article:tag']&.join(', '),
-     metadata['article:section']&.join(', ')]
+     metadata['keywords'],
+     metadata['article:tag'],
+     metadata['article:section']].map { |k| k&.join(', ') }
   end
 
   def extract_language
@@ -107,7 +107,7 @@ class HtmlDocument < WebDocument
   end
 
   def extract_created
-    metadata['article:published_time']&.first  || dublin_core_date || dcterms_date
+    metadata['article:published_time']&.first || dublin_core_date || dcterms_date
   end
 
   def extract_changed

--- a/app/models/html_document.rb
+++ b/app/models/html_document.rb
@@ -4,25 +4,25 @@ class HtmlDocument < WebDocument
   include RobotsTaggable
 
   def title
-    titles = [metadata['og:title'], html.title.try(:strip)]
+    titles = [metadata['og:title']&.first, html.title.try(:strip)]
     titles.compact_blank!
     titles.blank? ? url : titles.max_by(&:length)
   end
 
   def description
-    metadata['og:description'] || metadata['description'] || dublin_core_data['dc.description']
+    metadata['og:description']&.first || metadata['description']&.first || dublin_core_data['dc.description']&.first
   end
 
   def keywords
-    metadata['keywords'] || dublin_core_data['dc.subject']
+    extract_keywords.uniq.compact.join(', ')
   end
 
   def audience
-    dcterms_data['dcterms.audience']
+    dcterms_data['dcterms.audience']&.first
   end
 
   def image_url
-    metadata['og:image']
+    metadata['og:image']&.first
   end
 
   def content_type
@@ -32,7 +32,7 @@ class HtmlDocument < WebDocument
   def searchgov_custom(number)
     return if !number.is_a?(Integer) || !number.between?(1, 3)
 
-    metadata["searchgov_custom#{number}"]
+    metadata["searchgov_custom#{number}"]&.first
   end
 
   # Returns client-side redirect url
@@ -87,10 +87,19 @@ class HtmlDocument < WebDocument
     metadata = {}
     meta_nodes = html.xpath('//meta')
     meta_nodes.each do |node|
-      (metadata[node['name'].downcase] = node['content']) if node['name']
-      (metadata[node['property'].downcase] = node['content']) if node['property']
+      property = node['name'] || node['property']
+      (metadata[property.downcase] ||= []) << node['content'] unless property.nil?
     end
     metadata
+  end
+
+  def extract_keywords
+    [dublin_core_data['dc.subject'],
+     dcterms_data['dcterms.subject'],
+     dcterms_data['dcterms.keywords'],
+     metadata['keywords']&.join(', '),
+     metadata['article:tag']&.join(', '),
+     metadata['article:section']&.join(', ')]
   end
 
   def extract_language
@@ -98,15 +107,15 @@ class HtmlDocument < WebDocument
   end
 
   def extract_created
-    metadata['article:published_time'] || dublin_core_date || dcterms_date
+    metadata['article:published_time']&.first  || dublin_core_date || dcterms_date
   end
 
   def extract_changed
-    metadata['article:modified_time']
+    metadata['article:modified_time']&.first
   end
 
   def robots_directives
-    (metadata['robots'] || '').downcase.split(',').map(&:strip)
+    (metadata['robots']&.first || '').downcase.split(',').map(&:strip)
   end
 
   def main_html
@@ -116,11 +125,11 @@ class HtmlDocument < WebDocument
   end
 
   def dublin_core_date
-    dublin_core_data['dc.date'] || dublin_core_data['dc.date.created']
+    dublin_core_data['dc.date']&.first || dublin_core_data['dc.date.created']&.first
   end
 
   def dcterms_date
-    dcterms_data['dcterms.created']
+    dcterms_data['dcterms.created']&.first
   end
 
   def dublin_core_data

--- a/spec/fixtures/html/page_with_dc_metadata.html
+++ b/spec/fixtures/html/page_with_dc_metadata.html
@@ -12,7 +12,9 @@
     <meta name="DC.identifier" content="85518"/>
     <meta name="DC.language" content="en-us"/>
     <meta name="DC.relation" content="CMSGOV, About CMS"/>
-    <meta name="DC.subject" content="One Subject, Another Subject"/>
+    <meta name="dc.subject" content="One DC Subject, Another DC Subject"/>
+    <meta name="dcterms.subject" content="One DCTerms Subject, Another DCTerms Subject"/>
+    <meta name="dcterms.keywords" content="One DCTerms Keyword, Another DCTerms Keyword"/>
     <meta name="DC.title" content="My DC Title"/>
     <meta name="dcterms.audience" content="dcterms audience"/>
     <meta name="DC.type" content="dc type"/>

--- a/spec/fixtures/html/page_with_og_metadata.html
+++ b/spec/fixtures/html/page_with_og_metadata.html
@@ -12,6 +12,8 @@
   <meta property="og:type" content="video.movie" />
   <meta property="og:url" content="http://www.foo.gov/og_url/" />
   <meta property="og:image" content="http://www.foo.gov/og_image.jpg" />
+  <meta property="article:tag" content="the other">
+  <meta property="article:section" content="thing">
   <meta property="article:published_time" content="2015-07-02T10:12:32-04:00" />
   <meta property="article:modified_time" content="2017-03-30T13:18:28-04:00" />
   </head>

--- a/spec/models/application_document_spec.rb
+++ b/spec/models/application_document_spec.rb
@@ -84,6 +84,16 @@ describe ApplicationDocument do
     end
   end
 
+  describe '#keywords' do
+    subject(:keywords) { application_document.keywords }
+
+    context 'when the document has Keywords' do
+      it 'returns the keywords' do
+        expect(keywords).to eq 'this, that'
+      end
+    end
+  end
+
   describe '#parsed_content' do
     subject(:parsed_content) { application_document.parsed_content }
 

--- a/spec/models/application_document_spec.rb
+++ b/spec/models/application_document_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe ApplicationDocument do
@@ -10,11 +12,12 @@ describe ApplicationDocument do
     }
   end
   let(:application_document) { described_class.new(valid_attributes) }
-  let(:doc_without_description) { open_fixture_file('/pdf/no_metadata.pdf') }
-  let(:doc_without_language) { open_fixture_file('/pdf/arabic.pdf') }
-  let(:doc_with_lang_subcode) { open_fixture_file('/pdf/lang_subcode.pdf') }
 
-  it_should_behave_like 'a web document'
+  it_behaves_like 'a web document' do
+    let(:doc_without_description) { open_fixture_file('/pdf/no_metadata.pdf') }
+    let(:doc_without_language) { open_fixture_file('/pdf/arabic.pdf') }
+    let(:doc_with_lang_subcode) { open_fixture_file('/pdf/lang_subcode.pdf') }
+  end
 
   describe '#title' do
     subject(:title) { application_document.title }
@@ -69,7 +72,7 @@ describe ApplicationDocument do
   describe '#noindex?' do
     subject(:noindex) { application_document.noindex? }
 
-    it { is_expected.to eq false }
+    it { is_expected.to be false }
   end
 
   describe '#language' do
@@ -105,7 +108,7 @@ describe ApplicationDocument do
       end
     end
 
-    context 'when an XLS file contains a million empty rows' do #because that's a thing.
+    context 'when an XLS file contains a million empty rows' do # because that's a thing.
       let(:raw_document) { open_fixture_file('/excel/bazillion_empty_lines.xlsx') }
 
       it 'parses the content' do
@@ -117,6 +120,6 @@ describe ApplicationDocument do
   describe 'redirect_url' do
     subject(:redirect_url) { application_document.redirect_url }
 
-    it { is_expected.to be nil }
+    it { is_expected.to be_nil }
   end
 end

--- a/spec/models/html_document_spec.rb
+++ b/spec/models/html_document_spec.rb
@@ -318,9 +318,105 @@ describe HtmlDocument do
     subject(:keywords) { html_document.keywords }
 
     context 'when a Dublin Core subject is available' do
+      let(:raw_document) do
+        <<~HTML
+          <html lang="en">
+            <head>
+              <title>My Title</title>
+              <meta name="dc.subject" content="One DC Subject, Another DC Subject"/>
+            </head>
+          </html>
+        HTML
+      end
+
+      it { is_expected.to eq 'One DC Subject, Another DC Subject' }
+    end
+
+    context 'when a dcterms subject is available' do
+      let(:raw_document) do
+        <<~HTML
+          <html lang="en">
+            <head>
+              <title>My Title</title>
+              <meta name="dcterms.subject" content="One DCTerms Subject, Another DCTerms Subject"/>
+            </head>
+          </html>
+        HTML
+      end
+
+      it { is_expected.to eq 'One DCTerms Subject, Another DCTerms Subject' }
+    end
+
+    context 'when a dcterms keywords is available' do
+      let(:raw_document) do
+        <<~HTML
+          <html lang="en">
+            <head>
+              <title>My Title</title>
+              <meta name="dcterms.keywords" content="One DCTerms Keyword, Another DCTerms Keyword"/>
+            </head>
+          </html>
+        HTML
+      end
+
+      it { is_expected.to eq 'One DCTerms Keyword, Another DCTerms Keyword' }
+    end
+
+    context 'when all dc keyword sources are available' do
       let(:raw_document) { doc_with_dc_data }
 
-      it { is_expected.to eq 'One Subject, Another Subject' }
+      it { is_expected.to include('One DC Subject') }
+      it { is_expected.to include('One DCTerms Subject') }
+      it { is_expected.to include('One DCTerms Keyword') }
+      it { is_expected.to include('Another DC Subject') }
+      it { is_expected.to include('Another DCTerms Subject') }
+      it { is_expected.to include('Another DCTerms Keyword') }
+    end
+
+    context 'when a meta keywords is available' do
+      it { is_expected.to eq 'this, that' }
+    end
+
+    context 'when parallel article:tags are available' do
+      let(:raw_document) do
+        <<~HTML
+          <html lang="en">
+            <head>
+              <title>My Title</title>
+              <meta property="article:tag" content="article tag 1" />
+              <meta property="article:tag" content="article tag 2" />
+              <meta property="article:tag" content="article tag 3" />
+            </head>
+          </html>
+        HTML
+      end
+
+      it { is_expected.to eq 'article tag 1, article tag 2, article tag 3' }
+    end
+
+    context 'when an article:section is available' do
+      let(:raw_document) do
+        <<~HTML
+          <html lang="en">
+            <head>
+              <title>My Title</title>
+              <meta property="article:section" content="article section">
+            </head>
+          </html>
+        HTML
+      end
+
+      it { is_expected.to eq 'article section' }
+    end
+
+    context 'when meta keywords and article keywords are available' do
+      let(:raw_document) { read_fixture_file('/html/page_with_og_metadata.html') }
+
+      it { puts html_document.keywords }
+      it { is_expected.to include('this') }
+      it { is_expected.to include('that') }
+      it { is_expected.to include('the other') }
+      it { is_expected.to include('thing') }
     end
   end
 

--- a/spec/models/html_document_spec.rb
+++ b/spec/models/html_document_spec.rb
@@ -412,11 +412,48 @@ describe HtmlDocument do
     context 'when meta keywords and article keywords are available' do
       let(:raw_document) { read_fixture_file('/html/page_with_og_metadata.html') }
 
-      it { puts html_document.keywords }
       it { is_expected.to include('this') }
       it { is_expected.to include('that') }
       it { is_expected.to include('the other') }
       it { is_expected.to include('thing') }
+    end
+
+    context 'when parallel keywords duplicate a list of keywords' do
+      let(:raw_document) do
+        <<~HTML
+          <html lang="en">
+            <head>
+              <title>My Title</title>
+              <meta name="keywords" content="tag 1, tag 2, tag 3">
+              <meta property="article:section" content="tag 1" />
+              <meta property="article:section" content="tag 2" />
+              <meta property="article:section" content="tag 3" />
+            </head>
+          </html>
+        HTML
+      end
+
+      it { is_expected.to eq 'tag 1, tag 2, tag 3' }
+    end
+
+    context 'when all keywords are duplicates' do
+      let(:raw_document) do
+        <<~HTML
+          <html lang="en">
+            <head>
+              <title>My Title</title>
+              <meta name="dc.subject" content="tag 1, tag 2, tag 3">
+              <meta name="dcterms.subject" content="tag 1, tag 2, tag 3">
+              <meta name="dcterms.keywords" content="tag 1, tag 2, tag 3">
+              <meta name="keywords" content="tag 1, tag 2, tag 3">
+              <meta property="article:tag" content="tag 1, tag 2, tag 3" />
+              <meta property="article:section" content="tag 1, tag 2, tag 3" />
+            </head>
+          </html>
+        HTML
+      end
+
+      it { is_expected.to eq 'tag 1, tag 2, tag 3' }
     end
   end
 

--- a/spec/models/searchgov_url_spec.rb
+++ b/spec/models/searchgov_url_spec.rb
@@ -137,7 +137,7 @@ describe SearchgovUrl do
             description: 'My OG Description',
             content: "This is my headline.\nThis is my content.",
             language: 'en',
-            tags: 'this, that',
+            tags: 'this, that, the other, thing',
             created: '2015-07-02T10:12:32-04:00',
             changed: '2017-03-30T13:18:28-04:00'
         ))
@@ -192,7 +192,7 @@ describe SearchgovUrl do
               description: 'My OG Description',
               content: "This is my headline.\nThis is my content.",
               language: 'en',
-              tags: 'this, that',
+              tags: 'this, that, the other, thing',
               created: '2015-07-02T10:12:32-04:00',
               changed: '2017-03-30T13:18:28-04:00'
           ))

--- a/spec/models/searchgov_url_spec.rb
+++ b/spec/models/searchgov_url_spec.rb
@@ -1,22 +1,29 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe SearchgovUrl do
   let(:url) { 'http://www.agency.gov/boring.html' }
   let(:html) { read_fixture_file('/html/page_with_og_metadata.html') }
   let(:valid_attributes) { { url: url } }
-  let(:searchgov_url) { described_class.new(valid_attributes) }
-  let(:i14y_document) { I14yDocument.new }
+  let(:searchgov_url) { described_class.create!(valid_attributes) }
 
   it { is_expected.to have_readonly_attribute(:url) }
 
   describe 'schema' do
-    it { is_expected.to have_db_column(:url).of_type(:string).
-         with_options(null: false, limit: 2000) }
+    it {
+      is_expected.to have_db_column(:url).of_type(:string).
+        with_options(null: false, limit: 2000)
+    }
+
     it { is_expected.to have_db_column(:load_time).of_type(:integer) }
     it { is_expected.to have_db_column(:lastmod).of_type(:datetime) }
-    it { is_expected.to have_db_column(:enqueued_for_reindex).
-           of_type(:boolean).
-           with_options(default: false, null: false) }
+
+    it {
+      is_expected.to have_db_column(:enqueued_for_reindex).
+        of_type(:boolean).
+        with_options(default: false, null: false)
+    }
 
     it { is_expected.to have_db_index(:last_crawl_status) }
     it { is_expected.to have_db_index(:url) }
@@ -26,7 +33,6 @@ describe SearchgovUrl do
 
   describe 'scopes' do
     describe '.fetch_required' do
-
       it 'includes urls that have never been crawled and outdated urls' do
         expect(described_class.fetch_required.pluck(:url)).
           to include('http://www.agency.gov/new', 'http://www.agency.gov/outdated')
@@ -50,6 +56,8 @@ describe SearchgovUrl do
   end
 
   describe 'validations' do
+    let(:searchgov_url) { described_class.new(valid_attributes) }
+
     context 'when the URL domain does not already exist in our database' do
       let(:url) { 'https://new-agency.com/index.html' }
 
@@ -63,8 +71,6 @@ describe SearchgovUrl do
     end
 
     describe 'validating url uniqueness' do
-      let!(:existing) { described_class.create!(valid_attributes) }
-
       it { is_expected.to validate_uniqueness_of(:url).on(:create) }
 
       it 'is case-sensitive' do
@@ -91,7 +97,7 @@ describe SearchgovUrl do
         end
 
         it 'deletes the Searchgov Url' do
-          expect { searchgov_url.destroy }.to change{ described_class.count }.by(-1)
+          expect { searchgov_url.destroy }.to change { described_class.count }.by(-1)
         end
       end
     end
@@ -104,12 +110,11 @@ describe SearchgovUrl do
   end
 
   describe '#fetch' do
-    let!(:searchgov_url) { described_class.create!(valid_attributes) }
+    subject(:fetch) { searchgov_url.fetch }
+
     let(:searchgov_domain) do
       instance_double(SearchgovDomain, check_status: '200 OK', available?: true)
     end
-
-    subject(:fetch) { searchgov_url.fetch }
 
     before do
       allow(searchgov_url).to receive(:searchgov_domain).and_return(searchgov_domain)
@@ -120,6 +125,7 @@ describe SearchgovUrl do
       let(:success_hash) do
         { status: 200, body: html, headers: { content_type: 'text/html' } }
       end
+
       before do
         stub_request(:get, url).with(headers: { user_agent: DEFAULT_USER_AGENT }).
           to_return({ status: 200, body: html, headers: { content_type: 'text/html' } })
@@ -140,7 +146,7 @@ describe SearchgovUrl do
             tags: 'this, that, the other, thing',
             created: '2015-07-02T10:12:32-04:00',
             changed: '2017-03-30T13:18:28-04:00'
-        ))
+          ))
         fetch
       end
 
@@ -150,7 +156,7 @@ describe SearchgovUrl do
         end
 
         it 'sets enqueued_for_reindex to false' do
-          expect { fetch }.to change{ searchgov_url.enqueued_for_reindex }.
+          expect { fetch }.to change { searchgov_url.enqueued_for_reindex }.
             from(true).to(false)
         end
       end
@@ -169,6 +175,7 @@ describe SearchgovUrl do
             allow_any_instance_of(HtmlDocument).
               to receive(:modified).and_return('2018-03-30T01:00:00-04:00')
           end
+
           let(:valid_attributes) { { url: url, lastmod: '2018-01-01' } }
 
           it 'passes whichever value is more recent' do
@@ -195,33 +202,34 @@ describe SearchgovUrl do
               tags: 'this, that, the other, thing',
               created: '2015-07-02T10:12:32-04:00',
               changed: '2017-03-30T13:18:28-04:00'
-          ))
+            ))
           fetch
         end
       end
 
       context 'when the document is successfully indexed' do
+        let(:i14y_document) { I14yDocument.new }
+
         before do
           allow(I14yDocument).to receive(:create).with(anything).and_return(i14y_document)
         end
 
         it 'records the load time' do
-          expect{ fetch }.
-            to change{ searchgov_url.reload.load_time.class }
-            .from(NilClass).to(Fixnum)
+          expect { fetch }.
+            to change { searchgov_url.reload.load_time.class }.
+            from(NilClass).to(Integer)
         end
 
         it 'records the success status' do
-          expect{ fetch }.
-            to change{ searchgov_url.reload.last_crawl_status }
-            .from(NilClass).to('OK')
-
+          expect { fetch }.
+            to change { searchgov_url.reload.last_crawl_status }.
+            from(NilClass).to('OK')
         end
 
         it 'records the last crawl time' do
-          expect{ fetch }.
-            to change{ searchgov_url.reload.last_crawled_at }
-            .from(NilClass).to(Time)
+          expect { fetch }.
+            to change { searchgov_url.reload.last_crawled_at }.
+            from(NilClass).to(Time)
         end
       end
 
@@ -229,15 +237,16 @@ describe SearchgovUrl do
         before { allow(I14yDocument).to receive(:create).and_raise(StandardError.new('Kaboom')) }
 
         it 'records the error' do
-          expect{ fetch }.not_to raise_error
+          expect { fetch }.not_to raise_error
           expect(searchgov_url.last_crawl_status).to match(/Kaboom/)
         end
       end
 
-      context 'when the fetch successfully returns...an error page' do #Because that's a thing.
+      context 'when the fetch successfully returns...an error page' do # Because that's a thing.
         let(:fail_html) do
           '<html><head><title>My 404 error page</title></head><body>Epic fail!</body></html>'
         end
+
         before do
           stub_request(:get, url).
             to_return({ status: 200,
@@ -282,7 +291,7 @@ describe SearchgovUrl do
         context 'when the file is too large' do
           before do
             stub_request(:get, url).to_return(status: 200, headers: {  content_type: 'application/pdf',
-                                                                       content_length:  18.megabytes })
+                                                                       content_length: 18.megabytes })
           end
 
           it 'reports the error' do
@@ -299,7 +308,7 @@ describe SearchgovUrl do
           end
 
           it 'truncates too-long crawl statuses' do
-            expect{ fetch }.not_to raise_error
+            expect { fetch }.not_to raise_error
             expect(searchgov_url.last_crawl_status).to eq 'x' * 255
           end
         end
@@ -309,6 +318,7 @@ describe SearchgovUrl do
     context 'when the url points to a pdf' do
       let(:url) { 'https://agency.gov/test.pdf' }
       let(:pdf) { read_fixture_file('/pdf/test.pdf') }
+
       before do
         stub_request(:get, url).
           to_return({ status: 200,
@@ -326,7 +336,7 @@ describe SearchgovUrl do
             language: 'en',
             tags: 'this, that',
             created: '2018-06-09T17:42:11Z'
-        ))
+          ))
         fetch
       end
 
@@ -339,6 +349,7 @@ describe SearchgovUrl do
     context 'when the url points to a Word doc (.doc)' do
       let(:url) { 'https://agency.gov/test.doc' }
       let(:doc) { read_fixture_file('/word/test.doc') }
+
       before do
         stub_request(:get, url).
           to_return({ status: 200,
@@ -355,7 +366,7 @@ describe SearchgovUrl do
             description: 'My Word doc description',
             language: 'en',
             tags: 'word'
-        ))
+          ))
         fetch
       end
     end
@@ -363,6 +374,7 @@ describe SearchgovUrl do
     context 'when the url points to a Word doc (.docx)' do
       let(:url) { 'https://agency.gov/test.docx' }
       let(:doc) { read_fixture_file('/word/test.docx') }
+
       before do
         stub_request(:get, url).
           to_return({ status: 200,
@@ -379,7 +391,7 @@ describe SearchgovUrl do
             description: 'My Word doc description',
             language: 'en',
             tags: 'word'
-        ))
+          ))
         fetch
       end
     end
@@ -387,6 +399,7 @@ describe SearchgovUrl do
     context 'when the url points to an Excel doc (.xlsx)' do
       let(:url) { 'https://agency.gov/test.xlsx' }
       let(:doc) { read_fixture_file('/excel/test.xlsx') }
+
       before do
         stub_request(:get, url).
           to_return({ status: 200,
@@ -403,7 +416,7 @@ describe SearchgovUrl do
             description: 'My Excel doc description',
             language: 'en',
             tags: 'excel'
-        ))
+          ))
         fetch
       end
     end
@@ -411,6 +424,7 @@ describe SearchgovUrl do
     context 'when the url points to an Excel doc (.xls)' do
       let(:url) { 'https://agency.gov/test.xls' }
       let(:doc) { read_fixture_file('/excel/test.xls') }
+
       before do
         stub_request(:get, url).
           to_return({ status: 200,
@@ -427,7 +441,7 @@ describe SearchgovUrl do
             description: 'My Excel doc description',
             language: 'en',
             tags: 'excel'
-        ))
+          ))
         fetch
       end
     end
@@ -451,7 +465,7 @@ describe SearchgovUrl do
             description: nil,
             content: 'This is my text content.',
             language: 'en'
-        ))
+          ))
         fetch
       end
     end
@@ -462,7 +476,7 @@ describe SearchgovUrl do
       end
 
       it 'records the error' do
-        expect{ fetch }.not_to raise_error
+        expect { fetch }.not_to raise_error
         expect(searchgov_url.last_crawl_status).to match(/faaaaail/)
       end
 
@@ -487,7 +501,7 @@ describe SearchgovUrl do
 
       before do
         expect(I14yDocument).not_to receive(:create).
-          with(hash_including(title: 'My Title', description: 'My description' ))
+          with(hash_including(title: 'My Title', description: 'My description'))
         stub_request(:get, url).
           to_return({ status: 301, body: html, headers: { location: new_url } })
         stub_request(:get, new_url).
@@ -500,7 +514,7 @@ describe SearchgovUrl do
       end
 
       it 'reports the redirect' do
-        expect{ fetch }.to change{ searchgov_url.last_crawl_status }.
+        expect { fetch }.to change { searchgov_url.last_crawl_status }.
           from(nil).to('Redirected to https://www.agency.gov/new.html')
       end
 
@@ -523,10 +537,11 @@ describe SearchgovUrl do
         end
       end
 
-      context 'on the client side' do
+      context 'when on the client side' do
         let(:html) do
           "<header><meta http-equiv=\"refresh\" content=\"0; URL='/client_side.html'\"/></header>"
         end
+
         before do
           stub_request(:get, url).
             to_return(status: 200, body: html, headers: { content_type: 'text/html' })
@@ -575,6 +590,7 @@ describe SearchgovUrl do
 
         context 'when the domain is unavailable' do
           let!(:searchgov_domain) { searchgov_url.searchgov_domain }
+
           before do
             stub_request(:get, 'http://www.agency.gov/').to_return(status: 403)
             searchgov_domain.update!(scheme: 'http', status: '200 OK')
@@ -594,22 +610,23 @@ describe SearchgovUrl do
           SearchgovDomain, domain: 'unavailable.gov', available?: false, status: '403'
         )
       end
+
       before do
         allow(searchgov_url).to receive(:searchgov_domain).and_return(unavailable_domain)
       end
 
       it 'raises an error, including the domain' do
-        expect{ fetch }.to raise_error(described_class::DomainError, 'unavailable.gov: 403')
+        expect { fetch }.to raise_error(described_class::DomainError, 'unavailable.gov: 403')
       end
 
       it 'does not fetch the url' do
-        expect{ fetch }.to raise_error(described_class::DomainError, 'unavailable.gov: 403')
+        expect { fetch }.to raise_error(described_class::DomainError, 'unavailable.gov: 403')
         expect(stub_request(:get, url)).not_to have_been_requested
       end
     end
   end
 
-  it_should_behave_like 'a record with a fetchable url'
-  it_should_behave_like 'a record with an indexable url'
-  it_should_behave_like 'a record that belongs to a searchgov_domain'
+  it_behaves_like 'a record with a fetchable url'
+  it_behaves_like 'a record with an indexable url'
+  it_behaves_like 'a record that belongs to a searchgov_domain'
 end


### PR DESCRIPTION
## Summary
Primarily serves to update the parsing logic for `keywords` for search-gov crawled urls.
 
- Previously, keywords originated from either the first `metadata['keywords']` or, if not present, the first `dublin_core_data['dc.subject']`; now, all values in any/all of the following fields are gathered, deduplicated, and combined in the final keywords string:
    - dublin_core_data['dc.subject'],
    - dcterms_data['dcterms.subject'],
    - dcterms_data['dcterms.keywords'],
    - metadata['keywords']&.join(', '),
    - metadata['article:tag']&.join(', '),
    - metadata['article:section'];
- Because we wanted to support parallel descriptions (more in inline comment), additional tweaks were made to existing/non-keyword methods;
- The first commit includes required/necessary spec changes, as well as an new spec in `spec/models/application_document_spec.rb` to support current behavior (seems an oversight there wasn't a spec specifically for non-html keyword parsing to begin with);
- A second commit includes low-risk rubocop changes to a couple spec files just to cut down on the noise.  Larger refactoring to appease all rubocop rules has been deferred as it is out of scope for this work.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks

- [x] You have run `bundle update` and committed your changes to Gemfile.lock.
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
 
- [x] You have squashed your commits into a single commit (exceptions: your PR includes commits with formatting-only changes, such as required by Rubocop or Cookstyle, or if this is a feature branch that includes multiple commits).
 
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
:warning: Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
Many, but not all preexisting code style issues in `spec/models/searchgov_url_spec.rb` have been resolved.  5 instances of `too many memoized helpers` remain to be dealt with another day.
 
#### Process Checks

- [x] You have specified at least one "Reviewer".