### PR TITLE
SRCH-3330: create js_renderer boolean

### DIFF
--- a/app/models/searchgov_url.rb
+++ b/app/models/searchgov_url.rb
@@ -181,8 +181,13 @@ class SearchgovUrl < ApplicationRecord
     if /^application|text\/plain/ === response.content_type.mime_type
       ApplicationDocument.new(document: download.open, url: url)
     else
-      response = JsFetcher.fetch(url)
-      HtmlDocument.new(document: response, url: url)
+      if searchgov_domain.js_renderer?
+        js_response = JsFetcher.fetch(url)
+
+        HtmlDocument.new(document: js_response, url: url)
+      else
+        HtmlDocument.new(document: response.to_s, url: url)
+      end
     end
   end
 

--- a/db/migrate/20220831184226_add_js_renderer_to_searchgov_domain.rb
+++ b/db/migrate/20220831184226_add_js_renderer_to_searchgov_domain.rb
@@ -1,5 +1,5 @@
 class AddJsRendererToSearchgovDomain < ActiveRecord::Migration[6.1]
   def change
-    add_column :searchgov_domains, :js_renderer, :boolean, :default => true
+    add_column :searchgov_domains, :js_renderer, :boolean, :default => false
   end
 end

--- a/db/migrate/20220831184226_add_js_renderer_to_searchgov_domain.rb
+++ b/db/migrate/20220831184226_add_js_renderer_to_searchgov_domain.rb
@@ -1,0 +1,5 @@
+class AddJsRendererToSearchgovDomain < ActiveRecord::Migration[6.1]
+  def change
+    add_column :searchgov_domains, :js_renderer, :boolean, :default => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_08_09_182927) do
+ActiveRecord::Schema.define(version: 2022_08_31_184226) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -577,6 +577,7 @@ ActiveRecord::Schema.define(version: 2022_08_09_182927) do
     t.string "scheme", limit: 5, default: "http", null: false
     t.string "activity", limit: 100, default: "idle", null: false
     t.string "canonical_domain"
+    t.boolean "js_renderer", default: true
     t.index ["activity"], name: "index_searchgov_domains_on_activity"
     t.index ["domain"], name: "index_searchgov_domains_on_domain", unique: true, length: 100
     t.index ["status"], name: "index_searchgov_domains_on_status", length: 100

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -577,7 +577,7 @@ ActiveRecord::Schema.define(version: 2022_08_31_184226) do
     t.string "scheme", limit: 5, default: "http", null: false
     t.string "activity", limit: 100, default: "idle", null: false
     t.string "canonical_domain"
-    t.boolean "js_renderer", default: true
+    t.boolean "js_renderer", default: false
     t.index ["activity"], name: "index_searchgov_domains_on_activity"
     t.index ["domain"], name: "index_searchgov_domains_on_domain", unique: true, length: 100
     t.index ["status"], name: "index_searchgov_domains_on_status", length: 100


### PR DESCRIPTION
## Summary
- Add a new boolean column `js_renderer` to `SearchgovDomain` table default set to true.
- This can be used to opt-in/out of JS Rendering.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks

- [ ] You have run `bundle update` and committed your changes to Gemfile.lock.
 
- [ ] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [ ] You have specified at least one "Reviewer".