### PR TITLE
SRCH-3451 add unit tests for serialized columns

### DIFF
--- a/spec/models/low_query_ctr_watcher_spec.rb
+++ b/spec/models/low_query_ctr_watcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe LowQueryCtrWatcher do
   let(:affiliate) { affiliates(:basic_affiliate) }
@@ -23,6 +23,12 @@ describe LowQueryCtrWatcher do
 
   it { is_expected.to validate_numericality_of(:search_click_total).only_integer }
   it { is_expected.to validate_numericality_of(:low_ctr_threshold) }
+
+  describe '.conditions' do
+    subject(:conditions) { watcher.conditions }
+
+    it { is_expected.to eq({ low_ctr_threshold: 15.5, search_click_total: 101 }) }
+  end
 
   describe 'humanized_alert_threshold' do
     subject(:watcher) { described_class.new(search_click_total: 101, low_ctr_threshold: 15.5 ) }

--- a/spec/models/news_item_spec.rb
+++ b/spec/models/news_item_spec.rb
@@ -27,45 +27,47 @@ describe NewsItem do
     it { is_expected.to validate_uniqueness_of(:link).case_insensitive.scoped_to(:rss_feed_url_id) }
     it { is_expected.to validate_presence_of :rss_feed_url_id }
 
-    it 'should create a new instance given valid attributes' do
+    it 'creates a new instance given valid attributes' do
       described_class.create!(valid_attributes)
     end
 
-    it 'should allow blank description for YouTube video' do
+    it 'allows blank description for YouTube video' do
       described_class.create!(valid_attributes.merge(link: 'HTTPs://www.youtube.com/watch?v=q3GjT4zvUkk',
-                                               description: nil))
+                                                     description: nil))
     end
 
     it 'allows blank description when body is present' do
       described_class.create!(valid_attributes.merge(body: 'content body',
-                                               description: '   '))
+                                                     description: '   '))
     end
 
-    it 'should scrub out extra whitespace, tabs, newlines from fields' do
+    it 'scrubs out extra whitespace, tabs, newlines from fields' do
       news_item = described_class.create!(
         valid_attributes.merge(title: " \nDOD \tMarks Growth\r in Spouses’ \u00a0 Employment Program \n     ",
-                                description: " \nSome     description \n     ",
-                                link: "\t\t\t\n http://www.foo.gov/1.html\t\n",
-                                guid: "\t\t\t\nhttp://www.foo.gov/1.html \t\n"
-        ))
+                               description: " \nSome     description \n     ",
+                               link: "\t\t\t\n http://www.foo.gov/1.html\t\n",
+                               guid: "\t\t\t\nhttp://www.foo.gov/1.html \t\n")
+      )
       expect(news_item.title).to eq('DOD Marks Growth in Spouses’ Employment Program')
       expect(news_item.description).to eq('Some description')
       expect(news_item.link).to eq('http://www.foo.gov/1.html')
       expect(news_item.guid).to eq('http://www.foo.gov/1.html')
     end
 
-    it 'should set tags to image if media_thumbnail_url and media_content_url are present' do
+    it 'sets tags to image if media_thumbnail_url and media_content_url are present' do
       properties = {
         media_thumbnail: {
-          url: 'http://farm9.staticflickr.com/8381/8594929349_f6d8163c36_s.jpg', height: '75', width: '75' },
+          url: 'http://farm9.staticflickr.com/8381/8594929349_f6d8163c36_s.jpg', height: '75', width: '75'
+        },
         media_content: {
-          url: 'http://farm9.staticflickr.com/8381/8594929349_f6d8163c36_b.jpg', type: 'image/jpeg', height: '819', width: '1024' }
+          url: 'http://farm9.staticflickr.com/8381/8594929349_f6d8163c36_b.jpg', type: 'image/jpeg', height: '819', width: '1024'
+        }
       }
-      news_item = described_class.create!(valid_attributes.merge properties: properties)
-      expect(described_class.find(news_item.id).tags).to eq(%w(image))
+      news_item = described_class.create!(valid_attributes.merge(properties: properties))
+      expect(described_class.find(news_item.id).tags).to eq(%w[image])
     end
 
-    it 'should validate link URL is a well-formed absolute URL' do
+    it 'validates link URL is a well-formed absolute URL' do
       news_item = described_class.new(valid_attributes.merge(link: '/relative/url'))
       expect(news_item.valid?).to be false
     end
@@ -79,10 +81,9 @@ describe NewsItem do
   end
 
   describe '#language' do
-
     context 'when RSS feed URL does not have language specified' do
       context 'when owner is an Affiliate' do
-        it 'should use locale of first affiliate associated with feed URL' do
+        it 'uses locale of first affiliate associated with feed URL' do
           expect(news_item.language).to eq('en')
         end
       end
@@ -92,7 +93,7 @@ describe NewsItem do
           news_item.update_attribute(:rss_feed_url_id, rss_feed_urls(:whitehouse_youtube_url).id)
         end
 
-        it 'should use locale of first affiliate associated with feed URL youtube profile' do
+        it 'uses locale of first affiliate associated with feed URL youtube profile' do
           expect(news_item.language).to eq('en')
         end
       end
@@ -103,7 +104,7 @@ describe NewsItem do
         news_item.rss_feed_url.language = 'es'
       end
 
-      it 'should use it' do
+      it 'uses it' do
         expect(news_item.language).to eq('es')
       end
     end
@@ -113,7 +114,7 @@ describe NewsItem do
         news_item.rss_feed_url.rss_feeds.delete_all
       end
 
-      it 'should default to English' do
+      it 'defaults to English' do
         expect(news_item.language).to eq('en')
       end
     end

--- a/spec/models/no_results_watcher_spec.rb
+++ b/spec/models/no_results_watcher_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe NoResultsWatcher do
   let(:affiliate) { affiliates(:basic_affiliate) }
@@ -22,6 +22,12 @@ describe NoResultsWatcher do
   subject(:watcher) { described_class.new(watcher_args) }
 
   it { is_expected.to validate_numericality_of(:distinct_user_total).only_integer }
+
+  describe '.conditions' do
+    subject(:conditions) { watcher.conditions }
+
+    it { is_expected.to eq({ distinct_user_total: 34 }) }
+  end
 
   describe 'humanized_alert_threshold' do
     subject(:watcher) { described_class.new(distinct_user_total: 34) }

--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -6,7 +6,7 @@ describe Tweet do
     {
       tweet_id: 18700887835,
       tweet_text: 'this is a tweet',
-      published_at: Time.now,
+      published_at: Time.current,
       twitter_profile_id: twitter_profile.id
     }
   end
@@ -41,9 +41,10 @@ describe Tweet do
       let(:tweet) do
         urls = [
           Struct.new(:display_url, :expanded_url, :url).new(
-            "twitter.com/i/web/status/1…",
-            "https://twitter.com/i/web/status/123",
-            "https://t.co/abc")
+            'twitter.com/i/web/status/1…',
+            'https://twitter.com/i/web/status/123',
+            'https://t.co/abc'
+          )
         ]
 
         described_class.new(valid_attributes.merge(urls: urls))
@@ -62,9 +63,9 @@ describe Tweet do
 
   it 'sanitizes tweet text' do
     tweet = described_class.create!(tweet_text: "A <b>tweet</b> with \n http://t.co/h5vNlSdL and http://t.co/YQQSs9bb",
-                          tweet_id: 123456,
-                          published_at: Time.now,
-                          twitter_profile_id: 12345)
+                                    tweet_id: 123456,
+                                    published_at: Time.current,
+                                    twitter_profile_id: 12345)
     expect(described_class.find(tweet.id).tweet_text).to eq('A tweet with http://t.co/h5vNlSdL and http://t.co/YQQSs9bb')
   end
 
@@ -97,7 +98,7 @@ describe Tweet do
                              screen_name: 'USASearch',
                              name: 'USASearch',
                              profile_image_url: 'http://a0.twimg.com/profile_images/1879738641/USASearch_avatar_normal.png')
-      @tweet = described_class.create!(tweet_text: 'USA', tweet_id: 123456, published_at: Time.now, twitter_profile_id: 12345)
+      @tweet = described_class.create!(tweet_text: 'USA', tweet_id: 123456, published_at: Time.current, twitter_profile_id: 12345)
     end
 
     it 'outputs a properly formatted link to the tweet' do

--- a/spec/models/tweet_spec.rb
+++ b/spec/models/tweet_spec.rb
@@ -34,6 +34,32 @@ describe Tweet do
     is_expected.to validate_uniqueness_of :tweet_id
   end
 
+  describe '.urls' do
+    subject(:urls) { tweet.urls }
+
+    context 'when the tweet includes URLs' do
+      let(:tweet) do
+        urls = [
+          Struct.new(:display_url, :expanded_url, :url).new(
+            "twitter.com/i/web/status/1…",
+            "https://twitter.com/i/web/status/123",
+            "https://t.co/abc")
+        ]
+
+        described_class.new(valid_attributes.merge(urls: urls))
+      end
+
+      it { is_expected.to be_an Array }
+
+      it 'provides accessors to the URLs' do
+        url = tweet.urls.first
+        expect(url.display_url).to eq('twitter.com/i/web/status/1…')
+        expect(url.expanded_url).to eq('https://twitter.com/i/web/status/123')
+        expect(url.url).to eq('https://t.co/abc')
+      end
+    end
+  end
+
   it 'sanitizes tweet text' do
     tweet = described_class.create!(tweet_text: "A <b>tweet</b> with \n http://t.co/h5vNlSdL and http://t.co/YQQSs9bb",
                           tweet_id: 123456,

--- a/spec/models/twitter_list_spec.rb
+++ b/spec/models/twitter_list_spec.rb
@@ -1,7 +1,11 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe TwitterList do
-  fixtures :affiliates, :twitter_profiles
+  let(:twitter_profile1) { twitter_profiles(:usagov) }
+  let(:twitter_profile2) { twitter_profiles(:usasearch) }
+  let(:twitter_list) do
+    twitter_profile1.twitter_lists.create(member_ids: [twitter_profile2.twitter_id])
+  end
 
   it { is_expected.to validate_numericality_of(:id).only_integer }
   it 'should not allow id = 0' do
@@ -9,18 +13,24 @@ describe TwitterList do
   end
   it { is_expected.to have_and_belong_to_many :twitter_profiles }
 
+  describe '.member_ids' do
+    subject(:member_ids) { twitter_list.member_ids }
+
+    it 'returns an array of Twitter profile twitter_ids' do
+      expect(member_ids).to eq [260266634]
+    end
+  end
+
   describe '.active' do
-    let(:tp1) { twitter_profiles(:usagov) }
-    let(:tp2) { twitter_profiles(:usasearch) }
     let(:a1) { affiliates(:usagov_affiliate) }
     let(:a2) { affiliates(:basic_affiliate) }
     let(:tl1) { described_class.create(id: 1) }
     let(:tl2) { described_class.create(id: 2) }
     before do
-      tp1.twitter_lists << tl1; tp1.save!
-      tp2.twitter_lists << tl2; tp2.save!
-      AffiliateTwitterSetting.create(affiliate: a1, twitter_profile: tp1, show_lists: 1)
-      AffiliateTwitterSetting.create(affiliate: a2, twitter_profile: tp2, show_lists: 0)
+      twitter_profile1.twitter_lists << tl1; twitter_profile1.save!
+      twitter_profile2.twitter_lists << tl2; twitter_profile2.save!
+      AffiliateTwitterSetting.create(affiliate: a1, twitter_profile: twitter_profile1, show_lists: 1)
+      AffiliateTwitterSetting.create(affiliate: a2, twitter_profile: twitter_profile2, show_lists: 0)
     end
 
     it 'returns only the lists belonging to affiliates whose twitter settings indicate that lists should be shown' do

--- a/spec/models/watcher_spec.rb
+++ b/spec/models/watcher_spec.rb
@@ -1,6 +1,8 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe Watcher do
+  let(:watcher) { described_class.new }
+
   before do
     allow_any_instance_of(WatcherObserver).to receive(:after_save)
     allow_any_instance_of(WatcherObserver).to receive(:after_destroy)
@@ -18,4 +20,9 @@ describe Watcher do
     it { is_expected.not_to allow_value(value).for(:time_window) }
   end
 
+  describe '.conditions' do
+    subject(:conditions) { watcher.conditions }
+
+    it { is_expected.to be_a Hash }
+  end
 end

--- a/spec/models/youtube_playlist_spec.rb
+++ b/spec/models/youtube_playlist_spec.rb
@@ -1,7 +1,21 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe YoutubePlaylist do
+  let(:youtube_playlist) { described_class.new }
+
   it { is_expected.to belong_to :youtube_profile }
   it { is_expected.to validate_uniqueness_of(:playlist_id).
                 scoped_to(:youtube_profile_id) }
+
+  describe '.news_item_ids' do
+    subject(:news_item_ids) { youtube_playlist.news_item_ids }
+
+    it { is_expected.to be_an Array }
+
+    context 'when the playlist has news items' do
+      let(:youtube_playlist) { described_class.new(news_item_ids: [1, 2]) }
+
+      it { is_expected.to eq [1, 2] }
+    end
+  end
 end


### PR DESCRIPTION
## Summary
This PR:
- adds some model specs for serialized columns in a number of tables. This allows us to make changes to those columns more safely and easily (as we will be doing for SRCH-3206 which will change the serialization method for those columns). 
- cleans up a number of Rubocop offenses in the specs
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

⚠️  You have run `bundle update` and committed your changes to Gemfile.lock.
I did not `bundle update`, as these changes are only in the spec files, and should not require a separate deployment.
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".