### PR TITLE
SRCH-2606 Disable Bing image search by default

### DIFF
--- a/db/migrate/20221111205138_change_default_is_bing_image_search_enabled_on_affiliates_to_false.rb
+++ b/db/migrate/20221111205138_change_default_is_bing_image_search_enabled_on_affiliates_to_false.rb
@@ -1,0 +1,9 @@
+class ChangeDefaultIsBingImageSearchEnabledOnAffiliatesToFalse < ActiveRecord::Migration[6.1]
+  def up
+    change_column_default :affiliates, :is_bing_image_search_enabled, false
+  end
+
+  def down
+    change_column_default :affiliates, :is_bing_image_search_enabled, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_10_10_143533) do
+ActiveRecord::Schema.define(version: 2022_11_11_205138) do
 
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
@@ -87,7 +87,7 @@ ActiveRecord::Schema.define(version: 2022_10_10_143533) do
     t.boolean "dap_enabled", default: true, null: false
     t.text "dublin_core_mappings", size: :medium
     t.boolean "gets_blended_results", default: false, null: false
-    t.boolean "is_bing_image_search_enabled", default: true, null: false
+    t.boolean "is_bing_image_search_enabled", default: false, null: false
     t.boolean "is_federal_register_document_govbox_enabled", default: false, null: false
     t.string "google_cx"
     t.string "google_key"

--- a/features/admin_center_manage_display.feature
+++ b/features/admin_center_manage_display.feature
@@ -1,8 +1,8 @@
 Feature: Manage Display
   Scenario: Editing Sidebar Settings on a new site
     Given the following Affiliates exist:
-      | display_name | name       | contact_email   | first_name | last_name |
-      | agency site  | agency.gov | john@agency.gov | John       | Bar       |
+      | display_name | name       | contact_email   | first_name | last_name | is_bing_image_search_enabled |
+      | agency site  | agency.gov | john@agency.gov | John       | Bar       | true                         |
     And I am logged in with email "john@agency.gov"
     When I go to the agency.gov's Manage Display page
     Then I should see "Image Search Label 0"

--- a/features/searches.feature
+++ b/features/searches.feature
@@ -119,8 +119,8 @@ Feature: Search
 
   Scenario: Visiting Spanish affiliate search with multiple domains
     Given the following Affiliates exist:
-      | display_name | name    | contact_email | first_name | last_name | domains                | locale | is_image_search_navigable |
-      | bar site     | bar.gov | aff@bar.gov   | John       | Bar       | whitehouse.gov,usa.gov | es     | true                      |
+      | display_name | name    | contact_email | first_name | last_name | domains                | locale | is_image_search_navigable | is_bing_image_search_enabled |
+      | bar site     | bar.gov | aff@bar.gov   | John       | Bar       | whitehouse.gov,usa.gov | es     | true                      | true                         |
     When I am on bar.gov's search page
     And I fill in "Ingrese su búsqueda" with "president"
     And I press "Buscar" within the search box
@@ -342,8 +342,8 @@ Feature: Search
 
   Scenario: Searching with malformed query
     Given the following Affiliates exist:
-      | display_name | name       | contact_email | first_name | last_name | is_image_search_navigable |
-      | agency site  | agency.gov | aff@bar.gov   | John       | Bar       | true                      |
+      | display_name | name       | contact_email | first_name | last_name | is_image_search_navigable | is_bing_image_search_enabled |
+      | agency site  | agency.gov | aff@bar.gov   | John       | Bar       | true                      | true                         |
     When I am on agency.gov's search page
     And I search for "<b>hello</b><script>script</script>"
     Then I should see "hello"

--- a/spec/models/image_search_spec.rb
+++ b/spec/models/image_search_spec.rb
@@ -22,7 +22,7 @@ describe ImageSearch do
       described_class.new(affiliate: affiliate, query: 'corgis', cr: use_commercial_results)
     end
     let(:use_commercial_results) { nil }
-    let(:affiliate) { affiliates(:basic_affiliate) }
+    let(:affiliate) { affiliates(:bing_image_search_enabled_affiliate) }
     let(:search_engine) { nil }
     before do
       allow(affiliate).to receive(:search_engine).and_return(search_engine)

--- a/spec/models/image_search_spec.rb
+++ b/spec/models/image_search_spec.rb
@@ -22,7 +22,7 @@ describe ImageSearch do
       described_class.new(affiliate: affiliate, query: 'corgis', cr: use_commercial_results)
     end
     let(:use_commercial_results) { nil }
-    let(:affiliate) { affiliates(:bing_image_search_enabled_affiliate) }
+    let(:affiliate) { affiliates(:basic_affiliate) }
     let(:search_engine) { nil }
     before do
       allow(affiliate).to receive(:search_engine).and_return(search_engine)
@@ -129,6 +129,7 @@ describe ImageSearch do
     subject(:image_search) { described_class.new(affiliate: affiliate, query: 'lsdkjflskjflskjdf') }
     let(:search_engine_adapter) { double(SearchEngineAdapter, default_module_tag: 'module_tag', results: [], spelling_suggestion: 'spel') }
     before do
+      affiliate.update_attribute(:is_bing_image_search_enabled, true)
       allow(SuggestionBlock).to receive(:exists?).and_return(suggestion_block_exists)
       allow(SearchEngineAdapter).to receive(:new).and_return(search_engine_adapter)
       allow(search_engine_adapter).to receive(:run)


### PR DESCRIPTION
## Summary
This PR adds a migration to set `Is bing image search enabled` to `false` by default for new affiliates.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
