### PR TITLE
SRCH-3434 expose JS indexing option to domains table for super admins

### DIFF
--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -21,7 +21,8 @@ class Admin::SearchgovDomainsController < Admin::AdminController
       inline: true,
       confirm: 'Are you sure you want to reindex this entire domain?'
     )
-    config.update.columns = %I[js_renderer]
+    config.update.columns = %i[js_renderer]
+    config.columns[:js_renderer].label = 'Render Javascript'
   end
 
   def after_create_save(record)

--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -3,7 +3,7 @@
 class Admin::SearchgovDomainsController < Admin::AdminController
   active_scaffold :searchgov_domain do |config|
     config.label = 'Search.gov Domains'
-    config.actions = %i[create list search export nested]
+    config.actions = %i[create update list search export nested]
     config.create.columns = [:domain]
     config.columns = %i[
       id domain canonical_domain status activity
@@ -21,6 +21,16 @@ class Admin::SearchgovDomainsController < Admin::AdminController
       inline: true,
       confirm: 'Are you sure you want to reindex this entire domain?'
     )
+
+    update_columns = %i[
+      js_renderer
+    ]
+    config.update.columns = []
+    enable_disable_column_regex = /^(is_|js_renderer)/.freeze
+    config.update.columns.add_subgroup 'Enable/Disable Settings' do |name_group|
+      name_group.add *update_columns.select { |column| column =~ enable_disable_column_regex }
+      name_group.collapsed = true
+    end
   end
 
   def after_create_save(record)

--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -21,16 +21,7 @@ class Admin::SearchgovDomainsController < Admin::AdminController
       inline: true,
       confirm: 'Are you sure you want to reindex this entire domain?'
     )
-
-    update_columns = %i[
-      js_renderer
-    ]
-    config.update.columns = []
-    enable_disable_column_regex = /^(is_|js_renderer)/.freeze
-    config.update.columns.add_subgroup 'Enable/Disable Settings' do |name_group|
-      name_group.add *update_columns.select { |column| column =~ enable_disable_column_regex }
-      name_group.collapsed = true
-    end
+    config.update.columns = %I[js_renderer]
   end
 
   def after_create_save(record)

--- a/app/models/searchgov_domain.rb
+++ b/app/models/searchgov_domain.rb
@@ -26,6 +26,10 @@ class SearchgovDomain < ApplicationRecord
   scope :ok, -> { where(status: OK_STATUS) }
   scope :not_ok, -> { where.not(status: OK_STATUS).or(where(status: nil)) }
 
+  def to_label
+    domain
+  end
+
   def delay
     @delay ||= (robotex.delay("http://#{domain}/") || 1)
   end

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -223,6 +223,12 @@ Feature:  Administration
     And I wait for ajax
     Then I should see "Reindexing has been enqueued for www.state.gov"
 
+    When I follow "Edit" within the first scaffold row
+    Then I should see "Js renderer"
+    When I check "Js renderer"
+    Then the "Js renderer" checkbox should be checked
+    And I press "Update"
+
   @javascript
   Scenario: Adding a system alert
     When I go to the admin home page

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -224,10 +224,11 @@ Feature:  Administration
     Then I should see "Reindexing has been enqueued for www.state.gov"
 
     When I follow "Edit" within the first scaffold row
-    Then I should see "Js renderer"
-    When I check "Js renderer"
-    Then the "Js renderer" checkbox should be checked
+    Then I should see "Render Javascript"
+    When I check "Render Javascript"
+    Then the "Render Javascript" checkbox should be checked
     And I press "Update"
+    Then I should see "www.state.gov"
 
   @javascript
   Scenario: Adding a system alert

--- a/features/step_definitions/web_steps.rb
+++ b/features/step_definitions/web_steps.rb
@@ -176,7 +176,7 @@ Then /^the "([^"]*)" checkbox(?: within (.*))? should be checked$/ do |label, pa
   with_scope(parent) do
     field_checked = find_field(label)['checked']
     if field_checked.respond_to? :should
-      field_checked.should be_true
+      field_checked.should be_truthy
     else
       assert field_checked
     end

--- a/spec/controllers/admin/searchgov_domains_controller_spec.rb
+++ b/spec/controllers/admin/searchgov_domains_controller_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe Admin::SearchgovDomainsController do
+  fixtures :users, :searchgov_domains
+  let(:config) { described_class.active_scaffold_config }
+
+  describe '#update' do
+    before do
+      activate_authlogic
+      UserSession.create(users(:affiliate_admin))
+    end
+
+    context 'when configuring Active Scaffold' do
+      let(:update_columns) { config.update.columns }
+
+      let(:enable_disable_columns) do
+        %i[js_renderer]
+      end
+
+      it 'contains the specified columns' do
+        expect(update_columns.to_a).to match_array(enable_disable_columns)
+      end
+    end
+  end
+end

--- a/spec/controllers/admin/searchgov_domains_controller_spec.rb
+++ b/spec/controllers/admin/searchgov_domains_controller_spec.rb
@@ -12,10 +12,7 @@ describe Admin::SearchgovDomainsController do
 
     context 'when configuring Active Scaffold' do
       let(:update_columns) { config.update.columns }
-
-      let(:enable_disable_columns) do
-        %i[js_renderer]
-      end
+      let(:enable_disable_columns) { %i[js_renderer] }
 
       it 'contains the specified columns' do
         expect(update_columns.to_a).to match_array(enable_disable_columns)


### PR DESCRIPTION
## Summary
- New "Edit" button to update Searchgov Domains for Super Admin. So that admin can access functionality of enable/disable ''js_renderer" from UI for Searchgov Domains.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
