### PR TITLE
SRCH-1413 Remove ElasticSearch 6 from CircleCI matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,6 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 6.8.23
                 - 7.17.3
 
       - rspec:
@@ -280,7 +279,6 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 6.8.23
                 - 7.17.3
 
       - cucumber:
@@ -292,7 +290,6 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 6.8.23
                 - 7.17.3
 
       - report_coverage:
@@ -307,4 +304,4 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 6.8.23
+                - 7.17.3


### PR DESCRIPTION
## Summary
This PR removes ElasticSearch 6 from all CircleCI jobs.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [ ] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [ ] You have specified at least one "Reviewer".
