### PR TITLE
SRCH-3556 Disable the twitter list setting in the admin center

### DIFF
--- a/app/helpers/twitter_profiles_helper.rb
+++ b/app/helpers/twitter_profiles_helper.rb
@@ -34,10 +34,11 @@ module TwitterProfilesHelper
             target: '_blank'
   end
 
-  def twitter_profile_properties(site, twitter_profile)
-    if site.affiliate_twitter_settings.
-        exists?(twitter_profile_id: twitter_profile.id, show_lists: 1)
-      content_tag :span, '(show lists)', class: 'properties'
-    end
-  end
+  # Temporarily disabling show lists as per JIRA ticket #SRCH-3556
+  # def twitter_profile_properties(site, twitter_profile)
+  #   if site.affiliate_twitter_settings.
+  #       exists?(twitter_profile_id: twitter_profile.id, show_lists: 1)
+  #     content_tag :span, '(show lists)', class: 'properties'
+  #   end
+  # end
 end

--- a/app/views/sites/twitter_profiles/index.html.haml
+++ b/app/views/sites/twitter_profiles/index.html.haml
@@ -13,7 +13,7 @@
       %tr
         %td
           = link_to_twitter_handle twitter_profile
-          = twitter_profile_properties @site, twitter_profile
+          / = twitter_profile_properties @site, twitter_profile
         %td.actions
           %ul
             %li= button_to 'Remove', site_twitter_handle_path(@site, twitter_profile.id), method: :delete, data: { confirm: "Are you sure you wish to remove @#{twitter_profile.screen_name} from this site?" }, class: 'btn btn-small'

--- a/app/views/sites/twitter_profiles/index.html.haml
+++ b/app/views/sites/twitter_profiles/index.html.haml
@@ -13,6 +13,7 @@
       %tr
         %td
           = link_to_twitter_handle twitter_profile
+          -# Temporarily disabling show lists as per JIRA ticket #SRCH-3556
           / = twitter_profile_properties @site, twitter_profile
         %td.actions
           %ul

--- a/app/views/sites/twitter_profiles/new.html.haml
+++ b/app/views/sites/twitter_profiles/new.html.haml
@@ -11,6 +11,7 @@
   = render_error_messages(@profile)
   = f.label :screen_name, 'Twitter Handle', class: 'required'
   = f.text_field :screen_name, class: 'required input-primary'
-  = label_tag nil, class: 'checkbox' do
-    = check_box_tag :show_lists
-    Show tweets from my lists
+  / Temporarily disabling checkbox as per JIRA ticket #SRCH-3556
+  / = label_tag nil, class: 'checkbox' do
+  /   = check_box_tag :show_lists
+  /   Show tweets from my lists

--- a/app/views/sites/twitter_profiles/new.html.haml
+++ b/app/views/sites/twitter_profiles/new.html.haml
@@ -11,7 +11,7 @@
   = render_error_messages(@profile)
   = f.label :screen_name, 'Twitter Handle', class: 'required'
   = f.text_field :screen_name, class: 'required input-primary'
-  / Temporarily disabling checkbox as per JIRA ticket #SRCH-3556
+  -# Temporarily disabling checkbox as per JIRA ticket #SRCH-3556
   / = label_tag nil, class: 'checkbox' do
   /   = check_box_tag :show_lists
-  /   Show tweets from my lists
+  -#   Show tweets from my lists

--- a/features/admin_center_manage_content.feature
+++ b/features/admin_center_manage_content.feature
@@ -674,11 +674,11 @@ Feature: Manage Content
     And I follow "Twitter" within the Admin Center content
     And I follow "Add Twitter Handle"
     When I fill in "Twitter Handle" with "NIH"
-    And I check "Show tweets from my lists"
+    # And I check "Show tweets from my lists"
     And I submit the form by pressing "Add"
     Then I should see "You have added @NIH to this site"
     And I should see a link to "@NIH" with url for "https://twitter.com/NIH"
-    And I should see "@NIH (show lists)"
+    # And I should see "@NIH (show lists)"
     When I press "Remove" and confirm "Are you sure you wish to remove @NIH from this site?"
     Then I should see "You have removed @NIH from this site"
     When I follow "Add Twitter Handle"


### PR DESCRIPTION
## Summary
- Commented out the twitter list checkbox in admin center, setting cannot be enabled for users in going forward from the view.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
