### PR TITLE
SRCH-3293 Make ElasticSearch 7 the default for development and testing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,7 +269,7 @@ workflows:
                 - 2.7.5
               elasticsearch_version:
                 - 7.17.3
-                - 8.5.3
+                # not yet compatible with Elasticsearch 8
 
       - rspec:
           requires:
@@ -281,7 +281,6 @@ workflows:
                 - 2.7.5
               elasticsearch_version:
                 - 7.17.3
-                - 8.5.3
 
       - cucumber:
           requires:
@@ -293,7 +292,6 @@ workflows:
                 - 2.7.5
               elasticsearch_version:
                 - 7.17.3
-                - 8.5.3
 
       - report_coverage:
           requires:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,8 +268,8 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 6.8.23
                 - 7.17.3
+                - 8.5.3
 
       - rspec:
           requires:
@@ -280,8 +280,8 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 6.8.23
                 - 7.17.3
+                - 8.5.3
 
       - cucumber:
           requires:
@@ -292,8 +292,8 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 6.8.23
                 - 7.17.3
+                - 8.5.3
 
       - report_coverage:
           requires:
@@ -307,4 +307,4 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 6.8.23
+                - 7.17.3

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -268,7 +268,7 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 7.17.3
+                - 7.17.7
                 # not yet compatible with Elasticsearch 8
 
       - rspec:
@@ -280,7 +280,7 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 7.17.3
+                - 7.17.7
 
       - cucumber:
           requires:
@@ -291,7 +291,7 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 7.17.3
+                - 7.17.7
 
       - report_coverage:
           requires:
@@ -305,4 +305,4 @@ workflows:
               ruby_version:
                 - 2.7.5
               elasticsearch_version:
-                - 7.17.3
+                - 7.17.7

--- a/README.md
+++ b/README.md
@@ -26,24 +26,24 @@ The Elasticsearch service provided by `searchgov-services` is configured to run 
 
     ES_HOSTS=localhost:9207 bundle exec rspec spec
 
-Verify that Elasticsearch 6.8.x is running on the expected port (port 9200 by default):
+Verify that Elasticsearch 7.17.x is running on the expected port (port 9200 by default):
 
 ```bash
 $ curl localhost:9200
 {
-  "name" : "wp9TsCe",
-  "cluster_name" : "docker-cluster",
-  "cluster_uuid" : "WGf_peYTTZarT49AtEgc3g",
+  "name" : "5de7e4b93c66",
+  "cluster_name" : "es7-docker-cluster",
+  "cluster_uuid" : "DHM6yefJS6qH7OQrSptUdw",
   "version" : {
-    "number" : "6.8.7",
+    "number" : "7.17.3",
     "build_flavor" : "default",
     "build_type" : "docker",
-    "build_hash" : "c63e621",
-    "build_date" : "2020-02-26T14:38:01.193138Z",
+    "build_hash" : "5ad023604c8d7416c9eb6c0eadb62b14e766caff",
+    "build_date" : "2022-04-19T08:11:19.070913226Z",
     "build_snapshot" : false,
-    "lucene_version" : "7.7.2",
-    "minimum_wire_compatibility_version" : "5.6.0",
-    "minimum_index_compatibility_version" : "5.0.0"
+    "lucene_version" : "8.11.1",
+    "minimum_wire_compatibility_version" : "6.8.0",
+    "minimum_index_compatibility_version" : "6.0.0-beta1"
   },
   "tagline" : "You Know, for Search"
 }
@@ -88,14 +88,14 @@ Use [Bundler](https://bundler.io/) 2.3.8 to install the required gems:
     $ gem install bundler -v 2.3.8
     $ bundle install
 
+Refer to [the wiki](https://github.com/GSA/search-gov/wiki/Gem-Installation-gotchas-and-solutions) to troubleshoot gem installation errors.
+
 ### JavaScript dependencies
 
 Use [Yarn](https://classic.yarnpkg.com/en/) to install the required JavaScript dependencies:
 
     $ npm install --global yarn
     $ yarn install
-
-Refer to [the wiki](https://github.com/GSA/search-gov/wiki/Gem-Installation-gotchas-and-solutions) to troubleshoot gem installation errors.
 
 ## Service credentials; how we protect secrets
 

--- a/README.md
+++ b/README.md
@@ -31,15 +31,15 @@ Verify that Elasticsearch 7.17.x is running on the expected port (port 9200 by d
 ```bash
 $ curl localhost:9200
 {
-  "name" : "5de7e4b93c66",
+  "name" : "002410188f61",
   "cluster_name" : "es7-docker-cluster",
-  "cluster_uuid" : "DHM6yefJS6qH7OQrSptUdw",
+  "cluster_uuid" : "l3cAhBd4Sqa3B4SkpUilPQ",
   "version" : {
-    "number" : "7.17.3",
+    "number" : "7.17.7",
     "build_flavor" : "default",
     "build_type" : "docker",
-    "build_hash" : "5ad023604c8d7416c9eb6c0eadb62b14e766caff",
-    "build_date" : "2022-04-19T08:11:19.070913226Z",
+    "build_hash" : "78dcaaa8cee33438b91eca7f5c7f56a70fec9e80",
+    "build_date" : "2022-10-17T15:29:54.167373105Z",
     "build_snapshot" : false,
     "lucene_version" : "8.11.1",
     "minimum_wire_compatibility_version" : "6.8.0",


### PR DESCRIPTION
## Summary
This PR removes ElasticSearch v6.x from the CircleCI matrix and also updates the `README` to reference ElasticSearch v7.x. This PR should not be merged until `search-services` is modified so that ElasticSearch 7 runs on the default 9200 port.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
