### PR TITLE
SRCH-3684 fix intermittent spec failures for .download_medline_xml

### DIFF
--- a/spec/models/med_topic_spec.rb
+++ b/spec/models/med_topic_spec.rb
@@ -250,7 +250,7 @@ describe MedTopic do
   end
 
   describe '.download_medline_xml' do
-    before { allow(File).to receive(:exist?) }
+    before { allow(File).to receive(:exist?).and_call_original }
 
     context 'when file is not present in the tmp/medline directory' do
       let(:xml_content) { 'xml content' }


### PR DESCRIPTION
## Summary
This prevents intermittent spec failures for `MedTopic.download_medline_xml`. The `debug` gem makes various calls to `File.exist?` under the hood during a spec run. This change ensures that method calls from `debug` function as desired while allowing us to stub the return value when the method is called with specific arguments.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
