### PR TITLE
SRCH-3685 resolve deprecation warnings re. Date/TimeWithZone#to_s(:db)

### DIFF
--- a/app/engines/api_rate_limiter.rb
+++ b/app/engines/api_rate_limiter.rb
@@ -36,7 +36,7 @@ class ApiRateLimiter
   end
 
   def current_used_count_key
-    d = outbound_limit ? outbound_limit.current_interval : Date.current.to_s(:db)
+    d = outbound_limit ? outbound_limit.current_interval : Date.current.to_fs(:db)
     "#{@namespace}:#{d}:used_count"
   end
 

--- a/app/helpers/federal_register_documents_helper.rb
+++ b/app/helpers/federal_register_documents_helper.rb
@@ -28,7 +28,7 @@ module FederalRegisterDocumentsHelper
     else
       date_delta = (document.comments_close_on - today).to_i
       date_delta_span = content_tag :span, pluralize(date_delta, 'day')
-      comments_close_on_span = content_tag :span, document.comments_close_on.to_fs(:long)
+      comments_close_on_span = content_tag(:span, document.comments_close_on.to_fs(:long))
       "Comment period ends in #{date_delta_span} (#{comments_close_on_span})".html_safe
     end
   end

--- a/app/helpers/federal_register_documents_helper.rb
+++ b/app/helpers/federal_register_documents_helper.rb
@@ -28,7 +28,7 @@ module FederalRegisterDocumentsHelper
     else
       date_delta = (document.comments_close_on - today).to_i
       date_delta_span = content_tag :span, pluralize(date_delta, 'day')
-      comments_close_on_span = content_tag :span, document.comments_close_on.to_s(:long)
+      comments_close_on_span = content_tag :span, document.comments_close_on.to_fs(:long)
       "Comment period ends in #{date_delta_span} (#{comments_close_on_span})".html_safe
     end
   end

--- a/app/helpers/jobs_helper.rb
+++ b/app/helpers/jobs_helper.rb
@@ -6,7 +6,7 @@ module JobsHelper
   def job_application_deadline(yyyy_mm_dd)
     if yyyy_mm_dd
       html = content_tag(:span, '&nbsp;&nbsp;&bull;&nbsp;&nbsp;'.html_safe, class: 'field-separator')
-      html << "Apply by #{Date.parse(yyyy_mm_dd).to_s(:long)}"
+      html << "Apply by #{Date.parse(yyyy_mm_dd).to_fs(:long)}"
     end
   end
 

--- a/app/models/sayt_suggestion.rb
+++ b/app/models/sayt_suggestion.rb
@@ -64,7 +64,7 @@ class SaytSuggestion < ApplicationRecord
     def expire(days_back)
       where(
         'updated_at < ? AND is_protected = ?',
-        days_back.days.ago.beginning_of_day.to_s(:db),
+        days_back.days.ago.beginning_of_day.to_fs(:db),
         false
       ).in_batches.destroy_all
     end

--- a/app/models/tweet.rb
+++ b/app/models/tweet.rb
@@ -35,7 +35,7 @@ class Tweet < ApplicationRecord
   end
 
   def self.expire(days_back)
-    where('published_at < ?', days_back.days.ago.beginning_of_day.to_s(:db)).
+    where('published_at < ?', days_back.days.ago.beginning_of_day.to_fs(:db)).
       in_batches.destroy_all
   end
 end

--- a/app/views/superfresh/index.rss.builder
+++ b/app/views/superfresh/index.rss.builder
@@ -4,7 +4,7 @@ xml.rss :version => "2.0" do
     xml.title "Search.USA.gov Superfresh Feed"
     xml.description "Recently updated URLs from around the US Government"
     xml.link 'https://search.usa.gov'
-    time_now = Time.now.to_s(:rfc822)
+    time_now = Time.now.to_fs(:rfc822)
 
     @superfresh_urls.each do |superfresh_url|
       xml.item do

--- a/lib/api/v2/search_as_json.rb
+++ b/lib/api/v2/search_as_json.rb
@@ -69,13 +69,13 @@ module Api::V2::SearchAsJson
     { title: news_item.title,
       url: news_item.link,
       snippet: news_item.description,
-      publication_date: news_item.published_at.to_date.to_s(:db),
+      publication_date: news_item.published_at.to_date.to_fs(:db),
       source: source }
   end
 
   def as_json_federal_register_documents
     federal_register_documents.results.collect do |document|
-      comments_close_on = document.comments_close_on ? document.comments_close_on.to_s(:db) : nil
+      comments_close_on = document.comments_close_on ? document.comments_close_on.to_fs(:db) : nil
       { id: document.id,
         document_number: document.document_number,
         document_type: document.document_type,
@@ -85,7 +85,7 @@ module Api::V2::SearchAsJson
         page_length: document.page_length,
         start_page: document.start_page,
         end_page: document.end_page,
-        publication_date: document.publication_date.to_s(:db),
+        publication_date: document.publication_date.to_fs(:db),
         comments_close_date: comments_close_on }
     end
   end

--- a/lib/tasks/sayt_suggestions.rake
+++ b/lib/tasks/sayt_suggestions.rake
@@ -4,7 +4,7 @@ namespace :usasearch do
     desc 'generate top X SAYT suggestions from human Logstash searches
       for given YYYYMMDD date (defaults to 1000 for yesterday)'.squish
     task :compute, [:day, :limit] => [:environment] do |t, args|
-      args.with_defaults(:day => Date.yesterday.to_s(:number))
+      args.with_defaults(:day => Date.yesterday.to_fs(:number))
       yyyymmdd = args.day.to_i
       limit = args.limit.nil? ? 1000 : args.limit.to_i
       SaytSuggestion.populate_for(yyyymmdd, limit)

--- a/spec/fixtures/federal_register_documents.yml
+++ b/spec/fixtures/federal_register_documents.yml
@@ -8,7 +8,7 @@
   end_page: 36702
   page_length: 4
   publication_date: 2014-06-30
-  comments_close_on: <%= Date.current.advance(days: 2).to_s(:db) %>
+  comments_close_on: <%= Date.current.advance(days: 2).to_fs(:db) %>
   significant: false
 
 '2014-15266':
@@ -21,7 +21,7 @@
   end_page: 36726
   page_length: 1
   publication_date: 2014-06-30
-  comments_close_on: <%= Date.current.advance(days: 1).to_s(:db) %>
+  comments_close_on: <%= Date.current.advance(days: 1).to_fs(:db) %>
   significant: false
 
 '2014-15170':
@@ -45,8 +45,8 @@
   start_page: 36728
   end_page: 36729
   page_length: 2
-  publication_date: <%= Date.current.advance(days: -90).to_s(:db) %>
-  comments_close_on: <%= Date.current.advance(days: -1).to_s(:db) %>
+  publication_date: <%= Date.current.advance(days: -90).to_fs(:db) %>
+  comments_close_on: <%= Date.current.advance(days: -1).to_fs(:db) %>
   significant: false
 
 '2014-25269':
@@ -58,7 +58,7 @@
   start_page: 36728
   end_page: 36729
   page_length: 2
-  publication_date: <%= Date.current.advance(days: -95).to_s(:db) %>
+  publication_date: <%= Date.current.advance(days: -95).to_fs(:db) %>
   significant: false
 
 '2014-15238':
@@ -145,7 +145,7 @@
   end_page: 8889
   page_length: 1
   publication_date: 2013-02-01
-  comments_close_on: <%= Date.current.advance(days: 2).to_s(:db) %>
+  comments_close_on: <%= Date.current.advance(days: 2).to_fs(:db) %>
   significant: false
 
 '2022-12345':

--- a/spec/fixtures/news_items.yml
+++ b/spec/fixtures/news_items.yml
@@ -4,11 +4,11 @@ item1:
   title: News element 1
   description: News element 1 has a description
   guid: This is a unique string per RSS feed and we are requiring it to be present
-  published_at: <%= 5.day.ago.to_s(:db) %>
+  published_at: <%= 5.day.ago.to_fs(:db) %>
 item2:
   rss_feed_url: :es_white_house_blog_url
   link: http://es.some.agency.gov/news/1
   title: Spanish news element 1
   description: Spanish news element 1 has a description
   guid: This is a unique string per RSS feed and we are requiring it to be present
-  published_at: <%= 5.day.ago.to_s(:db) %>
+  published_at: <%= 5.day.ago.to_fs(:db) %>

--- a/spec/fixtures/searchgov_urls.yml
+++ b/spec/fixtures/searchgov_urls.yml
@@ -3,21 +3,21 @@ new:
 
 outdated:
   url: http://www.agency.gov/outdated
-  last_crawled_at: <%= 1.week.ago.to_s(:db) %>
-  lastmod: <%= 1.day.ago.to_s(:db) %>
+  last_crawled_at: <%= 1.week.ago.to_fs(:db) %>
+  lastmod: <%= 1.day.ago.to_fs(:db) %>
 
 current:
   url: http://www.agency.gov/current
-  last_crawled_at: <%= 1.day.ago.to_s(:db) %>
-  lastmod: <%= 1.week.ago.to_s(:db) %>
+  last_crawled_at: <%= 1.day.ago.to_fs(:db) %>
+  lastmod: <%= 1.week.ago.to_fs(:db) %>
 
 enqueued:
   url: http://www.agency.gov/enqueued
-  last_crawled_at: <%= 1.day.ago.to_s(:db) %>
-  lastmod: <%= 1.week.ago.to_s(:db) %>
+  last_crawled_at: <%= 1.day.ago.to_fs(:db) %>
+  lastmod: <%= 1.week.ago.to_fs(:db) %>
   enqueued_for_reindex: true
 
 crawled_more_than_month:
   url: http://www.agency.gov/crawled_more_than_month
-  last_crawled_at: <%= 45.days.ago.to_s(:db) %>
+  last_crawled_at: <%= 45.days.ago.to_fs(:db) %>
   last_crawl_status: 'OK'

--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -80,7 +80,7 @@ developer:
 
 active_user:
   <<: *DEFAULTS
-  current_login_at: <%= 1.day.ago.to_s(:db) %>
+  current_login_at: <%= 1.day.ago.to_fs(:db) %>
 
 omniauth_user:
   <<: *DEFAULTS
@@ -97,28 +97,28 @@ user_without_uid:
 
 never_active_user:
   <<: *DEFAULTS
-  created_at: <%= 100.days.ago.to_s(:db) %>
+  created_at: <%= 100.days.ago.to_fs(:db) %>
 
 not_active_user:
   <<: *DEFAULTS
-  current_login_at: <%= 100.days.ago.to_s(:db) %>
+  current_login_at: <%= 100.days.ago.to_fs(:db) %>
 
 new_non_active_user:
   <<: *DEFAULTS
-  created_at: <%= 3.days.ago.to_s(:db) %>
+  created_at: <%= 3.days.ago.to_fs(:db) %>
 
 not_active_76_days:
   <<: *DEFAULTS
-  current_login_at: <%= 76.days.ago.to_s(:db) %>
+  current_login_at: <%= 76.days.ago.to_fs(:db) %>
 
 not_active_unapproved_76_days:
   <<: *DEFAULTS
-  current_login_at: <%= 76.days.ago.to_s(:db) %>
+  current_login_at: <%= 76.days.ago.to_fs(:db) %>
   approval_status: not_approved
 
 never_active_76_days:
   <<: *DEFAULTS
-  created_at: <%= 76.days.ago.to_s(:db) %>
+  created_at: <%= 76.days.ago.to_fs(:db) %>
 
 affiliate_manager_with_pending_contact_information_status:
   <<: *DEFAULTS

--- a/spec/lib/tasks/sayt_suggestions_spec.rb
+++ b/spec/lib/tasks/sayt_suggestions_spec.rb
@@ -20,7 +20,7 @@ describe 'SAYT suggestions rake tasks' do
 
       context 'when target day is specified' do
         it 'should populate sayt_suggestions for that given day' do
-          day = Date.current.to_s(:number).to_i
+          day = Date.current.to_fs(:number).to_i
           expect(SaytSuggestion).to receive(:populate_for).with(day, 1000)
           @rake[task_name].invoke(day)
         end
@@ -28,7 +28,7 @@ describe 'SAYT suggestions rake tasks' do
 
       context 'when target day is not specified' do
         it 'should default to yesterday' do
-          day = Date.yesterday.to_s(:number).to_i
+          day = Date.yesterday.to_fs(:number).to_i
           expect(SaytSuggestion).to receive(:populate_for).with(day, 1000)
           @rake[task_name].invoke
         end
@@ -36,7 +36,7 @@ describe 'SAYT suggestions rake tasks' do
 
       context 'when limit is specified' do
         it 'should pass that along to #populate_for' do
-          day = Date.current.to_s(:number).to_i
+          day = Date.current.to_fs(:number).to_i
           limit = '20'
           expect(SaytSuggestion).to receive(:populate_for).with(day, limit.to_i)
           @rake[task_name].invoke(day, limit)
@@ -45,7 +45,7 @@ describe 'SAYT suggestions rake tasks' do
 
       context 'when limit is not specified' do
         it 'should pass 1000 to #populate_for' do
-          day = Date.current.to_s(:number).to_i
+          day = Date.current.to_fs(:number).to_i
           expect(SaytSuggestion).to receive(:populate_for).with(day, 1000)
           @rake[task_name].invoke(day)
         end


### PR DESCRIPTION
## Summary
This PR resolves some Rails 7 deprecation warnings such as:

- `DEPRECATION WARNING: TimeWithZone#to_s(:db) is deprecated. Please use TimeWithZone#to_fs(:db) instead. (called from get_binding at /Users/marthacthompson/src/GSA/search-gov/spec/fixtures/users.yml:83)`
- `DEPRECATION WARNING: Time#to_s(:rfc822) is deprecated. Please use Time#to_fs(:rfc822) instead. (called from block (2 levels) in _app_views_superfresh_index_rss_builder__3951269083807529362_356960 at /home/circleci/search-gov/app/views/superfresh/index.rss.builder:7)`
- `DEPRECATION WARNING: Date#to_s(:number) is deprecated. Please use Date#to_fs(:number) instead. (called from block (3 levels) in <top (required)> at /home/circleci/search-gov/lib/tasks/sayt_suggestions.rake:7)`

 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
