### PR TITLE
SRCH-3717 rename watchers.*conditions columns to use JSON

### DIFF
--- a/app/models/low_query_ctr_watcher.rb
+++ b/app/models/low_query_ctr_watcher.rb
@@ -6,11 +6,11 @@ class LowQueryCtrWatcher < Watcher
   store_accessor :conditions, :search_click_total
   store_accessor :conditions, :low_ctr_threshold
 
-  validates_numericality_of :search_click_total, greater_than_or_equal_to: 20, only_integer: true
-  validates_numericality_of :low_ctr_threshold, greater_than: 0.0, less_than: 100.0
+  validates :search_click_total, numericality: { greater_than_or_equal_to: 20, only_integer: true }
+  validates :low_ctr_threshold, numericality: { greater_than: 0.0, less_than: 100.0 }
 
   def humanized_alert_threshold
-    "#{low_ctr_threshold}% CTR on #{number_with_delimiter search_click_total} Queries & Clicks"
+    "#{low_ctr_threshold}% CTR on #{number_with_delimiter(search_click_total)} Queries & Clicks"
   end
 
   def label

--- a/app/models/low_query_ctr_watcher.rb
+++ b/app/models/low_query_ctr_watcher.rb
@@ -2,8 +2,9 @@
 
 class LowQueryCtrWatcher < Watcher
   WATCHER_DEFAULTS = { search_click_total: 100, low_ctr_threshold: 15 }
-  define_hash_columns_accessors column_name_method: :conditions,
-                                fields: [:search_click_total, :low_ctr_threshold]
+
+  store_accessor :conditions, :search_click_total
+  store_accessor :conditions, :low_ctr_threshold
 
   validates_numericality_of :search_click_total, greater_than_or_equal_to: 20, only_integer: true
   validates_numericality_of :low_ctr_threshold, greater_than: 0.0, less_than: 100.0

--- a/app/models/no_results_watcher.rb
+++ b/app/models/no_results_watcher.rb
@@ -5,10 +5,10 @@ class NoResultsWatcher < Watcher
 
   store_accessor :conditions, :distinct_user_total
 
-  validates_numericality_of :distinct_user_total, greater_than_or_equal_to: 1, only_integer: true
+  validates :distinct_user_total, numericality: { greater_than_or_equal_to: 1, only_integer: true }
 
   def humanized_alert_threshold
-    "#{number_with_delimiter distinct_user_total} Queries"
+    "#{number_with_delimiter(distinct_user_total)} Queries"
   end
 
   def input(json)

--- a/app/models/no_results_watcher.rb
+++ b/app/models/no_results_watcher.rb
@@ -2,8 +2,8 @@
 
 class NoResultsWatcher < Watcher
   WATCHER_DEFAULTS = { distinct_user_total: 50 }
-  define_hash_columns_accessors column_name_method: :conditions,
-                                fields: [:distinct_user_total]
+
+  store_accessor :conditions, :distinct_user_total
 
   validates_numericality_of :distinct_user_total, greater_than_or_equal_to: 1, only_integer: true
 

--- a/app/models/watcher.rb
+++ b/app/models/watcher.rb
@@ -9,11 +9,11 @@ class Watcher < ApplicationRecord
   belongs_to :user
   belongs_to :affiliate
 
-  validates_presence_of :name, :conditions, :type
-  validates_uniqueness_of :name, case_sensitive: false
-  validates_format_of :check_interval, with: INTERVAL_REGEXP
-  validates_format_of :throttle_period, with: INTERVAL_REGEXP
-  validates_length_of :query_blocklist, maximum: 150, allow_nil: true
+  validates :name, :conditions, :type, presence: true
+  validates :name, uniqueness: { case_sensitive: false }
+  validates :check_interval, format: { with: INTERVAL_REGEXP }
+  validates :throttle_period, format: { with: INTERVAL_REGEXP }
+  validates :query_blocklist, length: { maximum: 150, allow_nil: true }
   validates :time_window, format: INTERVAL_REGEXP, time_window: true
 
   def body
@@ -41,7 +41,7 @@ class Watcher < ApplicationRecord
   def trigger(json)
     json.trigger do
       json.schedule do
-        json.interval self.check_interval
+        json.interval check_interval
       end
     end
   end

--- a/app/models/watcher.rb
+++ b/app/models/watcher.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Watcher < ApplicationRecord
-  extend HashColumnsAccessible
   include ActionView::Helpers::NumberHelper
   include LogstashPrefix
   include WatcherDsl
@@ -16,8 +15,6 @@ class Watcher < ApplicationRecord
   validates_format_of :throttle_period, with: INTERVAL_REGEXP
   validates_length_of :query_blocklist, maximum: 150, allow_nil: true
   validates :time_window, format: INTERVAL_REGEXP, time_window: true
-
-  serialize :conditions, Hash
 
   def body
     Jbuilder.encode do |json|

--- a/app/models/watcher.rb
+++ b/app/models/watcher.rb
@@ -10,7 +10,14 @@ class Watcher < ApplicationRecord
   belongs_to :affiliate
 
   validates :name, :conditions, :type, presence: true
+  # Disabling the Rubocop check for a unique index to back up a uniquness validation.
+  # This validation is as old as the class, but I'm not sure it is correct/needed.
+  # It may make sense to enforce unique names per user/affiliate, but I doubt that
+  # the name needs to be universally unique, unless it affects something on the Elasticsearch
+  # side. Until that is determined, I'm leaving this as-is.
+  # rubocop:disable Rails/UniqueValidationWithoutIndex
   validates :name, uniqueness: { case_sensitive: false }
+  # rubocop:enable Rails/UniqueValidationWithoutIndex
   validates :check_interval, format: { with: INTERVAL_REGEXP }
   validates :throttle_period, format: { with: INTERVAL_REGEXP }
   validates :query_blocklist, length: { maximum: 150, allow_nil: true }

--- a/db/migrate/20230106201846_rename_watcher_conditions_columns.rb
+++ b/db/migrate/20230106201846_rename_watcher_conditions_columns.rb
@@ -1,0 +1,11 @@
+class RenameWatcherConditionsColumns < ActiveRecord::Migration[7.0]
+  def up
+    rename_column :watchers, :conditions, :unsafe_conditions
+    rename_column :watchers, :safe_conditions, :conditions
+  end
+
+  def down
+    rename_column :watchers, :conditions, :safe_conditions
+    rename_column :watchers, :unsafe_conditions, :conditions
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_12_13_161648) do
+ActiveRecord::Schema[7.0].define(version: 2023_01_06_201846) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -756,12 +756,12 @@ ActiveRecord::Schema[7.0].define(version: 2022_12_13_161648) do
     t.string "name"
     t.string "check_interval"
     t.string "throttle_period"
-    t.string "conditions"
+    t.string "unsafe_conditions"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false
     t.string "time_window"
     t.string "query_blocklist"
-    t.json "safe_conditions"
+    t.json "conditions"
   end
 
   create_table "youtube_playlists", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|

--- a/spec/models/low_query_ctr_watcher_spec.rb
+++ b/spec/models/low_query_ctr_watcher_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe LowQueryCtrWatcher do
+  subject(:watcher) { described_class.new(watcher_args) }
+
   let(:affiliate) { affiliates(:basic_affiliate) }
   let(:user) { affiliate.users.first }
   let(:watcher_args) do
@@ -19,7 +21,6 @@ describe LowQueryCtrWatcher do
   let(:expected_body) do
     JSON.parse(read_fixture_file('/json/watcher/low_query_ctr_watcher_body.json')).to_json
   end
-  subject(:watcher) { described_class.new(watcher_args) }
 
   it { is_expected.to validate_numericality_of(:search_click_total).only_integer }
   it { is_expected.to validate_numericality_of(:low_ctr_threshold) }
@@ -39,7 +40,8 @@ describe LowQueryCtrWatcher do
   end
 
   describe 'humanized_alert_threshold' do
-    subject(:watcher) { described_class.new(search_click_total: 101, low_ctr_threshold: 15.5 ) }
+    subject(:watcher) { described_class.new(search_click_total: 101, low_ctr_threshold: 15.5) }
+
     it 'returns a human-readable version of the alert threshold(s)' do
       expect(watcher.humanized_alert_threshold).to eq('15.5% CTR on 101 Queries & Clicks')
     end

--- a/spec/models/low_query_ctr_watcher_spec.rb
+++ b/spec/models/low_query_ctr_watcher_spec.rb
@@ -24,10 +24,18 @@ describe LowQueryCtrWatcher do
   it { is_expected.to validate_numericality_of(:search_click_total).only_integer }
   it { is_expected.to validate_numericality_of(:low_ctr_threshold) }
 
-  describe '.conditions' do
-    subject(:conditions) { watcher.conditions }
+  describe 'conditions column accessors' do
+    describe '#low_ctr_threshold' do
+      subject(:low_ctr_threshold) { watcher.low_ctr_threshold }
 
-    it { is_expected.to eq({ low_ctr_threshold: 15.5, search_click_total: 101 }) }
+      it { is_expected.to eq(15.5) }
+    end
+
+    describe '#search_click_total' do
+      subject(:search_click_total) { watcher.search_click_total }
+
+      it { is_expected.to eq(101) }
+    end
   end
 
   describe 'humanized_alert_threshold' do

--- a/spec/models/no_results_watcher_spec.rb
+++ b/spec/models/no_results_watcher_spec.rb
@@ -23,10 +23,12 @@ describe NoResultsWatcher do
 
   it { is_expected.to validate_numericality_of(:distinct_user_total).only_integer }
 
-  describe '.conditions' do
-    subject(:conditions) { watcher.conditions }
+  describe 'conditions column accessors' do
+    describe '#distinct_user_total' do
+      subject(:distinct_user_total) { watcher.distinct_user_total }
 
-    it { is_expected.to eq({ distinct_user_total: 34 }) }
+      it { is_expected.to eq(34) }
+    end
   end
 
   describe 'humanized_alert_threshold' do

--- a/spec/models/no_results_watcher_spec.rb
+++ b/spec/models/no_results_watcher_spec.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 describe NoResultsWatcher do
+  subject(:watcher) { described_class.new(watcher_args) }
+
   let(:affiliate) { affiliates(:basic_affiliate) }
   let(:user) { affiliate.users.first }
   let(:watcher_args) do
@@ -19,8 +21,6 @@ describe NoResultsWatcher do
     JSON.parse(read_fixture_file('/json/watcher/no_results_watcher_body.json')).to_json
   end
 
-  subject(:watcher) { described_class.new(watcher_args) }
-
   it { is_expected.to validate_numericality_of(:distinct_user_total).only_integer }
 
   describe 'conditions column accessors' do
@@ -33,6 +33,7 @@ describe NoResultsWatcher do
 
   describe 'humanized_alert_threshold' do
     subject(:watcher) { described_class.new(distinct_user_total: 34) }
+
     it 'returns a human-readable version of the alert threshold(s)' do
       expect(watcher.humanized_alert_threshold).to eq('34 Queries')
     end

--- a/spec/models/watcher_spec.rb
+++ b/spec/models/watcher_spec.rb
@@ -9,7 +9,9 @@ describe Watcher do
   end
 
   describe 'schema' do
-    it { is_expected.to have_db_column(:safe_conditions).of_type(:json) }
+    it { is_expected.to have_db_column(:conditions).of_type(:json) }
+    # temporary backup column - will be removed per SRCH-3465
+    it { is_expected.to have_db_column(:unsafe_conditions).of_type(:string) }
   end
 
   it { is_expected.to validate_presence_of :name }
@@ -24,11 +26,5 @@ describe Watcher do
 
   %w[5w 30d 800h].each do |value|
     it { is_expected.not_to allow_value(value).for(:time_window) }
-  end
-
-  describe '.conditions' do
-    subject(:conditions) { watcher.conditions }
-
-    it { is_expected.to be_a Hash }
   end
 end

--- a/spec/support/watcher_behavior.rb
+++ b/spec/support/watcher_behavior.rb
@@ -41,4 +41,19 @@ shared_examples_for 'a watcher' do
       expect(execute_watcher['watch_record'].keys).not_to include('exception')
     end
   end
+
+  # The conditions column is a JSON column that will return a hash with string keys:
+  # https://api.rubyonrails.org/classes/ActiveRecord/Store.html
+  # However, the conditions should be accessed via the methods provided by `store_accessor`
+  # in each subclass, rather than directly via the hash. These specs exist mostly as
+  # signposts to help future debuggers.
+  describe '.conditions' do
+    subject(:conditions) { watcher.conditions }
+
+    it { is_expected.to be_a Hash }
+
+    it 'uses string keys' do
+      expect(watcher.conditions.keys).to all be_a(String)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
This PR renames the `watchers.*conditions` columns to use the new JSON column insead of the old, unsafe YAML column. The YAML column will be dropped per SRCH-3465.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
