### PR TITLE
SRCH-3719 remove spec code re. 'pending_contact_information'

### DIFF
--- a/spec/fixtures/users.yml
+++ b/spec/fixtures/users.yml
@@ -120,13 +120,6 @@ never_active_76_days:
   <<: *DEFAULTS
   created_at: <%= 76.days.ago.to_fs(:db) %>
 
-affiliate_manager_with_pending_contact_information_status:
-  <<: *DEFAULTS
-  first_name: Pending Contact Information Affiliate Manager
-  last_name: Smith
-  approval_status: pending_contact_information
-  requires_manual_approval: true
-
 affiliate_manager_with_pending_approval_status:
   <<: *DEFAULTS
   first_name: Pending Approval Affiliate Manager

--- a/spec/support/shared_sites_controller_shared_behavior.rb
+++ b/spec/support/shared_sites_controller_shared_behavior.rb
@@ -16,15 +16,6 @@ shared_examples 'restricted to approved user' do |request_method, action, parame
       expect(response).to redirect_to(account_path)
     end
   end
-
-  describe 'when user is pending contact information status' do
-    before { UserSession.create(users(:affiliate_manager_with_pending_contact_information_status)) }
-
-    it 'redirects to affiliates page' do
-      send request_method, action, params: parameters
-      expect(response).to redirect_to(account_path)
-    end
-  end
 end
 
 shared_context 'approved user logged in' do


### PR DESCRIPTION
## Summary
This PR removes some spec code for the User status `pending_contact_information`, as that status was deprecated in 2013:
https://github.com/GSA/search-gov/commit/9fe3154a5a4a6552a800ec554c71118b2a5f3bda#diff-9802ca3c9c4cf89904fd44bc114e35ebdf2c5dd3d5b645491e2b253e1afef29b
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
