### PR TITLE
SRCH-3728 Add Jest tests to CircleCI and push Jest coverage metrics to Code Climate

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -255,7 +255,6 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            mkdir /tmp/test-results
             ./cc-test-reporter before-build
 
             # Run jest tests

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -269,13 +269,6 @@ jobs:
           paths:
           - codeclimate.jest.*.json
 
-      # collect reports
-      - store_test_results:
-          path: /tmp/test-results
-      - store_artifacts:
-          path: /tmp/test-results
-          destination: test-results
-
   report_coverage:
     parameters:
       ruby_version:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -230,20 +230,23 @@ jobs:
 
   jest:
     parameters:
+      ruby_version:
+        type: string
+      elasticsearch_version:
+        type: string
       node_version:
         type: string
 
-    # executor: 
-    #   name: test_executor
-    #   node_version: << parameters.node_version >>
-
-    # parallelism: 10
+    executor: 
+      name: test_executor
+      ruby_version: << parameters.ruby_version >>
+      elasticsearch_version: << parameters.elasticsearch_version >>
 
     steps:
       - restore_cache:
           key: repo-{{ .Environment.CIRCLE_SHA1 }}
 
-      - node/install:
+      - nodejs/install:
           install-yarn: true
           node-version: << parameters.node_version >>
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,7 +298,7 @@ jobs:
       - run:
           name: Report coverage to Code Climate
           command: |
-            ./cc-test-reporter sum-coverage --parts 16 \
+            ./cc-test-reporter sum-coverage --parts 17 \
               coverage/codeclimate.*.json \
               --output coverage/codeclimate_full_report.json
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
   install_js_dependencies:
     description: 'Install JavaScript dependencies'
     steps:
-      - run: yarn install
+      - run: yarn install --frozen-lockfile
   precompile_assets:
     description: 'Pre-compile assets'
     steps:
@@ -299,7 +299,7 @@ jobs:
           name: Report coverage to Code Climate
           command: |
             ./cc-test-reporter sum-coverage --parts 16 \
-              coverage/codeclimate.*.<< parameters.ruby_version >>_<< parameters.elasticsearch_version >>.json \
+              coverage/codeclimate.*.json \
               --output coverage/codeclimate_full_report.json
 
             ./cc-test-reporter upload-coverage --input coverage/codeclimate_full_report.json

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,8 @@ jobs:
           install-yarn: true
           node-version: << parameters.node_version >>
 
+      - install_js_dependencies
+
       - run:
           name: Run Tests
           command: |
@@ -260,7 +262,7 @@ jobs:
             yarn test:coverage
 
             ./cc-test-reporter format-coverage \
-              --output coverage/codeclimate.jest.$CIRCLE_NODE_INDEX.<< parameters.node_version >>.json
+              --output coverage/codeclimate.jest.<< parameters.node_version >>.json
 
       - persist_to_workspace:
           root: ~/search-gov/coverage

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ version: 2.1
 orbs:
   ruby: circleci/ruby@1.6.0
   browser-tools: circleci/browser-tools@1.2.5
+  nodejs: circleci/node@5.1.0
 
 executors:
   test_executor:
@@ -227,6 +228,49 @@ jobs:
           path: /tmp/test-results
           destination: test-results
 
+  jest:
+    parameters:
+      node_version:
+        type: string
+
+    # executor: 
+    #   name: test_executor
+    #   node_version: << parameters.node_version >>
+
+    # parallelism: 10
+
+    steps:
+      - restore_cache:
+          key: repo-{{ .Environment.CIRCLE_SHA1 }}
+
+      - node/install:
+          install-yarn: true
+          node-version: << parameters.node_version >>
+
+      - run:
+          name: Run Tests
+          command: |
+            mkdir /tmp/test-results
+            ./cc-test-reporter before-build
+
+            # Run jest tests
+            yarn test:coverage
+
+            ./cc-test-reporter format-coverage \
+              --output coverage/codeclimate.jest.$CIRCLE_NODE_INDEX.<< parameters.node_version >>.json
+
+      - persist_to_workspace:
+          root: ~/search-gov/coverage
+          paths:
+          - codeclimate.jest.*.json
+
+      # collect reports
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results
+
   report_coverage:
     parameters:
       ruby_version:
@@ -293,10 +337,24 @@ workflows:
               elasticsearch_version:
                 - 7.17.7
 
+      - jest:
+          requires:
+            - checkout_code
+          name: "jest: NodeJS << matrix.node_version >>"
+          matrix:
+            parameters:
+              ruby_version:
+                - 2.7.5
+              elasticsearch_version:
+                - 7.17.7
+              node_version:
+                - 16.18.1
+
       - report_coverage:
           requires:
             - rspec
             - cucumber
+            - jest
           name: "report coverage: Ruby << matrix.ruby_version >>, ES << matrix.elasticsearch_version >>"
           matrix:
             # We only report coverage for one run, as the coverage will be


### PR DESCRIPTION
## Summary
This PR adds Jest JavaScript tests to the CircleCI pipeline. A coverage report is generated for Jest tests, and the `report results` job has been updated to include coverage data from Jest.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
