### PR TITLE
SRCH-3783 replace awesome_print with amazing_print

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -179,7 +179,9 @@ group :development, :test do
   gem 'pry-byebug', '~> 3.5'
   gem 'faker', '~> 1.8'
   gem 'pry-rails', '~> 0.3.6'
-  gem 'awesome_print'
+  # For improved console readability:
+  # https://github.com/amazing-print/amazing_print
+  gem 'amazing_print', '~> 1.4'
   gem 'puma', '~> 5.3'
   gem 'debug'
   gem 'bootsnap', '~> 1.13', require: 'bootsnap/setup'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,6 +196,7 @@ GEM
     after_commit_action (1.1.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
+    amazing_print (1.4.0)
     american_date (1.1.1)
     ast (2.4.2)
     authlogic (6.4.2)
@@ -203,7 +204,6 @@ GEM
       activerecord (>= 5.2, < 7.1)
       activesupport (>= 5.2, < 7.1)
       request_store (~> 1.0)
-    awesome_print (1.9.2)
     aws-eventstream (1.2.0)
     aws-partitions (1.699.0)
     aws-sdk-core (3.169.0)
@@ -867,9 +867,9 @@ DEPENDENCIES
   activerecord-validate_unique_child_attribute
   addressable (~> 2.8.0)
   after_commit_action (~> 1.1)
+  amazing_print (~> 1.4)
   american_date (~> 1.1.1)
   authlogic (~> 6.4.1)
-  awesome_print
   aws-sdk-s3 (~> 1.102.0)
   bootsnap (~> 1.13)
   capybara (~> 3.26)


### PR DESCRIPTION
## Summary
- This PR replaces the development gem `awesome_print` with `amazing_print` to avoid errors related to `awesome_print`, which is no longer maintained.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- ⚠️  Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
@danswick , this is another PR hung up on Circle Ci. The branch has passed CI:
https://app.circleci.com/pipelines/github/MothOnMars/search-gov/2670/workflows/8428b8c9-46cf-49d8-af46-b26ab16b796b
 
#### Process Checks

- [ ] You have specified at least one "Reviewer".
