### PR TITLE
SRCH-3788 lock selenium-webdriver to 4.7.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -105,7 +105,10 @@ gem 'active_scheduler', '~> 0.7.0'
 gem 'retriable', '~> 3.1'
 gem 'cld3', '~> 3.4.3'
 gem 'activejob-uniqueness', '~> 0.2.1'
-gem 'selenium-webdriver'
+# Temporarily locking the version to resolve SRCH-3788.
+# The fix for the bug in SRCH-3788 is NOT covered by automated specs.
+# A spec will be added (if possible) per SRCH-3790
+gem 'selenium-webdriver', '4.7.1'
 gem 'webdrivers', '~> 5.0'
 gem 'exception_notification', '~> 4.5'
 gem 'dogapi', '~> 1.45'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -751,7 +751,7 @@ GEM
       rubocop-rake (~> 0.5)
       rubocop-rspec (~> 2.5)
     select2-rails (4.0.13)
-    selenium-webdriver (4.8.0)
+    selenium-webdriver (4.7.1)
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
@@ -964,7 +964,7 @@ DEPENDENCIES
   saxerator (~> 0.9.9)
   searchgov_style (~> 0.1)
   select2-rails (~> 4.0.3)
-  selenium-webdriver
+  selenium-webdriver (= 4.7.1)
   shakapacker (= 6.5.4)
   shoulda-kept-assign-to (~> 1.1)
   shoulda-matchers (~> 5.0)


### PR DESCRIPTION
## Summary
This PR prevents the `SearchgovDomainIndexerJob` from opening a new database connection each time the job is run for a domain that is using Javascript rendering.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
