### PR TITLE
SRCH-3421 push custom Docker images for Ruby 3.0.5

### DIFF
--- a/.circleci/images/primary/Dockerfile.ruby275
+++ b/.circleci/images/primary/Dockerfile.ruby275
@@ -1,3 +1,5 @@
+# This Dockerfile can be removed once system wide update is done with Ruby 3.0
+
 FROM cimg/ruby:2.7.5-browsers
 
 USER root

--- a/.circleci/images/primary/Dockerfile.ruby305
+++ b/.circleci/images/primary/Dockerfile.ruby305
@@ -1,0 +1,10 @@
+FROM cimg/ruby:3.0.5-browsers
+
+USER root
+
+RUN apt-get update && apt-get install -y \
+  default-mysql-client \
+  libprotobuf-dev \
+  protobuf-compiler
+
+USER circleci


### PR DESCRIPTION
## Summary
- This PR contains the new Docker image for `Ruby-3.0.5`
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
