### PR TITLE
SRCH-3895 limit "popular" analytics buckets to 50k

### DIFF
--- a/app/models/rtu_popular_raw_human_array.rb
+++ b/app/models/rtu_popular_raw_human_array.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class RtuPopularRawHumanArray
-  MAX_RESULTS = 1000000
+  MAX_RESULTS = 50_000
   RESULTS_SIZE = 10
   INSUFFICIENT_DATA = "Not enough historic data to compute most popular"
 

--- a/app/models/rtu_popular_raw_human_array.rb
+++ b/app/models/rtu_popular_raw_human_array.rb
@@ -3,26 +3,30 @@
 class RtuPopularRawHumanArray
   MAX_RESULTS = 50_000
   RESULTS_SIZE = 10
-  INSUFFICIENT_DATA = "Not enough historic data to compute most popular"
+  INSUFFICIENT_DATA = 'Not enough historic data to compute most popular'
 
   def initialize(site_name, start_date, end_date, num_results = RESULTS_SIZE)
-    @site_name, @start_date, @end_date, @num_results = site_name, start_date, end_date, num_results
+    @site_name = site_name
+    @start_date = start_date
+    @end_date = end_date
+    @num_results = num_results
   end
 
   def most_popular
     return INSUFFICIENT_DATA if @end_date.nil? or @start_date.nil?
+
     date_range_top_n_query = DateRangeTopNQuery.new(*query_args)
     rtu_most_popular = query_class.new(date_range_top_n_query.body, false)
     raw_cnt_arr = rtu_most_popular.top_n
     rtu_human_most_popular = query_class.new(date_range_top_n_query.body, true)
-    human_cnt_hash = Hash[rtu_human_most_popular.top_n]
+    human_cnt_hash = rtu_human_most_popular.top_n.to_h
     return INSUFFICIENT_DATA if human_cnt_hash.empty?
+
     raw_human_arr = raw_cnt_arr.map do |popular_term, raw_count|
       human_count = human_cnt_hash[popular_term] || 0
       [popular_term, raw_count, human_count]
     end
     raw_human_arr.sort_by { |a| -a.last }.first(@num_results)
-
   end
 
   private

--- a/spec/models/rtu_click_raw_human_array_spec.rb
+++ b/spec/models/rtu_click_raw_human_array_spec.rb
@@ -13,7 +13,7 @@ describe RtuClickRawHumanArray do
           'click',
           Date.current,
           Date.current,
-          { field: 'params.url', size: 1_000_000 }
+          { field: 'params.url', size: 50_000 }
         ]
       end
 

--- a/spec/models/rtu_query_raw_human_array_spec.rb
+++ b/spec/models/rtu_query_raw_human_array_spec.rb
@@ -15,7 +15,7 @@ describe RtuQueryRawHumanArray do
           'search',
           Date.current,
           Date.current,
-          { field: 'params.query.raw', size: 1_000_000 }
+          { field: 'params.query.raw', size: 50_000 }
         ]
       end
 


### PR DESCRIPTION
## Summary
Follow-up to a similar PR: https://github.com/GSA/search-gov/pull/1135

This PR fixes a production bug caused by our upgrade to Elasticsearch 7, in which sites with more than ~65k unique queries in a year were unable to generate yearly reports. This limits the # of "popular" queries or clicks to the top 50k, which is under the cluster max_buckets limit of 65,546. (The fixes for the two issues are quite similar, and there *may* be opportunity for DRYing up the code. However, the analytics code is not covered very well by automated tests, so I erred on the side of making minimal changes.)
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
