### PR TITLE
SRCH-3921 Lock version of URI gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,8 @@ gem 'dogapi', '~> 1.45'
 # https://github.com/ruby/net-protocol/issues/10
 # This gem can be removed once we upgrade to Ruby 3.1.
 gem 'net-http'
+# Temporary fix for a gem version mismatch with Fullstaq Ruby.
+# This will be removed once we upgrade to Ruby 3.x in SRCH-3862.
 gem 'uri', '= 0.10.0'
 
 # Assets-related gems

--- a/Gemfile
+++ b/Gemfile
@@ -123,6 +123,7 @@ gem 'dogapi', '~> 1.45'
 # https://github.com/ruby/net-protocol/issues/10
 # This gem can be removed once we upgrade to Ruby 3.1.
 gem 'net-http'
+gem 'uri', '= 0.10.0'
 
 # Assets-related gems
 gem 'coffee-rails', '~> 5.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -849,7 +849,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
-    uri (0.12.0)
+    uri (0.10.0)
     validate_url (0.2.0)
       activemodel (>= 3.0.0)
     vcr (6.1.0)
@@ -1003,6 +1003,7 @@ DEPENDENCIES
   twitter-typeahead-rails (~> 0.11.1)
   typhoeus (~> 1.3.0)
   uglifier (~> 4.2.0)
+  uri (= 0.10.0)
   validate_url (= 0.2.0)
   vcr (~> 6.0)
   virtus (~> 1.0.5)


### PR DESCRIPTION
## Summary
This PR temporarily locks the version of `uri` to resolve an error seen with Fullstaq Ruby 2.7.5. This will be removed once we upgrade to Fullstaq Ruby 3.x.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
