### PR TITLE
SRCH-3923 Create I14y search options

### DIFF
--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -131,6 +131,10 @@ module Api
         respond_with({ errors: @search_options.errors.full_messages }, { status: 400 })
       end
 
+      # SRCH-3923: Temporarily disabling cop as at least one of these search classes (gss)
+      # is slated for removal, and another is current not used (docs). Future refactoring here
+      # is a given, and at that time this cop should be reenabled.
+      # rubocop:disable Metrics/CyclomaticComplexity
       def search_options_validator_klass
         case action_name.to_sym
         when :azure then Api::CommercialSearchOptions
@@ -142,6 +146,7 @@ module Api
         when :docs then Api::DocsSearchOptions
         end
       end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       def log_search_impression
         SearchImpression.log(@search, action_name, search_params, request)

--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -126,9 +126,9 @@ module Api
 
       def validate_search_options
         @search_options = search_options_validator_klass.new(search_params)
-        unless @search_options.valid? && @search_options.valid?(:affiliate)
-          respond_with({ errors: @search_options.errors.full_messages }, { status: 400 })
-        end
+        return if @search_options.valid? && @search_options.valid?(:affiliate)
+
+        respond_with({ errors: @search_options.errors.full_messages }, { status: 400 })
       end
 
       def search_options_validator_klass
@@ -136,7 +136,8 @@ module Api
         when :azure then Api::CommercialSearchOptions
         when :azure_web then Api::AzureCompositeWebSearchOptions
         when :azure_image then Api::AzureCompositeImageSearchOptions
-        when :blended, :i14y, :video then Api::NonCommercialSearchOptions
+        when :blended, :video then Api::NonCommercialSearchOptions
+        when :i14y then Api::I14ySearchOptions
         when :gss then Api::GssSearchOptions
         when :docs then Api::DocsSearchOptions
         end

--- a/lib/api/i14y_search_options.rb
+++ b/lib/api/i14y_search_options.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+class Api::I14ySearchOptions < Api::SearchOptions
+  attr_accessor :audience,
+                :content_type,
+                :mime_type,
+                :searchgov_custom1,
+                :searchgov_custom2,
+                :searchgov_custom3,
+                :sort_by,
+                :tags
+
+  # SRCH-3615: Disabling cop temporarily as facets work is ongoing and will continue to involve
+  # modifications to this method.
+  # rubocop:disable Metrics/AbcSize
+  def initialize(params = {})
+    super
+    self.audience = params[:audience]
+    self.content_type = params[:content_type]
+    self.mime_type = params[:mime_type]
+    self.searchgov_custom1 = params[:searchgov_custom1]
+    self.searchgov_custom2 = params[:searchgov_custom2]
+    self.searchgov_custom3 = params[:searchgov_custom3]
+    self.sort_by = params[:sort_by]
+    self.tags = params[:tags]
+  end
+  # rubocop:enable Metrics/AbcSize
+
+  def attributes
+    super.merge({ audience: audience,
+                  content_type: content_type,
+                  mime_type: mime_type,
+                  searchgov_custom1: searchgov_custom1,
+                  searchgov_custom2: searchgov_custom2,
+                  searchgov_custom3: searchgov_custom3,
+                  sort_by: sort_by,
+                  tags: tags })
+  end
+end

--- a/lib/api/non_commercial_search_options.rb
+++ b/lib/api/non_commercial_search_options.rb
@@ -1,40 +1,14 @@
 # frozen_string_literal: true
 
 class Api::NonCommercialSearchOptions < Api::SearchOptions
+  attr_accessor :sort_by
 
-  attr_accessor :audience,
-                :content_type,
-                :mime_type,
-                :searchgov_custom1,
-                :searchgov_custom2,
-                :searchgov_custom3,
-                :sort_by,
-                :tags
-
-  # SRCH-3615: Disabling cop temporarily as facets work is ongoing and will continue to involve
-  # modifications to this method.
-  # rubocop:disable Metrics/AbcSize
   def initialize(params = {})
     super
-    self.audience = params[:audience]
-    self.content_type = params[:content_type]
-    self.mime_type = params[:mime_type]
-    self.searchgov_custom1 = params[:searchgov_custom1]
-    self.searchgov_custom2 = params[:searchgov_custom2]
-    self.searchgov_custom3 = params[:searchgov_custom3]
     self.sort_by = params[:sort_by]
-    self.tags = params[:tags]
   end
-  # rubocop:enable Metrics/AbcSize
 
   def attributes
-    super.merge({ audience: audience,
-                  content_type: content_type,
-                  mime_type: mime_type,
-                  searchgov_custom1: searchgov_custom1,
-                  searchgov_custom2: searchgov_custom2,
-                  searchgov_custom3: searchgov_custom3,
-                  sort_by: sort_by,
-                  tags: tags })
+    super.merge({ sort_by: sort_by })
   end
 end

--- a/spec/lib/api/i14y_search_options_spec.rb
+++ b/spec/lib/api/i14y_search_options_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe Api::I14ySearchOptions do
+  describe '#attributes' do
+    it 'includes sort_by option' do
+      options = described_class.new sort_by: 'date'
+      expect(options.attributes).to include(sort_by: 'date')
+    end
+
+    it 'includes tags option' do
+      options = described_class.new tags: 'tag1, tag2'
+      expect(options.attributes).to include(tags: 'tag1, tag2')
+    end
+  end
+
+  it 'includes audience option' do
+    options = described_class.new audience: 'everyone'
+    expect(options.attributes).to include(audience: 'everyone')
+  end
+
+  it 'includes content_type option' do
+    options = described_class.new content_type: 'article'
+    expect(options.attributes).to include(content_type: 'article')
+  end
+
+  it 'includes mime_type option' do
+    options = described_class.new mime_type: 'application/pdf'
+    expect(options.attributes).to include(mime_type: 'application/pdf')
+  end
+
+  it 'includes searchgov_custom1 option' do
+    options = described_class.new searchgov_custom1: 'custom1'
+    expect(options.attributes).to include(searchgov_custom1: 'custom1')
+  end
+
+  it 'includes searchgov_custom2 option' do
+    options = described_class.new searchgov_custom2: 'custom2'
+    expect(options.attributes).to include(searchgov_custom2: 'custom2')
+  end
+
+  it 'includes searchgov_custom3 option' do
+    options = described_class.new searchgov_custom3: 'custom3'
+    expect(options.attributes).to include(searchgov_custom3: 'custom3')
+  end
+end

--- a/spec/lib/api/non_commercial_search_options_spec.rb
+++ b/spec/lib/api/non_commercial_search_options_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe Api::NonCommercialSearchOptions do
   describe '#attributes' do
@@ -6,40 +6,5 @@ describe Api::NonCommercialSearchOptions do
       options = described_class.new sort_by: 'date'
       expect(options.attributes).to include(sort_by: 'date')
     end
-
-    it 'includes tags option' do
-      options = described_class.new tags: 'tag1, tag2'
-      expect(options.attributes).to include(tags: 'tag1, tag2')
-    end
-  end
-
-  it 'includes audience option' do
-    options = described_class.new audience: 'everyone'
-    expect(options.attributes).to include(audience: 'everyone')
-  end
-
-  it 'includes content_type option' do
-    options = described_class.new content_type: 'article'
-    expect(options.attributes).to include(content_type: 'article')
-  end
-
-  it 'includes mime_type option' do
-    options = described_class.new mime_type: 'application/pdf'
-    expect(options.attributes).to include(mime_type: 'application/pdf')
-  end
-
-  it 'includes searchgov_custom1 option' do
-    options = described_class.new searchgov_custom1: 'custom1'
-    expect(options.attributes).to include(searchgov_custom1: 'custom1')
-  end
-
-  it 'includes searchgov_custom2 option' do
-    options = described_class.new searchgov_custom2: 'custom2'
-    expect(options.attributes).to include(searchgov_custom2: 'custom2')
-  end
-
-  it 'includes searchgov_custom3 option' do
-    options = described_class.new searchgov_custom3: 'custom3'
-    expect(options.attributes).to include(searchgov_custom3: 'custom3')
   end
 end


### PR DESCRIPTION
## Summary
- Moves I14y api search options out of the shared `Api::NonCommercialSearchOptions` and into its own `Api::I14ySearchOptions`
- As mentioned on [this code review](https://github.com/GSA/search-gov/pull/1079#pullrequestreview-1233217226), we risk confusion by continuing to add api search options to this shared class that are not expected to have any impact on blended and video searches
- Making this change now, before adding more i14y-only search options - namely, date filtering
- Added specs to confirm options are dropped when they are not recognized attributes for the specific class
- Also includes additional rubocop-necessitated changes/comments
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
:warning: Though, note, one cop has been disabled inline for reasons discussed in the comment
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
