### PR TITLE
SRCH-3797 Add ruby 3.0.5 to test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@
 version: 2.1
 
 orbs:
-  ruby: circleci/ruby@1.6.0
+  ruby: circleci/ruby@2.0.0
   browser-tools: circleci/browser-tools@1.2.5
   nodejs: circleci/node@5.1.0
 
@@ -290,7 +290,7 @@ jobs:
       - run:
           name: Report coverage to Code Climate
           command: |
-            ./cc-test-reporter sum-coverage --parts 17 \
+            ./cc-test-reporter sum-coverage --parts 33 \
               coverage/codeclimate.*.json \
               --output coverage/codeclimate_full_report.json
 
@@ -308,6 +308,7 @@ workflows:
             parameters:
               ruby_version:
                 - 2.7.5
+                - 3.0.5
               elasticsearch_version:
                 - 7.17.7
                 # not yet compatible with Elasticsearch 8
@@ -320,6 +321,7 @@ workflows:
             parameters:
               ruby_version:
                 - 2.7.5
+                - 3.0.5
               elasticsearch_version:
                 - 7.17.7
 
@@ -331,6 +333,7 @@ workflows:
             parameters:
               ruby_version:
                 - 2.7.5
+                - 3.0.5
               elasticsearch_version:
                 - 7.17.7
 


### PR DESCRIPTION
## Summary
- Adds ruby 3.0.5 to the CircleCI test matrix for rspec and cucumber (leaving at the current/prod version of 2.7.5 for jest for the time being as this should be updated up as part of SRCH-3884);
- Bumps the ruby orb version to current latest;
- Increases the number of report parts as needed:
  - cucumber parallelism 10 x 2 test matrices = 20
  - rspec parallelism 6 x 2 test matrices = 12
  - jest run = 1
  - summed up == 33 parts
- Cucumber/rspec all green for both versions of ruby
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
