### PR TITLE
SRCH-3922 Add date filtering to Results API

### DIFF
--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -96,6 +96,8 @@ module Api
                                          :api_key,
                                          :audience,
                                          :content_type,
+                                         :created_since,
+                                         :created_until,
                                          :cx, # SRCH-1429 This will be removed as GSS is deprecated
                                          :dc,
                                          :enable_highlighting,
@@ -116,7 +118,9 @@ module Api
                                          :searchgov_custom3,
                                          :sitelimit,
                                          :sort_by,
-                                         :tags).to_h
+                                         :tags,
+                                         :updated_since,
+                                         :updated_until).to_h
 
         # Mirrors param key renaming done for browser-based searches.
         # See: app/controllers/application_controller.rb #search_options_from_params

--- a/app/models/filterable_search.rb
+++ b/app/models/filterable_search.rb
@@ -52,14 +52,14 @@ class FilterableSearch < Search
 
     return unless (@since.nil? && @until.nil?) || (@created_since.nil? && @created_until.nil?)
 
-    time_based_search(options)
+    time_based_search(options[:tbs])
   end
 
-  def time_based_search(options)
-    extent = TIME_BASED_SEARCH_OPTIONS[options[:tbs]]
+  def time_based_search(tbs)
+    extent = TIME_BASED_SEARCH_OPTIONS[tbs]
     return unless extent
 
-    @tbs = options[:tbs]
+    @tbs = tbs
     @since = since_when(extent)
   end
 

--- a/app/models/i14y_search.rb
+++ b/app/models/i14y_search.rb
@@ -17,7 +17,7 @@ class I14ySearch < FilterableSearch
 
   def initialize(options = {})
     super
-    @enable_highlighting = !(false === options[:enable_highlighting])
+    @enable_highlighting = options[:enable_highlighting] != false
     @include_facets = options[:include_facets] == 'true'
     @collection = options[:document_collection]
     @site_limits = options[:site_limits]
@@ -71,6 +71,8 @@ class I14ySearch < FilterableSearch
     filter_options[:sort_by_date] = 1 if @sort_by == 'date'
     filter_options[:min_timestamp] = @since if @since
     filter_options[:max_timestamp] = @until if @until
+    filter_options[:min_timestamp_created] = @created_since if @created_since
+    filter_options[:max_timestamp_created] = @created_until if @created_until
   end
 
   def facet_filter_options(filter_options)

--- a/lib/api/i14y_search_options.rb
+++ b/lib/api/i14y_search_options.rb
@@ -3,12 +3,23 @@
 class Api::I14ySearchOptions < Api::SearchOptions
   attr_accessor :audience,
                 :content_type,
+                :created_since_date,
+                :created_until_date,
                 :mime_type,
                 :searchgov_custom1,
                 :searchgov_custom2,
                 :searchgov_custom3,
+                :since_date,
                 :sort_by,
-                :tags
+                :tags,
+                :until_date
+
+  # SRCH-3922: Very basic first-pass date validation, not tackling localization at this time
+  # rubocop:disable Rails/I18nLocaleTexts
+  validates :created_since_date, :created_until_date, :since_date, :until_date,
+            exclusion: { in: ['invalid date'],
+                         message: 'must be in YYYY-mm-dd format' }
+  # rubocop:enable Rails/I18nLocaleTexts
 
   # SRCH-3615: Disabling cop temporarily as facets work is ongoing and will continue to involve
   # modifications to this method.
@@ -23,17 +34,37 @@ class Api::I14ySearchOptions < Api::SearchOptions
     self.searchgov_custom3 = params[:searchgov_custom3]
     self.sort_by = params[:sort_by]
     self.tags = params[:tags]
+    initialize_date_fields(params)
   end
   # rubocop:enable Metrics/AbcSize
+
+  def initialize_date_fields(params)
+    self.created_since_date = modify_date_string(params[:created_since]) if params[:created_since]
+    self.created_until_date = modify_date_string(params[:created_until]) if params[:created_until]
+    self.since_date = modify_date_string(params[:updated_since]) if params[:updated_since]
+    self.until_date = modify_date_string(params[:updated_until]) if params[:updated_until]
+  end
 
   def attributes
     super.merge({ audience: audience,
                   content_type: content_type,
+                  created_since_date: created_since_date,
+                  created_until_date: created_until_date,
                   mime_type: mime_type,
                   searchgov_custom1: searchgov_custom1,
                   searchgov_custom2: searchgov_custom2,
                   searchgov_custom3: searchgov_custom3,
+                  since_date: since_date,
                   sort_by: sort_by,
-                  tags: tags })
+                  tags: tags,
+                  until_date: until_date })
+  end
+
+  private
+
+  def modify_date_string(date)
+    Date.parse(date).strftime(I18n.t(:cdr_format))
+  rescue
+    'invalid date'
   end
 end

--- a/spec/controllers/api/v2/searches_controller_spec.rb
+++ b/spec/controllers/api/v2/searches_controller_spec.rb
@@ -1,4 +1,4 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe Api::V2::SearchesController do
   let(:affiliate) { affiliates(:basic_affiliate) }
@@ -67,17 +67,16 @@ describe Api::V2::SearchesController do
     end
 
     context 'when the search options are valid' do
-      let!(:search) { double(ApiAzureSearch, as_json: { foo: 'bar'}, modules: %w(AWEB)) }
+      let!(:search) { instance_double(ApiAzureSearch, as_json: { foo: 'bar' }, modules: %w[AWEB]) }
 
       before do
-        expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
-
-        expect(ApiAzureSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
-        expect(search).to receive(:run)
-        expect(SearchImpression).to receive(:log).with(search,
-                                                       'azure',
-                                                       hash_including('query'),
-                                                       be_a(ActionDispatch::Request))
+        allow(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(ApiAzureSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
+        allow(search).to receive(:run)
+        allow(SearchImpression).to receive(:log).with(search,
+                                                      'azure',
+                                                      hash_including('query'),
+                                                      be_a(ActionDispatch::Request))
 
         get :azure, params: search_params
       end
@@ -91,7 +90,7 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        expect(RoutedQueryImpressionLogger).to receive(:log).
+        allow(RoutedQueryImpressionLogger).to receive(:log).
           with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :azure, params: search_params.merge(query: 'moar unclaimed money')
@@ -117,18 +116,17 @@ describe Api::V2::SearchesController do
     end
 
     context 'when the search options are valid' do
-      let!(:search) { double(ApiAzureCompositeWebSearch, as_json: { foo: 'bar'}, modules: %w(AZCW)) }
+      let!(:search) { instance_double(ApiAzureCompositeWebSearch, as_json: { foo: 'bar' }, modules: %w[AZCW]) }
 
       before do
-        expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
-
-        expect(ApiAzureCompositeWebSearch).to receive(:new).
+        allow(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(ApiAzureCompositeWebSearch).to receive(:new).
           with(hash_including(query_params)).and_return(search)
-        expect(search).to receive(:run)
-        expect(SearchImpression).to receive(:log).with(search,
-                                                       'azure_web',
-                                                       hash_including('query'),
-                                                       be_a(ActionDispatch::Request))
+        allow(search).to receive(:run)
+        allow(SearchImpression).to receive(:log).with(search,
+                                                      'azure_web',
+                                                      hash_including('query'),
+                                                      be_a(ActionDispatch::Request))
 
         get :azure_web, params: search_params
       end
@@ -142,7 +140,7 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        expect(RoutedQueryImpressionLogger).to receive(:log).
+        allow(RoutedQueryImpressionLogger).to receive(:log).
           with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :azure_web, params: search_params.merge(query: 'moar unclaimed money')
@@ -168,18 +166,17 @@ describe Api::V2::SearchesController do
     end
 
     context 'when the search options are valid' do
-      let!(:search) { double(ApiAzureCompositeImageSearch, as_json: { foo: 'bar'}, modules: %w(AZCI)) }
+      let!(:search) { instance_double(ApiAzureCompositeImageSearch, as_json: { foo: 'bar' }, modules: %w[AZCI]) }
 
       before do
-        expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
-
-        expect(ApiAzureCompositeImageSearch).to receive(:new).
+        allow(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(ApiAzureCompositeImageSearch).to receive(:new).
           with(hash_including(query_params)).and_return(search)
-        expect(search).to receive(:run)
-        expect(SearchImpression).to receive(:log).with(search,
-                                                       'azure_image',
-                                                       hash_including('query'),
-                                                       be_a(ActionDispatch::Request))
+        allow(search).to receive(:run)
+        allow(SearchImpression).to receive(:log).with(search,
+                                                      'azure_image',
+                                                      hash_including('query'),
+                                                      be_a(ActionDispatch::Request))
 
         get :azure_image, params: search_params
       end
@@ -193,7 +190,7 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        expect(RoutedQueryImpressionLogger).to receive(:log).
+        allow(RoutedQueryImpressionLogger).to receive(:log).
           with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :azure_image, params: search_params.merge(query: 'moar unclaimed money')
@@ -225,17 +222,16 @@ describe Api::V2::SearchesController do
     end
 
     context 'when the search options are valid' do
-      let!(:search) { double(ApiGssSearch, as_json: { foo: 'bar'}, modules: %w(GWEB)) }
+      let!(:search) { instance_double(ApiGssSearch, as_json: { foo: 'bar' }, modules: %w[GWEB]) }
 
       before do
-        expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
-
-        expect(ApiGssSearch).to receive(:new).with(hash_including(query: 'api')).and_return(search)
-        expect(search).to receive(:run)
-        expect(SearchImpression).to receive(:log).with(search,
-                                                       'gss',
-                                                       hash_including('query'),
-                                                       be_a(ActionDispatch::Request))
+        allow(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(ApiGssSearch).to receive(:new).with(hash_including(query: 'api')).and_return(search)
+        allow(search).to receive(:run)
+        allow(SearchImpression).to receive(:log).with(search,
+                                                      'gss',
+                                                      hash_including('query'),
+                                                      be_a(ActionDispatch::Request))
 
         get :gss, params: gss_params
       end
@@ -249,7 +245,7 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        expect(RoutedQueryImpressionLogger).to receive(:log).
+        allow(RoutedQueryImpressionLogger).to receive(:log).
           with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :gss, params: gss_params.merge(query: 'moar unclaimed money')
@@ -369,6 +365,34 @@ describe Api::V2::SearchesController do
         end
       end
 
+      context 'when updated date filters are present' do
+        let(:params_with_updated_dates) do
+          search_params.
+            merge(updated_since: '2020-01-01', updated_until: '2022-01-01')
+        end
+
+        it 'passes the tags filter to its ApiI14ySearch object' do
+          get :i14y, params: params_with_updated_dates
+          expect(assigns(:search_options).attributes).
+            to include({ since_date: '01/01/2020',
+                         until_date: '01/01/2022' })
+        end
+      end
+
+      context 'when created date filters are present' do
+        let(:params_with_created_dates) do
+          search_params.
+            merge(created_since: '2020-01-01', created_until: '2022-01-01')
+        end
+
+        it 'passes the tags filter to its ApiI14ySearch object' do
+          get :i14y, params: params_with_created_dates
+          expect(assigns(:search_options).attributes).
+            to include({ created_since_date: '01/01/2020',
+                         created_until_date: '01/01/2022' })
+        end
+      end
+
       context 'when a sitelimit filter is present' do
         let(:params_with_sitelimit) { search_params.merge(sitelimit: 'nps.gov') }
 
@@ -457,7 +481,7 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        expect(RoutedQueryImpressionLogger).to receive(:log).
+        allow(RoutedQueryImpressionLogger).to receive(:log).
           with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :video, params: search_params.merge(query: 'moar unclaimed money')
@@ -485,21 +509,19 @@ describe Api::V2::SearchesController do
     end
 
     context 'when the search options are valid, the affiliate is using BingV6, and the collection is deep' do
-      let!(:search) { double(ApiI14ySearch, as_json: { foo: 'bar'}, modules: %w(I14Y)) }
-      let!(:document_collection) { double(DocumentCollection, too_deep_for_bing?: true) }
+      let!(:search) { instance_double(ApiI14ySearch, as_json: { foo: 'bar' }, modules: %w[I14Y]) }
+      let!(:document_collection) { instance_double(DocumentCollection, too_deep_for_bing?: true) }
 
       before do
-        expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(Affiliate).to receive(:find_by_name).and_return(affiliate)
         allow(affiliate).to receive(:search_engine).and_return('BingV6')
-
-        expect(DocumentCollection).to receive(:find).and_return(document_collection)
-
-        expect(ApiI14ySearch).to receive(:new).with(hash_including(query_params)).and_return(search)
-        expect(search).to receive(:run)
-        expect(SearchImpression).to receive(:log).with(search,
-                                                       'docs',
-                                                       hash_including('query'),
-                                                       be_a(ActionDispatch::Request))
+        allow(DocumentCollection).to receive(:find).and_return(document_collection)
+        allow(ApiI14ySearch).to receive(:new).with(hash_including(query_params)).and_return(search)
+        allow(search).to receive(:run)
+        allow(SearchImpression).to receive(:log).with(search,
+                                                      'docs',
+                                                      hash_including('query'),
+                                                      be_a(ActionDispatch::Request))
 
         get :docs, params: docs_params
       end
@@ -512,18 +534,17 @@ describe Api::V2::SearchesController do
     end
 
     context 'when the search options are valid and the affiliate is using Google' do
-      let!(:search) { double(ApiGoogleDocsSearch, as_json: { foo: 'bar'}, modules: %w(GWEB)) }
+      let!(:search) { instance_double(ApiGoogleDocsSearch, as_json: { foo: 'bar' }, modules: %w[GWEB]) }
 
       before do
-        expect(Affiliate).to receive(:find_by_name).and_return(affiliate)
+        allow(Affiliate).to receive(:find_by_name).and_return(affiliate)
         allow(affiliate).to receive(:search_engine).and_return('Google')
-
-        expect(ApiGoogleDocsSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
-        expect(search).to receive(:run)
-        expect(SearchImpression).to receive(:log).with(search,
-                                                       'docs',
-                                                       hash_including('query'),
-                                                       be_a(ActionDispatch::Request))
+        allow(ApiGoogleDocsSearch).to receive(:new).with(hash_including(query_params)).and_return(search)
+        allow(search).to receive(:run)
+        allow(SearchImpression).to receive(:log).with(search,
+                                                      'docs',
+                                                      hash_including('query'),
+                                                      be_a(ActionDispatch::Request))
 
         get :docs, params: docs_params
       end
@@ -537,7 +558,7 @@ describe Api::V2::SearchesController do
 
     context 'when a routed query term is matched' do
       before do
-        expect(RoutedQueryImpressionLogger).to receive(:log).
+        allow(RoutedQueryImpressionLogger).to receive(:log).
           with(affiliate, 'moar unclaimed money', an_instance_of(ActionController::TestRequest))
 
         get :docs, params: docs_params.merge(query: 'moar unclaimed money')

--- a/spec/lib/api/i14y_search_options_spec.rb
+++ b/spec/lib/api/i14y_search_options_spec.rb
@@ -11,35 +11,68 @@ describe Api::I14ySearchOptions do
       options = described_class.new tags: 'tag1, tag2'
       expect(options.attributes).to include(tags: 'tag1, tag2')
     end
+
+    it 'includes audience option' do
+      options = described_class.new audience: 'everyone'
+      expect(options.attributes).to include(audience: 'everyone')
+    end
+
+    it 'includes content_type option' do
+      options = described_class.new content_type: 'article'
+      expect(options.attributes).to include(content_type: 'article')
+    end
+
+    it 'includes mime_type option' do
+      options = described_class.new mime_type: 'application/pdf'
+      expect(options.attributes).to include(mime_type: 'application/pdf')
+    end
+
+    it 'includes searchgov_custom1 option' do
+      options = described_class.new searchgov_custom1: 'custom1'
+      expect(options.attributes).to include(searchgov_custom1: 'custom1')
+    end
+
+    it 'includes searchgov_custom2 option' do
+      options = described_class.new searchgov_custom2: 'custom2'
+      expect(options.attributes).to include(searchgov_custom2: 'custom2')
+    end
+
+    it 'includes searchgov_custom3 option' do
+      options = described_class.new searchgov_custom3: 'custom3'
+      expect(options.attributes).to include(searchgov_custom3: 'custom3')
+    end
+
+    it 'includes updated dates options in m/d/y format' do
+      options = described_class.new updated_since: '2020-01-01', updated_until: '2021-01-01'
+      expect(options.attributes).
+        to include(since_date: '01/01/2020', until_date: '01/01/2021')
+    end
+
+    it 'includes created dates options in m/d/y format' do
+      options = described_class.new created_since: '2020-01-01', created_until: '2021-01-01'
+      expect(options.attributes).
+        to include(created_since_date: '01/01/2020', created_until_date: '01/01/2021')
+    end
   end
 
-  it 'includes audience option' do
-    options = described_class.new audience: 'everyone'
-    expect(options.attributes).to include(audience: 'everyone')
-  end
+  describe 'validations' do
+    let(:required_params) do
+      {
+        access_key: 'my_access_key',
+        affiliate: 'my_site_handle',
+        query: 'my query'
+      }
+    end
 
-  it 'includes content_type option' do
-    options = described_class.new content_type: 'article'
-    expect(options.attributes).to include(content_type: 'article')
-  end
+    it 'rejects invalid date parameters' do
+      options = described_class.new(required_params.merge(updated_since: 'not a date'))
+      expect(options).not_to be_valid
+      expect(options.errors.full_messages).to include('since_date must be in YYYY-mm-dd format')
+    end
 
-  it 'includes mime_type option' do
-    options = described_class.new mime_type: 'application/pdf'
-    expect(options.attributes).to include(mime_type: 'application/pdf')
-  end
-
-  it 'includes searchgov_custom1 option' do
-    options = described_class.new searchgov_custom1: 'custom1'
-    expect(options.attributes).to include(searchgov_custom1: 'custom1')
-  end
-
-  it 'includes searchgov_custom2 option' do
-    options = described_class.new searchgov_custom2: 'custom2'
-    expect(options.attributes).to include(searchgov_custom2: 'custom2')
-  end
-
-  it 'includes searchgov_custom3 option' do
-    options = described_class.new searchgov_custom3: 'custom3'
-    expect(options.attributes).to include(searchgov_custom3: 'custom3')
+    it 'accepts valid date parameters' do
+      options = described_class.new(required_params.merge(created_until: '2020-01-01'))
+      expect(options).to be_valid
+    end
   end
 end

--- a/spec/support/filterable_search_behavior.rb
+++ b/spec/support/filterable_search_behavior.rb
@@ -1,92 +1,100 @@
 # frozen_string_literal: true
 
 shared_examples 'an initialized filterable search' do
-  context 'when since_date and until_date are valid' do
-    subject(:test_search) do
-      described_class.new filterable_search_options.
-        merge(since_date: '8/20/2012',
-              until_date: '11/30/2014')
-    end
+  context 'when date based filtering' do
+    # Testing since_date/until_date and created_since_date/created_until_date in parallel.
+    # The existing `since_date` and `until_date` functionality refers to the publication_date for
+    # blended and news searches, and updated_date for i14y. `created_since_date` and `created_until_date`
+    # only pertains (at the moment) to i14y searches.
+    (%w[created_] << '').each do |date_type|
+      context "when #{date_type}since_date and #{date_type}until_date are valid" do
+        subject(:test_search) do
+          described_class.new filterable_search_options.
+            merge("#{date_type}since_date": '8/20/2012',
+                  "#{date_type}until_date": '11/30/2014')
+        end
 
-    let(:expected_since) { DateTime.parse('2012-08-20T00:00:00Z') }
-    let(:expected_until) { DateTime.parse('2014-11-30T23:59:59.999999999Z') }
+        let(:expected_since) { DateTime.parse('2012-08-20T00:00:00Z') }
+        let(:expected_until) { DateTime.parse('2014-11-30T23:59:59.999999999Z') }
 
-    its(:since) { is_expected.to eq(expected_since) }
-    its(:until) { is_expected.to eq(expected_until) }
-  end
-
-  context 'when since_date is invalid and until_date is valid' do
-    subject(:test_search) do
-      described_class.new filterable_search_options.
-        merge(since_date: '20/20/2012',
-              until_date: '11/30/2014')
-    end
-
-    let(:expected_since) { DateTime.parse('2013-11-30T00:00:00Z') }
-    let(:expected_until) { DateTime.parse('2014-11-30T23:59:59.999999999Z') }
-
-    its(:since) { is_expected.to eq(expected_since) }
-    its(:until) { is_expected.to eq(expected_until) }
-  end
-
-  context 'when since_date is invalid and until_date is blank' do
-    subject(:test_search) do
-      described_class.new filterable_search_options.
-        merge(since_date: '20/20/2012',
-              until_date: '')
-    end
-
-    let(:expected_since) { DateTime.current.prev_year.beginning_of_day }
-
-    its(:since) { is_expected.to eq(expected_since) }
-    its(:until) { is_expected.to be_nil }
-  end
-
-  context 'when until_date is invalid' do
-    subject(:test_search) do
-      described_class.new filterable_search_options.
-        merge(since_date: '8/20/2012',
-              until_date: '20/30/2014')
-    end
-
-    let(:expected_since) { DateTime.parse('2012-08-20T00:00:00Z') }
-    let(:expected_until) { DateTime.current.end_of_day }
-
-    its(:since) { is_expected.to eq(expected_since) }
-    its(:until) { is_expected.to eq(expected_until) }
-  end
-
-  context 'when since_date is > until_date' do
-    subject(:test_search) do
-      described_class.new filterable_search_options.
-        merge(since_date: '12/25/2014',
-              until_date: '10/18/2012')
-    end
-
-    let(:expected_since) { DateTime.parse('2012-10-18T00:00:00Z') }
-    let(:expected_until) { DateTime.parse('2014-12-25T23:59:59.999999999Z') }
-
-    its(:since) { is_expected.to eq(expected_since) }
-    its(:until) { is_expected.to eq(expected_until) }
-  end
-
-  context 'when locale is set to :es' do
-    before(:all) { I18n.locale = :es }
-
-    after(:all) { I18n.locale = I18n.default_locale }
-
-    context 'when the since_date and until_date params are valid' do
-      subject(:test_search) do
-        described_class.new filterable_search_options.
-          merge(since_date: '25/12/2014',
-                until_date: '18/10/2012')
+        its(:"#{date_type}since") { is_expected.to eq(expected_since) }
+        its(:"#{date_type}until") { is_expected.to eq(expected_until) }
       end
 
-      let(:expected_since) { DateTime.parse('2012-10-18T00:00:00Z') }
-      let(:expected_until) { DateTime.parse('2014-12-25T23:59:59.999999999Z') }
+      context "when #{date_type}since_date is invalid and #{date_type}until_date is valid" do
+        subject(:test_search) do
+          described_class.new filterable_search_options.
+            merge("#{date_type}since_date": '20/20/2012',
+                  "#{date_type}until_date": '11/30/2014')
+        end
 
-      its(:since) { is_expected.to eq(expected_since) }
-      its(:until) { is_expected.to eq(expected_until) }
+        let(:expected_since) { DateTime.parse('2013-11-30T00:00:00Z') }
+        let(:expected_until) { DateTime.parse('2014-11-30T23:59:59.999999999Z') }
+
+        its(:"#{date_type}since") { is_expected.to eq(expected_since) }
+        its(:"#{date_type}until") { is_expected.to eq(expected_until) }
+      end
+
+      context "when #{date_type}since_date is invalid and #{date_type}until_date is blank" do
+        subject(:test_search) do
+          described_class.new filterable_search_options.
+            merge("#{date_type}since_date": '20/20/2012',
+                  "#{date_type}until_date": '')
+        end
+
+        let(:expected_since) { DateTime.current.prev_year.beginning_of_day }
+
+        its(:"#{date_type}since") { is_expected.to eq(expected_since) }
+        its(:"#{date_type}until") { is_expected.to be_nil }
+      end
+
+      context "when #{date_type}until_date is invalid" do
+        subject(:test_search) do
+          described_class.new filterable_search_options.
+            merge("#{date_type}since_date": '8/20/2012',
+                  "#{date_type}until_date": '20/30/2014')
+        end
+
+        let(:expected_since) { DateTime.parse('2012-08-20T00:00:00Z') }
+        let(:expected_until) { DateTime.current.end_of_day }
+
+        its(:"#{date_type}since") { is_expected.to eq(expected_since) }
+        its(:"#{date_type}until") { is_expected.to eq(expected_until) }
+      end
+
+      context "when #{date_type}since_date is > #{date_type}until_date" do
+        subject(:test_search) do
+          described_class.new filterable_search_options.
+            merge("#{date_type}since_date": '12/25/2014',
+                  "#{date_type}until_date": '10/18/2012')
+        end
+
+        let(:expected_since) { DateTime.parse('2012-10-18T00:00:00Z') }
+        let(:expected_until) { DateTime.parse('2014-12-25T23:59:59.999999999Z') }
+
+        its(:"#{date_type}since") { is_expected.to eq(expected_since) }
+        its(:"#{date_type}until") { is_expected.to eq(expected_until) }
+      end
+
+      context 'when locale is set to :es' do
+        before(:all) { I18n.locale = :es }
+
+        after(:all) { I18n.locale = I18n.default_locale }
+
+        context "when the #{date_type}since_date and #{date_type}until_date params are valid" do
+          subject(:test_search) do
+            described_class.new filterable_search_options.
+              merge("#{date_type}since_date": '25/12/2014',
+                    "#{date_type}until_date": '18/10/2012')
+          end
+
+          let(:expected_since) { DateTime.parse('2012-10-18T00:00:00Z') }
+          let(:expected_until) { DateTime.parse('2014-12-25T23:59:59.999999999Z') }
+
+          its(:"#{date_type}since") { is_expected.to eq(expected_since) }
+          its(:"#{date_type}until") { is_expected.to eq(expected_until) }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds date filtering functionality to the I14y Results API (has no impact on other Results API searches);
- Mild refactoring of `app/models/filterable_search.rb` to break out various bits of logic in `initialize_date_attributes`
- Basic date validation in `lib/api/i14y_search_options.rb`
- New tests
- Rubocop tidying, especially in spec/controllers/api/v2/searches_controller_spec.rb
- See comments in SRCH-3806 investigation for more on the decisions the influenced this implementation
- Acceptance testing is already spelled out in SRCH-3922 if you want to further interrogate the expected behavior
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
