### PR TITLE
SRCH-3929 Redact PII from request params in logs

### DIFF
--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -6,3 +6,10 @@
 Rails.application.config.filter_parameters += [
   :passw, :secret, :token, :_key, :crypt, :salt, :certificate, :otp, :ssn
 ]
+
+# SRCH-3929: Filter the exact 'q' parameter for sayt searches, filter potentially sensitive
+# information from the 'query' parameter.
+Rails.application.config.filter_parameters += [ /\Aq\z/ ]
+Rails.application.config.filter_parameters += [->(k, v) { 
+  v&.gsub!(v, Redactor.redact(v)) if /query/.match?(k)
+}]

--- a/spec/config/initializers/filter_parameter_logging_spec.rb
+++ b/spec/config/initializers/filter_parameter_logging_spec.rb
@@ -9,18 +9,22 @@ describe 'ActiveSupport::ParameterFilter' do
   end
 
   it 'filters sayt q parameter' do
-    expect(parameter_filter.filter({ 'q' => 'bar' })).to eq({ 'q' => '[FILTERED]' })
+    expect(parameter_filter.filter({ 'q' => 'bar' })).
+      to eq({ 'q' => '[FILTERED]' })
   end
 
   it 'redacts queries that may contain social security numbers' do
-    expect(parameter_filter.filter({ 'query' => '111-11-1111 tax return' })).to eq({ 'query' => 'REDACTED_SSN tax return' })
+    expect(parameter_filter.filter({ 'query' => '111-11-1111 tax return' })).
+      to eq({ 'query' => 'REDACTED_SSN tax return' })
   end
 
   it 'redacts queries that may contain email addresses' do
-    expect(parameter_filter.filter({ 'query' => 'contact someone@gsa.gov' })).to eq({ 'query' => 'contact REDACTED_EMAIL' })
+    expect(parameter_filter.filter({ 'query' => 'contact someone@gsa.gov' })).
+      to eq({ 'query' => 'contact REDACTED_EMAIL' })
   end
 
   it 'does not redact non-sensitive queries' do
-    expect(parameter_filter.filter({ 'query' => 'safe query' })).to eq({ 'query' => 'safe query' })
+    expect(parameter_filter.filter({ 'query' => 'safe query' })).
+      to eq({ 'query' => 'safe query' })
   end
 end

--- a/spec/config/initializers/filter_parameter_logging_spec.rb
+++ b/spec/config/initializers/filter_parameter_logging_spec.rb
@@ -9,18 +9,18 @@ describe 'ActiveSupport::ParameterFilter' do
   end
 
   it 'filters sayt q parameter' do
-    expect(parameter_filter.filter({ 'q' => 'bar' })).
-      to eq({ 'q' => '[FILTERED]' })
+    expect(parameter_filter.filter('q' => 'bar')).
+      to eq('q' => '[FILTERED]')
   end
 
   it 'redacts queries that may contain social security numbers' do
-    expect(parameter_filter.filter({ 'query' => '111-11-1111 tax return' })).
-      to eq({ 'query' => 'REDACTED_SSN tax return' })
+    expect(parameter_filter.filter('query' => '111-11-1111 tax return')).
+      to eq('query' => 'REDACTED_SSN tax return')
   end
 
   it 'redacts queries that may contain email addresses' do
-    expect(parameter_filter.filter({ 'query' => 'contact someone@gsa.gov' })).
-      to eq({ 'query' => 'contact REDACTED_EMAIL' })
+    expect(parameter_filter.filter('query' => 'contact someone@gsa.gov')).
+      to eq('query' => 'contact REDACTED_EMAIL')
   end
 
   it 'does not redact non-sensitive queries' do

--- a/spec/config/initializers/filter_parameter_logging_spec.rb
+++ b/spec/config/initializers/filter_parameter_logging_spec.rb
@@ -24,7 +24,7 @@ describe 'ActiveSupport::ParameterFilter' do
   end
 
   it 'does not redact non-sensitive queries' do
-    expect(parameter_filter.filter({ 'query' => 'safe query' })).
-      to eq({ 'query' => 'safe query' })
+    expect(parameter_filter.filter('query' => 'safe query')).
+      to eq('query' => 'safe query')
   end
 end

--- a/spec/config/initializers/filter_parameter_logging_spec.rb
+++ b/spec/config/initializers/filter_parameter_logging_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+describe 'ActiveSupport::ParameterFilter' do
+  let(:config) { Usasearch::Application.config }
+  let(:parameter_filter) { ActiveSupport::ParameterFilter.new(config.filter_parameters) }
+
+  it 'filters passwords from logs' do
+    expect(config.filter_parameters).to match(array_including(/passw/))
+  end
+
+  it 'filters sayt q parameter' do
+    expect(parameter_filter.filter({ 'q' => 'bar' })).to eq({ 'q' => '[FILTERED]' })
+  end
+
+  it 'redacts queries that may contain social security numbers' do
+    expect(parameter_filter.filter({ 'query' => '111-11-1111 tax return' })).to eq({ 'query' => 'REDACTED_SSN tax return' })
+  end
+
+  it 'redacts queries that may contain email addresses' do
+    expect(parameter_filter.filter({ 'query' => 'contact someone@gsa.gov' })).to eq({ 'query' => 'contact REDACTED_EMAIL' })
+  end
+
+  it 'does not redact non-sensitive queries' do
+    expect(parameter_filter.filter({ 'query' => 'safe query' })).to eq({ 'query' => 'safe query' })
+  end
+end


### PR DESCRIPTION
## Summary
- Two additions to `filtered_parameter_logging` to ensure potentially sensitive queries do not end up in our searchgov logs:
 - Fully filters the `q` param to ensure sayt searches don't divulge sensitive information;
 - Runs the values of the `query` parameters through `Redactor.redact` to ensure potentially sensitive strings (and _only_ potentially sensitive strings) are redacted
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
