### PR TITLE
SRCH-4072 Replace gem github-markdown with redcarpet

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ gem 'validate_url', '= 0.2.0' # Newer versions use Addressable::URI for validati
 gem 'elasticsearch', git: 'https://github.com/GSA/elasticsearch-ruby', branch: '7.4'
 gem 'elasticsearch-xpack', '~> 7.4.0'
 gem 'federal_register', '~> 0.6.3'
-gem 'github-markdown', '~> 0.6.9'
+gem 'redcarpet', '~> 3.6'
 gem 'google-api-client', '~> 0.53.0'
 gem 'iso8601', '~> 0.10.1'
 gem 'jbuilder', '~> 2.11.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -409,7 +409,6 @@ GEM
       raabro (~> 1.4)
     gems (1.2.0)
     geoip (1.6.4)
-    github-markdown (0.6.9)
     globalid (1.1.0)
       activesupport (>= 5.0)
     google-api-client (0.53.0)
@@ -644,6 +643,7 @@ GEM
       tilt
     recaptcha (4.6.6)
       json
+    redcarpet (3.6.0)
     redis (4.0.3)
     redis-actionpack (5.3.0)
       actionpack (>= 5, < 8)
@@ -922,7 +922,6 @@ DEPENDENCIES
   font-awesome-grunticon-rails!
   font-awesome-rails (~> 4.7.0)
   geoip (~> 1.6.3)
-  github-markdown (~> 0.6.9)
   google-api-client (~> 0.53.0)
   google_visualr!
   googlecharts (~> 1.6.12)
@@ -962,6 +961,7 @@ DEPENDENCIES
   rash_alt (~> 0.4.12)
   react-rails (~> 2.6.2)
   recaptcha (~> 4.6.3)
+  redcarpet (~> 3.6)
   redis (~> 4.0.1)
   redis-namespace (~> 1.6.0)
   redis-rails (~> 5.0.2)

--- a/app/views/sites/click_tracking_api_instructions/_show_md.html.haml
+++ b/app/views/sites/click_tracking_api_instructions/_show_md.html.haml
@@ -31,14 +31,16 @@
 
   Please note that we only support the `application/x-www-form-urlencoded` content type. A full example is below.
 
-  ```
-  curl -i -X POST \
-  -H "Content-Type: application/x-www-form-urlencoded" \
-  -H "Content-Length: 0" \
-  -A "user agent string" \
-  "https://api.gsa.gov/technology/searchgov/v2/clicks/?url=https://foo.gov/clicked&affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&module_code=BOOS&query=test%20query&position=1"
-  ```
+%pre
+  %code
+    :preserve
+      curl -i -X POST \
+      -H "Content-Type: application/x-www-form-urlencoded" \
+      -H "Content-Length: 0" \
+      -A "user agent string" \
+      "https://api.gsa.gov/technology/searchgov/v2/clicks/?url=https://foo.gov/clicked&affiliate=#{h(@site.name)}&access_key=#{h(@site.api_access_key)}&module_code=BOOS&query=test%20query&position=1"
 
+:markdown
   ## Terms of Service
 
   By using this API, you agree to our [Terms of Service](https://search.gov/tos.html).

--- a/config/initializers/markdown.rb
+++ b/config/initializers/markdown.rb
@@ -1,4 +1,4 @@
-require 'github/markdown'
+require 'redcarpet'
 
 module Haml::Filters
   remove_filter 'Markdown'
@@ -7,7 +7,8 @@ module Haml::Filters
     include Haml::Filters::Base
 
     def render(text)
-      ::GitHub::Markdown.render text
+      markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, tables: true)
+      markdown.render(text)
     end
   end
 end


### PR DESCRIPTION
## Summary
- Replaced gem `github-markdown` with `redcarpet`.
- Few tweaks to preserve code block format in `app/views/sites/click_tracking_api_instructions/_show_md.html.haml`
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
