### PR TITLE
SRCH-3666 implement axe accessibility testing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -201,18 +201,20 @@ group :development, :test do
 end
 
 group :test do
+  gem 'axe-core-capybara'
+  gem 'axe-core-cucumber'
   gem 'capybara-screenshot'
-  gem 'simplecov', '~> 0.17.0', require: false
-  gem 'cucumber', '~> 7.1', require: false
   gem 'cucumber-rails', '~> 2.4', require: false
+  gem 'cucumber', '~> 7.1', require: false
+  gem 'rails-controller-testing', '~> 1.0'
   # resque-spec hasn't been supported since 2018. Consider replacing with equivalent
   # functionality from rspec-rails: https://relishapp.com/rspec/rspec-rails/v/5-0/docs/job-specs/job-spec
   gem 'resque_spec', '~> 0.18.0'
-  gem 'shoulda-matchers', '~> 5.0'
+  gem 'rspec_junit_formatter', '~> 0.4'
+  gem 'rspec-activemodel-mocks', '~> 1.1'
   gem 'shoulda-kept-assign-to', '~> 1.1'
+  gem 'shoulda-matchers', '~> 5.0'
+  gem 'simplecov', '~> 0.17.0', require: false
   gem 'vcr', '~> 6.0'
   gem 'webmock', '~> 3.8'
-  gem 'rspec-activemodel-mocks', '~> 1.1'
-  gem 'rspec_junit_formatter', '~> 0.4'
-  gem 'rails-controller-testing', '~> 1.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -226,6 +226,16 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
+    axe-core-api (4.6.0)
+      dumb_delegator
+      virtus
+    axe-core-capybara (4.6.0)
+      axe-core-api
+      dumb_delegator
+    axe-core-cucumber (4.6.0)
+      axe-core-api
+      dumb_delegator
+      virtus
     axiom-types (0.1.1)
       descendants_tracker (~> 0.0.4)
       ice_nine (~> 0.11.0)
@@ -356,6 +366,7 @@ GEM
     dogstatsd-ruby (3.2.0)
     domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
+    dumb_delegator (1.0.0)
     elasticsearch-xpack (7.4.0)
       elasticsearch-api (>= 6)
     em-http-request (1.1.7)
@@ -892,6 +903,8 @@ DEPENDENCIES
   american_date (~> 1.1.1)
   authlogic (~> 6.4.1)
   aws-sdk-s3 (~> 1.102.0)
+  axe-core-capybara
+  axe-core-cucumber
   bootsnap (~> 1.13)
   capybara (~> 3.26)
   capybara-screenshot

--- a/README.md
+++ b/README.md
@@ -162,7 +162,13 @@ Make sure the unit tests, functional and integration tests run:
 
     # Run the JavaScript tests
     $ yarn test
-    
+
+Optionally, to only run Cucumber accessibility tests:
+
+    $ cucumber features/ --tags @a11y
+
+The above will call the axe step defined in `features/support/hooks.rb` for any scenario tagged with the `@a11y` tag (but not `@a11y_wip` as these are expected to fail).
+
 ## Code Coverage
 
 We require 100% code coverage. After running the tests (both RSpec & Cucumber), open `coverage/index.html` in your favorite browser to view the report. You can click around on the files that have < 100% coverage to see what lines weren't exercised.

--- a/features/redesigned_image_search.feature
+++ b/features/redesigned_image_search.feature
@@ -3,7 +3,7 @@ Feature: Image search - redesign
   As a site visitor
   I want to search for images on the redesigned Search page
 
-  @javascript
+  @javascript @a11y @a11y_wip
   Scenario: English Image search
     Given the following Affiliates exist:
       | display_name | name   | contact_email | first_name | last_name | domains        |

--- a/features/redesigned_searches.feature
+++ b/features/redesigned_searches.feature
@@ -3,7 +3,7 @@ Feature: Search - redesign
   As a site visitor
   I want to be able to search for information on the redesigned Search page
 
-  @javascript
+  @javascript @a11y
   Scenario: Search with no query on an affiliate page
     Given the following Affiliates exist:
       | display_name     | name             | contact_email         | first_name | last_name | domains        |
@@ -11,7 +11,7 @@ Feature: Search - redesign
     When I am on bar.gov's redesigned search page
     Then I should see "Please enter a search term in the box above."
 
-  @javascript
+  @javascript @a11y
   Scenario: Searching a domain with Bing results
     Given the following Affiliates exist:
       | display_name     | name             | contact_email         | first_name | last_name | domains        |
@@ -23,7 +23,7 @@ Feature: Search - redesign
     And I should see "https://www.whitehouse.gov/"
     And I should see "Press Secretary Karine Jean-Pierre on the Meeting Between President Joe Biden and President Xi Jinping"
 
-  @javascript
+  @javascript @a11y
   Scenario: Search with I14y results
     Given the following SearchGov Affiliates exist:
       | display_name   | name           | contact_email      | first_name | last_name | domains            |
@@ -36,7 +36,7 @@ Feature: Search - redesign
     And I should see "https://www.healthcare.gov/glossary/marketplace"
     And I should see "More info on Health Insurance"
 
-  @javascript
+  @javascript @a11y
   Scenario: Search with blended results
     Given the following Affiliates exist:
       | display_name | name    | contact_email | first_name | last_name | gets_blended_results    |
@@ -56,7 +56,7 @@ Feature: Search - redesign
     And I should see "http://p.whitehouse.gov/hour.html"
     And I should see "Within the last hour article on item"
 
-  @javascript
+  @javascript @a11y @a11y_wip
   Scenario: News search
     Given the following Affiliates exist:
       | display_name     | name       | contact_email | first_name | last_name |
@@ -74,7 +74,7 @@ Feature: Search - redesign
     And I should see "Second"
     And I should see exactly "2" web search results
 
-  @javascript
+  @javascript @a11y
   Scenario: Docs search
     Given the following Affiliates exist:
       | display_name | name       | contact_email | first_name | last_name | domains |

--- a/features/redesigned_searches.feature
+++ b/features/redesigned_searches.feature
@@ -3,7 +3,7 @@ Feature: Search - redesign
   As a site visitor
   I want to be able to search for information on the redesigned Search page
 
-  @javascript @a11y
+  @javascript @a11y @a11y_wip
   Scenario: Search with no query on an affiliate page
     Given the following Affiliates exist:
       | display_name     | name             | contact_email         | first_name | last_name | domains        |
@@ -11,7 +11,7 @@ Feature: Search - redesign
     When I am on bar.gov's redesigned search page
     Then I should see "Please enter a search term in the box above."
 
-  @javascript @a11y
+  @javascript @a11y @a11y_wip
   Scenario: Searching a domain with Bing results
     Given the following Affiliates exist:
       | display_name     | name             | contact_email         | first_name | last_name | domains        |
@@ -23,7 +23,7 @@ Feature: Search - redesign
     And I should see "https://www.whitehouse.gov/"
     And I should see "Press Secretary Karine Jean-Pierre on the Meeting Between President Joe Biden and President Xi Jinping"
 
-  @javascript @a11y
+  @javascript @a11y @a11y_wip
   Scenario: Search with I14y results
     Given the following SearchGov Affiliates exist:
       | display_name   | name           | contact_email      | first_name | last_name | domains            |
@@ -36,7 +36,7 @@ Feature: Search - redesign
     And I should see "https://www.healthcare.gov/glossary/marketplace"
     And I should see "More info on Health Insurance"
 
-  @javascript @a11y
+  @javascript @a11y @a11y_wip
   Scenario: Search with blended results
     Given the following Affiliates exist:
       | display_name | name    | contact_email | first_name | last_name | gets_blended_results    |
@@ -74,7 +74,7 @@ Feature: Search - redesign
     And I should see "Second"
     And I should see exactly "2" web search results
 
-  @javascript @a11y
+  @javascript @a11y @a11y_wip
   Scenario: Docs search
     Given the following Affiliates exist:
       | display_name | name       | contact_email | first_name | last_name | domains |

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,6 +11,8 @@ require 'cucumber/rails'
 require 'capybara/rails'
 require 'email_spec/cucumber'
 require 'capybara-screenshot/cucumber'
+require 'axe-capybara'
+require 'axe-cucumber-steps'
 
 # Capybara defaults to XPath selectors rather than Webrat's default of CSS3. In
 # order to ease the transition to Capybara we set the default here. If you'd

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -27,3 +27,8 @@ After do |scenario|
   ScenarioStatusTracker.success = false if scenario.failed?
   travel_back
 end
+
+# Run axe tests on scenarios with @a11y tag, but not @a11y_wip tag
+After('@a11y and not @a11y_wip') do
+  step 'the page should be axe clean according to: section508, wcag2aa'
+end


### PR DESCRIPTION
## Summary
- Implements a means to run axe accessibility testing in the two redesigned cucumber features (though the tests are all flagged off - see below);
- Scenarios with an `@a11y` tag (but not an `@a11y_wip` tag) will be subject to accessibility testing in an after hook (defined in `hooks.rb`);
- All existing redesigned pages are currently failing, so the `@a11y_wip` tag has been added... subsequent tickets have been filed to investigate/remedy these failures (SRCH-4012, SRCH-4013, and SRCH-4014);
- Open to discussions on how hooks/tags were applied here -- I was trying to deliver what the ticket requested, but wasn't part of the initial decision making to use tags/hooks.

Also updates the readme per the ACs in the ticket.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
