### PR TITLE
SRCH-4159 reduce SearchgovDomainIndexerJob lock timeout

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,7 +47,7 @@ GIT
 
 GIT
   remote: https://github.com/activescaffold/active_scaffold
-  revision: ccfc9d71d5223b80bdc44ed92d105e09c6987783
+  revision: 5393631fc2b97a7510051da955dcf8b470480d11
   branch: master
   specs:
     active_scaffold (3.6.99)
@@ -184,7 +184,7 @@ GEM
       activesupport (>= 5.2, < 7.1)
       request_store (~> 1.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.749.0)
+    aws-partitions (1.755.0)
     aws-sdk-core (3.171.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
@@ -426,7 +426,7 @@ GEM
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
     httpclient (2.8.3)
-    i18n (1.12.0)
+    i18n (1.13.0)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)
@@ -530,7 +530,7 @@ GEM
     open_uri_redirections (0.2.1)
     os (1.1.4)
     parallel (1.23.0)
-    parser (3.2.2.0)
+    parser (3.2.2.1)
       ast (~> 2.4.1)
     pry (0.14.2)
       coderay (~> 1.1)
@@ -545,7 +545,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.6.2)
-    rack (2.2.6.4)
+    rack (2.2.7)
     rack-contrib (2.1.0)
       rack (~> 2.0)
     rack-cors (1.1.1)
@@ -669,9 +669,9 @@ GEM
       activemodel (>= 3.0)
       activesupport (>= 3.0)
       rspec-mocks (>= 2.99, < 4.0)
-    rspec-core (3.12.1)
+    rspec-core (3.12.2)
       rspec-support (~> 3.12.0)
-    rspec-expectations (3.12.2)
+    rspec-expectations (3.12.3)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-its (1.3.0)

--- a/app/jobs/searchgov_domain_indexer_job.rb
+++ b/app/jobs/searchgov_domain_indexer_job.rb
@@ -6,7 +6,7 @@ class SearchgovDomainIndexerJob < ApplicationJob
   # ensures we respect each website's crawl-delay by fetching URLs one at a time
   # with a delay between them. After a reasonable period of time (lock_ttl), assume
   # something has gone wrong, and unlock the job.
-  unique :until_executing, lock_ttl: 4.hours
+  unique :until_executing, lock_ttl: 30.minutes
 
   def perform(searchgov_domain:, delay:)
     searchgov_domain.searchgov_urls.fetch_required.first&.fetch

--- a/spec/jobs/searchgov_domain_indexer_job_spec.rb
+++ b/spec/jobs/searchgov_domain_indexer_job_spec.rb
@@ -21,7 +21,7 @@ describe SearchgovDomainIndexerJob do
   describe 'job locking options' do
     subject(:lock_options) { described_class.lock_options }
 
-    it { is_expected.to eq(lock_ttl: 4.hours) }
+    it { is_expected.to eq(lock_ttl: 30.minutes) }
   end
 
   context 'when a domain has unfetched urls' do


### PR DESCRIPTION
## Summary
This is a minor follow-up to https://github.com/GSA/search-gov/pull/1194. I realized belatedly that I was being far too conservative with the specified `lock timeout` for the de-duped `SearchgovDomainIndexerJob`s. 30 minutes should be more than sufficient to ensure we are not processing parallel sets of indexing jobs for the same domain.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
