### PR TITLE
SRCH-4068 Drop Twitter-related db tables

### DIFF
--- a/db/migrate/20230426210615_drop_affiliate_twitter_settings.rb
+++ b/db/migrate/20230426210615_drop_affiliate_twitter_settings.rb
@@ -1,0 +1,13 @@
+class DropAffiliateTwitterSettings < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :affiliate_twitter_settings, id: :integer do |t|
+      t.integer "affiliate_id", null: false
+      t.integer "twitter_profile_id", null: false
+      t.boolean "show_lists", default: false, null: false
+      t.datetime "created_at", precision: nil
+      t.datetime "updated_at", precision: nil
+      t.index ["affiliate_id", "twitter_profile_id"], name: "aff_id_tp_id"
+      t.index ["twitter_profile_id"], name: "index_affiliate_twitter_settings_on_twitter_profile_id"
+    end
+  end
+end

--- a/db/migrate/20230426211104_drop_tweets.rb
+++ b/db/migrate/20230426211104_drop_tweets.rb
@@ -1,0 +1,17 @@
+class DropTweets < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :tweets, id: :integer do |t|
+      t.bigint "tweet_id", null: false, unsigned: true
+      t.string "tweet_text"
+      t.bigint "twitter_profile_id", null: false, unsigned: true
+      t.datetime "created_at", precision: nil
+      t.datetime "updated_at", precision: nil
+      t.datetime "published_at", precision: nil
+      t.text "urls", size: :medium
+      t.json "safe_urls"
+      t.index ["published_at"], name: "index_tweets_on_published_at"
+      t.index ["tweet_id"], name: "index_tweets_on_tweet_id", unique: true
+      t.index ["twitter_profile_id"], name: "index_tweets_on_twitter_profile_id"
+    end
+  end
+end

--- a/db/migrate/20230426211256_drop_twitter_lists_twitter_profiles.rb
+++ b/db/migrate/20230426211256_drop_twitter_lists_twitter_profiles.rb
@@ -1,0 +1,10 @@
+class DropTwitterListsTwitterProfiles < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :twitter_lists_twitter_profiles, id: false do |t|
+      t.bigint "twitter_list_id", null: false, unsigned: true
+      t.integer "twitter_profile_id", null: false
+      t.index ["twitter_list_id", "twitter_profile_id"], name: "twitter_list_id_profile_id", unique: true
+      t.index ["twitter_profile_id"], name: "index_twitter_lists_twitter_profiles_on_twitter_profile_id"
+    end
+  end
+end

--- a/db/migrate/20230426211401_drop_twitter_profiles.rb
+++ b/db/migrate/20230426211401_drop_twitter_profiles.rb
@@ -1,0 +1,13 @@
+class DropTwitterProfiles < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :twitter_profiles, id: :integer do |t|
+      t.bigint "twitter_id", null: false, unsigned: true
+      t.string "screen_name"
+      t.datetime "created_at", precision: nil
+      t.datetime "updated_at", precision: nil
+      t.string "profile_image_url", null: false
+      t.string "name", null: false
+      t.index ["twitter_id"], name: "index_twitter_profiles_on_twitter_id", unique: true
+    end
+  end
+end

--- a/db/migrate/20230426211536_drop_twitter_lists.rb
+++ b/db/migrate/20230426211536_drop_twitter_lists.rb
@@ -1,0 +1,14 @@
+class DropTwitterLists < ActiveRecord::Migration[7.0]
+  def change
+    drop_table :twitter_lists, id: false do |t|
+      t.bigint "id", null: false, unsigned: true
+      t.text "member_ids", size: :long
+      t.bigint "last_status_id", default: 1, null: false, unsigned: true
+      t.string "statuses_updated_at"
+      t.datetime "created_at", precision: nil, null: false
+      t.datetime "updated_at", precision: nil, null: false
+      t.json "safe_member_ids"
+      t.index ["id"], name: "index_twitter_lists_on_id", unique: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_01_10_203501) do
+ActiveRecord::Schema[7.0].define(version: 2023_04_26_211536) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -44,16 +44,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_10_203501) do
     t.integer "feature_id", null: false
     t.datetime "created_at", precision: nil, null: false
     t.index ["affiliate_id", "feature_id"], name: "index_affiliate_feature_additions_on_affiliate_id_and_feature_id", unique: true
-  end
-
-  create_table "affiliate_twitter_settings", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.integer "affiliate_id", null: false
-    t.integer "twitter_profile_id", null: false
-    t.boolean "show_lists", default: false, null: false
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.index ["affiliate_id", "twitter_profile_id"], name: "aff_id_tp_id"
-    t.index ["twitter_profile_id"], name: "index_affiliate_twitter_settings_on_twitter_profile_id"
   end
 
   create_table "affiliates", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
@@ -667,48 +657,6 @@ ActiveRecord::Schema[7.0].define(version: 2023_01_10_203501) do
     t.integer "affiliate_id"
     t.index ["affiliate_id"], name: "index_top_searches_on_affiliate_id"
     t.index ["position", "affiliate_id"], name: "index_top_searches_on_position_and_affiliate_id", unique: true
-  end
-
-  create_table "tweets", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "tweet_id", null: false, unsigned: true
-    t.string "tweet_text"
-    t.bigint "twitter_profile_id", null: false, unsigned: true
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.datetime "published_at", precision: nil
-    t.text "urls", size: :medium
-    t.json "safe_urls"
-    t.index ["published_at"], name: "index_tweets_on_published_at"
-    t.index ["tweet_id"], name: "index_tweets_on_tweet_id", unique: true
-    t.index ["twitter_profile_id"], name: "index_tweets_on_twitter_profile_id"
-  end
-
-  create_table "twitter_lists", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "id", null: false, unsigned: true
-    t.text "member_ids", size: :long
-    t.bigint "last_status_id", default: 1, null: false, unsigned: true
-    t.string "statuses_updated_at"
-    t.datetime "created_at", precision: nil, null: false
-    t.datetime "updated_at", precision: nil, null: false
-    t.json "safe_member_ids"
-    t.index ["id"], name: "index_twitter_lists_on_id", unique: true
-  end
-
-  create_table "twitter_lists_twitter_profiles", id: false, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "twitter_list_id", null: false, unsigned: true
-    t.integer "twitter_profile_id", null: false
-    t.index ["twitter_list_id", "twitter_profile_id"], name: "twitter_list_id_profile_id", unique: true
-    t.index ["twitter_profile_id"], name: "index_twitter_lists_twitter_profiles_on_twitter_profile_id"
-  end
-
-  create_table "twitter_profiles", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
-    t.bigint "twitter_id", null: false, unsigned: true
-    t.string "screen_name"
-    t.datetime "created_at", precision: nil
-    t.datetime "updated_at", precision: nil
-    t.string "profile_image_url", null: false
-    t.string "name", null: false
-    t.index ["twitter_id"], name: "index_twitter_profiles_on_twitter_id", unique: true
   end
 
   create_table "url_prefixes", id: :integer, charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|


### PR DESCRIPTION
## Summary
- A follow-on to #1184 , this PR removes 5 db tables related to the now deprecated Twitter functionality;
- Per the discussion in SRCH-505 (a similar removal of instagram columns), the migrations are written to be reversible (however unlikely it is that we would want to reverse them);
- Current production data has been backed up per SRCH-4125.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
