### PR TITLE
SRCH-4171 make hashed_url non-nullable and read-only

### DIFF
--- a/app/models/searchgov_url.rb
+++ b/app/models/searchgov_url.rb
@@ -17,7 +17,7 @@ class SearchgovUrl < ApplicationRecord
                               ]
 
   attr_reader :response, :document, :tempfile
-  attr_readonly :url
+  attr_readonly :hashed_url, :url
 
   validates_associated :searchgov_domain, on: :create
   validates(:searchgov_domain,

--- a/db/migrate/20230504172002_add_index_on_hashed_url.rb
+++ b/db/migrate/20230504172002_add_index_on_hashed_url.rb
@@ -1,0 +1,5 @@
+class AddIndexOnHashedUrl < ActiveRecord::Migration[7.0]
+  def change
+    add_index :searchgov_urls, :hashed_url, unique: true
+  end
+end

--- a/db/migrate/20230504173700_change_hashed_url_to_non_null.rb
+++ b/db/migrate/20230504173700_change_hashed_url_to_non_null.rb
@@ -1,0 +1,5 @@
+class ChangeHashedUrlToNonNull < ActiveRecord::Migration[7.0]
+  def change
+    change_column_null :searchgov_urls, :hashed_url, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2023_05_03_151057) do
+ActiveRecord::Schema[7.0].define(version: 2023_05_04_173700) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -582,7 +582,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_05_03_151057) do
     t.integer "searchgov_domain_id"
     t.datetime "lastmod", precision: nil
     t.boolean "enqueued_for_reindex", default: false, null: false
-    t.string "hashed_url", limit: 64
+    t.string "hashed_url", limit: 64, null: false
+    t.index ["hashed_url"], name: "index_searchgov_urls_on_hashed_url", unique: true
     t.index ["last_crawl_status"], name: "index_searchgov_urls_on_last_crawl_status"
     t.index ["searchgov_domain_id", "enqueued_for_reindex"], name: "searchgov_urls_on_searchgov_domain_id_and_enqueued_for_reindex"
     t.index ["searchgov_domain_id", "last_crawl_status"], name: "index_by_searchgov_domain_id_and_last_crawl_status"

--- a/spec/fixtures/searchgov_urls.yml
+++ b/spec/fixtures/searchgov_urls.yml
@@ -1,23 +1,28 @@
 new:
   url: https://www.agency.gov/new
+  hashed_url: 3c8b54ce13ebc521f293e0f17fb804d9f9a0a15a9896c510641ae7c975441555
 
 outdated:
   url: https://www.agency.gov/outdated
+  hashed_url: 5f6a904a44fb7ccd348f7994963b1950e885a9e78c97fc55a876f9e1f01be9a2
   last_crawled_at: <%= 1.week.ago.to_fs(:db) %>
   lastmod: <%= 1.day.ago.to_fs(:db) %>
 
 current:
   url: https://www.agency.gov/current
+  hashed_url: 6ee2781be00be54fa0c72f08263759db2ba3052ad2624e1d3023e56f043b8a1c
   last_crawled_at: <%= 1.day.ago.to_fs(:db) %>
   lastmod: <%= 1.week.ago.to_fs(:db) %>
 
 enqueued:
   url: https://www.agency.gov/enqueued
+  hashed_url: f03086b21237918bb4b135c38669d8b274b06c070bd56519c9394794202a4b4b
   last_crawled_at: <%= 1.day.ago.to_fs(:db) %>
   lastmod: <%= 1.week.ago.to_fs(:db) %>
   enqueued_for_reindex: true
 
 crawled_more_than_month:
   url: https://www.agency.gov/crawled_more_than_month
+  hashed_url: 367f5717e22c0484a557326a6ff68c8974cf7865e927803739f860c21f0f7456
   last_crawled_at: <%= 45.days.ago.to_fs(:db) %>
   last_crawl_status: 'OK'

--- a/spec/models/searchgov_url_spec.rb
+++ b/spec/models/searchgov_url_spec.rb
@@ -8,6 +8,7 @@ describe SearchgovUrl do
   let(:valid_attributes) { { url: url } }
   let(:searchgov_url) { described_class.new(valid_attributes) }
 
+  it { is_expected.to have_readonly_attribute(:hashed_url) }
   it { is_expected.to have_readonly_attribute(:url) }
 
   describe 'schema' do
@@ -18,7 +19,12 @@ describe SearchgovUrl do
 
     it { is_expected.to have_db_column(:load_time).of_type(:integer) }
     it { is_expected.to have_db_column(:lastmod).of_type(:datetime) }
-    it { is_expected.to have_db_column(:hashed_url).of_type(:string).with_options(limit: 64) }
+
+    it do
+      is_expected.to have_db_column(:hashed_url).
+        of_type(:string).
+        with_options(limit: 64, null: false)
+    end
 
     it {
       is_expected.to have_db_column(:enqueued_for_reindex).
@@ -26,6 +32,7 @@ describe SearchgovUrl do
         with_options(default: false, null: false)
     }
 
+    it { is_expected.to have_db_index(:hashed_url).unique(true) }
     it { is_expected.to have_db_index(:last_crawl_status) }
     it { is_expected.to have_db_index(:url) }
     it { is_expected.to have_db_index([:searchgov_domain_id, :last_crawl_status]) }


### PR DESCRIPTION
## Summary
This is a follow-up to https://github.com/GSA/search-gov/pull/1203, which added the `hashed_url` column to the `SearchgovUrls` table. Once I've set the `hashed_url` values in the production db and purged any duplicates, we'll be able to lock down that column as non-null and enforce unique values via an index.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [ ] You have specified at least one "Reviewer".
