### PR TITLE
SRCH-4241 rescue 'Document already exists' errors

### DIFF
--- a/app/models/searchgov_url.rb
+++ b/app/models/searchgov_url.rb
@@ -179,6 +179,8 @@ class SearchgovUrl < ApplicationRecord
   def index_document
     Rails.logger.info "[Index SearchgovUrl] #{log_data}"
     indexed? ? I14yDocument.update(i14y_params) : I14yDocument.create(i14y_params)
+  rescue I14yDocument::DuplicateID => e
+    Rails.logger.warn("#{e}: #{hashed_url}")
   end
 
   def i14y_params


### PR DESCRIPTION
## Summary
This PR handles the scenario where multiple processes attempt to index the same new SearchgovUrl record simultaneously:
- raise a new custom `I14yDocument::DuplicateID` error when calling `I14yDocument.create` with a pre-existing ID
- rescue and log that error when indexing `SearchgovUrl` records (we don't want to rescue that error in the `I14yDocument` class, as the business logic for some other process creating docs may differ)
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
