### PR TITLE
SRCH 4079 Investigate and remove/bump uri from 0.10.0 to 0.10.0.1 

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -118,7 +118,7 @@ gem 'dogapi', '~> 1.45'
 gem 'net-http'
 # Temporary fix for a gem version mismatch with Fullstaq Ruby.
 # This will be removed once we upgrade to Ruby 3.x in SRCH-3862.
-gem 'uri', '= 0.10.0'
+# gem 'uri', '= 0.10.0'
 
 # Assets-related gems
 gem 'coffee-rails', '~> 5.0.0'

--- a/Gemfile
+++ b/Gemfile
@@ -116,9 +116,6 @@ gem 'dogapi', '~> 1.45'
 # https://github.com/ruby/net-protocol/issues/10
 # This gem can be removed once we upgrade to Ruby 3.1.
 gem 'net-http'
-# Temporary fix for a gem version mismatch with Fullstaq Ruby.
-# This will be removed once we upgrade to Ruby 3.x in SRCH-3862.
-# gem 'uri', '= 0.10.0'
 
 # Assets-related gems
 gem 'coffee-rails', '~> 5.0.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -959,7 +959,6 @@ DEPENDENCIES
   twitter-typeahead-rails (~> 0.11.1)
   typhoeus (~> 1.3.0)
   uglifier (~> 4.2.0)
-  uri (= 0.10.0)
   validate_url (= 0.2.0)
   vcr (~> 6.0)
   virtus (~> 1.0.5)


### PR DESCRIPTION
## Summary
- Initial task was to bump gem version. Since the gem is not required after Ruby 3.x upgrade, removed gem URI from `search-gov`

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [ ] You have specified at least one "Reviewer".
