### PR TITLE
SRCH-4240 Remove unneeded `nil`/`null` attributes from web search results data in SERP redesign

### DIFF
--- a/app/javascript/components/Results/Results.tsx
+++ b/app/javascript/components/Results/Results.tsx
@@ -15,9 +15,9 @@ interface ResultsProps {
       url: string
     },
     description: string,
-    updatedDate: string | null,
-    publishedDate: string | null,
-    thumbnailUrl: string | null
+    updatedDate?: string,
+    publishedDate?: string,
+    thumbnailUrl?: string
   }[] | null;
   additionalResults?: {
     recommendedBy: string;

--- a/app/javascript/components/SearchResultsLayout.tsx
+++ b/app/javascript/components/SearchResultsLayout.tsx
@@ -20,9 +20,9 @@ interface SearchResultsLayoutProps {
         url: string
       },
       description: string,
-      updatedDate: string | null,
-      publishedDate: string | null,
-      thumbnailUrl: string | null
+      updatedDate?: string,
+      publishedDate?: string,
+      thumbnailUrl?: string
     }[] | null;
   } | null;
   additionalResults?: {

--- a/app/javascript/test/SearchResultsLayout.test.tsx
+++ b/app/javascript/test/SearchResultsLayout.test.tsx
@@ -56,7 +56,7 @@ describe('SearchResultsLayout', () => {
   });
 
   it('renders image search results', () => {
-    const resultsData = { totalPages: 2, unboundedResults: true, results: [{ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', thumbnail: { url: 'https://www.search.gov/test_image.png' }, publishedDate: 'May 9th, 2023', updatedDate: 'May 10th, 2023', thumbnailUrl: null }] };
+    const resultsData = { totalPages: 2, unboundedResults: true, results: [{ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', thumbnail: { url: 'https://www.search.gov/test_image.png' }, publishedDate: 'May 9th, 2023', updatedDate: 'May 10th, 2023' }] };
     render(<SearchResultsLayout params={{ query: 'foo' }} resultsData={resultsData} vertical='image' />);
     const resultTitle = screen.getByText(/test result 1/i);
     const img = Array.from(document.getElementsByClassName('result-image')).pop() as HTMLImageElement;

--- a/app/models/i14y_post_processor.rb
+++ b/app/models/i14y_post_processor.rb
@@ -63,8 +63,8 @@ class I14yPostProcessor < ResultsWithBodyAndDescriptionPostProcessor
         description: result['body'],
         updatedDate: parse_result_date(result['changed']),
         publishedDate: parse_result_date(result['published_at']),
-        thumbnailUrl: result['thumbnail_url'] || nil
-      }
+        thumbnailUrl: result['thumbnail_url']
+      }.compact
     end
   end
 end

--- a/app/models/results_with_body_and_description_post_processor.rb
+++ b/app/models/results_with_body_and_description_post_processor.rb
@@ -41,10 +41,7 @@ class ResultsWithBodyAndDescriptionPostProcessor < ResultsPostProcessor
       {
         title: result['title'],
         url: result['url'],
-        description: result['description'] || result['body'],
-        updatedDate: nil,
-        publishedDate: nil,
-        thumbnailUrl: nil
+        description: result['description'] || result['body']
       }
     end
   end

--- a/app/models/web_results_post_processor.rb
+++ b/app/models/web_results_post_processor.rb
@@ -45,10 +45,7 @@ class WebResultsPostProcessor < ResultsPostProcessor
       {
         title: result['title'],
         url: result['unescaped_url'],
-        description: result['content'],
-        updatedDate: nil,
-        publishedDate: nil,
-        thumbnailUrl: nil
+        description: result['content']
       }
     end
   end

--- a/spec/models/results_with_body_and_description_post_processor_spec.rb
+++ b/spec/models/results_with_body_and_description_post_processor_spec.rb
@@ -16,14 +16,6 @@ describe ResultsWithBodyAndDescriptionPostProcessor do
       let(:normalized_results) { described_class.new(results).normalized_results(5) }
     end
 
-    it 'has no published date, updated date, or thumbnaul URL' do
-      normalized_results[:results].each do |result|
-        expect(result[:updatedDate]).to be_nil
-        expect(result[:publishedDate]).to be_nil
-        expect(result[:thumbnailUrl]).to be_nil
-      end
-    end
-
     it 'does not use unbounded pagination' do
       expect(normalized_results[:unboundedResults]).to be false
     end

--- a/spec/models/web_results_post_processor_spec.rb
+++ b/spec/models/web_results_post_processor_spec.rb
@@ -19,14 +19,6 @@ describe WebResultsPostProcessor do
       let(:normalized_results) { post_processor.normalized_results(5) }
     end
 
-    it 'does not have a published date, updated date, or thumbnail URL' do
-      normalized_results[:results].each do |result|
-        expect(result[:publishedDate]).to be_nil
-        expect(result[:updatedDate]).to be_nil
-        expect(result[:thumbnailUrl]).to be_nil
-      end
-    end
-
     it 'uses unbounded pagination' do
       expect(normalized_results[:unboundedResults]).to be true
     end

--- a/spec/support/normalized_results.rb
+++ b/spec/support/normalized_results.rb
@@ -2,7 +2,7 @@
 
 shared_examples 'a search with normalized results' do
   let(:normalized_result_data_keys) { %i[results totalPages unboundedResults] }
-  let(:normalized_result_keys) { %i[description url title updatedDate publishedDate thumbnailUrl] }
+  let(:normalized_result_keys) { %i[description url title] }
   let(:result_count) { 5 }
   let(:total_pages) { 1 }
 
@@ -21,7 +21,7 @@ shared_examples 'a search with normalized results' do
 
     it 'has a normalized set of keys for results' do
       normalized_results[:results].each do |result|
-        expect(result.keys).to contain_exactly(*normalized_result_keys)
+        expect(result.keys).to include(*normalized_result_keys)
       end
     end
 


### PR DESCRIPTION
## Summary
This PR removes `nil`s (which become `null`s in React) from web search results used in the SERP redesign. These values have no use and only clutter up the code.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
