### PR TITLE
SRCH-4243 notify Datadog when the search client fails

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     after_commit_action (1.1.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
-    amazing_print (1.4.0)
+    amazing_print (1.5.0)
     american_date (1.1.1)
     ast (2.4.2)
     authlogic (6.4.2)
@@ -184,13 +184,13 @@ GEM
       activesupport (>= 5.2, < 7.1)
       request_store (~> 1.0)
     aws-eventstream (1.2.0)
-    aws-partitions (1.755.0)
-    aws-sdk-core (3.171.0)
+    aws-partitions (1.768.0)
+    aws-sdk-core (3.173.0)
       aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.651.0)
       aws-sigv4 (~> 1.5)
       jmespath (~> 1, >= 1.6.1)
-    aws-sdk-kms (1.63.0)
+    aws-sdk-kms (1.64.0)
       aws-sdk-core (~> 3, >= 3.165.0)
       aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.102.0)
@@ -199,13 +199,13 @@ GEM
       aws-sigv4 (~> 1.4)
     aws-sigv4 (1.5.2)
       aws-eventstream (~> 1, >= 1.0.2)
-    axe-core-api (4.6.1)
+    axe-core-api (4.7.0)
       dumb_delegator
       virtus
-    axe-core-capybara (4.6.1)
+    axe-core-capybara (4.7.0)
       axe-core-api
       dumb_delegator
-    axe-core-cucumber (4.6.1)
+    axe-core-cucumber (4.7.0)
       axe-core-api
       dumb_delegator
       virtus
@@ -222,7 +222,7 @@ GEM
       msgpack (~> 1.2)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.39.0)
+    capybara (3.39.1)
       addressable
       matrix
       mini_mime (>= 0.1.3)
@@ -268,7 +268,7 @@ GEM
       sass-rails (< 5.1)
       sprockets (< 4.0)
     concurrent-ruby (1.2.2)
-    connection_pool (2.4.0)
+    connection_pool (2.4.1)
     counter_culture (2.9.0)
       activerecord (>= 4.2)
       activesupport (>= 4.2)
@@ -322,7 +322,7 @@ GEM
       database_cleaner-core (~> 2.0.0)
     database_cleaner-core (2.0.1)
     date (3.3.3)
-    debug (1.7.2)
+    debug (1.8.0)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
     declarative (0.0.20)
@@ -491,11 +491,11 @@ GEM
       mime-types-data (~> 3.2015)
     mime-types-data (3.2023.0218.1)
     mini_mime (1.1.2)
-    mini_portile2 (2.8.1)
+    mini_portile2 (2.8.2)
     minitest (5.18.0)
     moneta (1.6.0)
     mono_logger (1.1.2)
-    msgpack (1.7.0)
+    msgpack (1.7.1)
     multi_json (1.15.0)
     multi_test (0.1.2)
     multi_xml (0.6.0)
@@ -517,7 +517,7 @@ GEM
       net-protocol
     newrelic_rpm (8.12.0)
     nio4r (2.5.9)
-    nokogiri (1.14.3)
+    nokogiri (1.14.5)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     omniauth (2.1.1)
@@ -579,7 +579,7 @@ GEM
       nokogiri (>= 1.6)
     rails-html-sanitizer (1.5.0)
       loofah (~> 2.19, >= 2.19.1)
-    rails-i18n (7.0.6)
+    rails-i18n (7.0.7)
       i18n (>= 0.7, < 2)
       railties (>= 6.0.0, < 8)
     rails-observers (0.1.5)
@@ -598,7 +598,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    react-rails (2.7.0)
+    react-rails (2.7.1)
       babel-transpiler (>= 0.7.0)
       connection_pool
       execjs
@@ -630,7 +630,7 @@ GEM
       redis (>= 3.0.0, < 6.0)
     ref (2.0.0)
     regexp_parser (2.8.0)
-    reline (0.3.3)
+    reline (0.3.4)
       io-console (~> 0.5)
     representable (3.2.0)
       declarative (< 0.1.0)
@@ -701,9 +701,9 @@ GEM
       rubocop-ast (>= 1.23.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 3.0)
-    rubocop-ast (1.28.0)
+    rubocop-ast (1.28.1)
       parser (>= 3.2.1.0)
-    rubocop-performance (1.17.1)
+    rubocop-performance (1.18.0)
       rubocop (>= 1.7.0, < 2.0)
       rubocop-ast (>= 0.4.0)
     rubocop-rails (2.19.1)
@@ -773,7 +773,7 @@ GEM
       sprockets (>= 3.0.0)
     sys-uname (1.2.3)
       ffi (~> 1.1)
-    temple (0.10.0)
+    temple (0.10.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     terrapin (0.6.0)
@@ -781,7 +781,7 @@ GEM
     therubyracer (0.12.3)
       libv8 (~> 3.16.14.15)
       ref
-    thor (1.2.1)
+    thor (1.2.2)
     thread_safe (0.3.6)
     tilt (2.1.0)
     timeout (0.3.2)
@@ -806,7 +806,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (2.4.2)
-    uri (0.10.0)
+    uri (0.12.1)
     validate_url (0.2.0)
       activemodel (>= 3.0.0)
     vcr (6.1.0)
@@ -836,7 +836,7 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yui-compressor (0.12.0)
-    zeitwerk (2.6.7)
+    zeitwerk (2.6.8)
 
 PLATFORMS
   ruby

--- a/app/engines/cached_search_api_connection.rb
+++ b/app/engines/cached_search_api_connection.rb
@@ -8,6 +8,9 @@ class CachedSearchApiConnection
   def initialize(namespace, site, cache_duration = DEFAULT_CACHE_DURATION)
     @connection = Faraday.new(site) do |conn|
       conn.request(:json)
+      conn.use(FaradayMiddleware::ExceptionNotifier, [namespace])
+      # raise Faraday::Error on status code 4xx or 5xx
+      conn.response(:raise_error)
       conn.response(:rashify)
       conn.response(:json)
       conn.headers[:user_agent] = 'USASearch'

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,16 +96,6 @@ Rails.application.configure do
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
 
-  # Datadog API client used to send exception data to Datadog.
-  datadog_api_config = Rails.application.secrets.datadog
-  if datadog_api_config[:api_enabled]
-    datadog_api_client = Dogapi::Client.new(datadog_api_config[:api_key], datadog_api_config[:application_key])
-    config.middleware.use ExceptionNotification::Rack,
-    datadog: {
-      client: datadog_api_client
-    }
-  end
-
   # Inserts middleware to perform automatic connection switching.
   # The `database_selector` hash is used to pass options to the DatabaseSelector
   # middleware. The `delay` is used to determine how long to wait after a write

--- a/config/initializers/datadog.rb
+++ b/config/initializers/datadog.rb
@@ -1,0 +1,13 @@
+# Datadog API client used to send exception data to Datadog.
+datadog_api_config = Rails.application.secrets.datadog
+
+if datadog_api_config[:api_enabled]
+  datadog_api_client = Dogapi::Client.new(
+    datadog_api_config[:api_key],
+    datadog_api_config[:application_key]
+  )
+  Rails.application.config.middleware.use ExceptionNotification::Rack,
+  datadog: {
+    client: datadog_api_client
+  }
+end

--- a/config/secrets.yml.dev
+++ b/config/secrets.yml.dev
@@ -21,7 +21,7 @@ secret_keys: &SECRET_KEYS
     web_subscription_id: FILL_THIS_IN_ONCE_WE_HAVE_A_WEB_SUBSCRIPTION_ID
     image_subscription_id: FILL_THIS_IN_ONCE_WE_HAVE_AN_IMAGE_SUBSCRIPTION_ID
   datadog:
-    api_enabled: false
+    api_enabled: true
     api_key: datadogapikey
     application_key: datadogapplicationkey
   email:

--- a/lib/faraday_middleware/exception_notifier.rb
+++ b/lib/faraday_middleware/exception_notifier.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# If we ever need more complex logic, or to include this our other apps, we should
+# move it to a gem: https://github.com/lostisland/faraday/blob/main/docs/middleware/custom.md
+class FaradayMiddleware::ExceptionNotifier < Faraday::Middleware
+  attr_reader :tags
+
+  def initialize(app, tags = [])
+    super(app)
+    @tags = tags
+  end
+
+  def call(env)
+    @app.call(env)
+  rescue Faraday::ClientError => e
+    ExceptionNotifier.notify_exception(e, tags: tags)
+    raise
+  end
+end

--- a/spec/engines/cached_search_api_connection_spec.rb
+++ b/spec/engines/cached_search_api_connection_spec.rb
@@ -41,18 +41,20 @@ describe CachedSearchApiConnection do
         expect(cache).to receive(:read).with(endpoint, params).and_return(response)
       end
 
-      specify { expect(cached_connection.get(endpoint, params)).
-        to eq(CachedSearchApiConnectionResponse.new(response, 'some_cache')) }
+      it 'returns a cached response' do
+        expect(cached_connection.get(endpoint, params)).
+          to eq(CachedSearchApiConnectionResponse.new(response, 'some_cache'))
+      end
     end
 
     context 'on cache miss' do
       before do
-        expect(cache).to receive(:read).with(endpoint, params).and_return(nil)
+        allow(cache).to receive(:read).with(endpoint, params).and_return(nil)
       end
 
       it 'sends outbound request and cache response' do
-        expect(cached_connection.connection).to receive(:get).with(endpoint, params).and_return(response)
-        expect(cache).to receive(:write).with(endpoint, params, response)
+        allow(cached_connection.connection).to receive(:get).with(endpoint, params).and_return(response)
+        allow(cache).to receive(:write).with(endpoint, params, response)
 
         expect(cached_connection.get(endpoint, params)).
           to eq(CachedSearchApiConnectionResponse.new(response, 'none'))

--- a/spec/engines/cached_search_api_connection_spec.rb
+++ b/spec/engines/cached_search_api_connection_spec.rb
@@ -1,8 +1,8 @@
-require 'spec_helper'
+# frozen_string_literal: true
 
 describe CachedSearchApiConnection do
   let(:cache) { double(ApiCache, namespace: 'some_cache') }
-  let(:connection) { described_class.new('my_api', 'http://localhost', 1000) }
+  let(:cached_connection) { described_class.new('my_api', 'http://localhost', 1000) }
   let(:endpoint) { '/search.json' }
   let(:params) { { query: 'gov' } }
   let(:response) { double('response', status: 200 ) }
@@ -11,10 +11,27 @@ describe CachedSearchApiConnection do
     expect(ApiCache).to receive(:new).with('my_api', 1000).and_return(cache)
   end
 
+  describe '#connection' do
+    subject(:connection) { cached_connection.connection }
+
+    it 'uses the desired handlers in the expected order' do
+      expect(connection.builder.handlers).to eq(
+        [
+          FaradayMiddleware::EncodeJson,
+          FaradayMiddleware::ExceptionNotifier,
+          Faraday::Response::RaiseError,
+          FaradayMiddleware::Rashify,
+          FaradayMiddleware::ParseJson,
+          Faraday::Adapter::NetHttpPersistent
+        ]
+      )
+    end
+  end
+
   describe '#basic_auth' do
     it 'delegates to @connection instance variable' do
-      expect(connection.connection).to receive(:basic_auth).with('user', 'pass')
-      connection.basic_auth 'user', 'pass'
+      expect(cached_connection.connection).to receive(:basic_auth).with('user', 'pass')
+      cached_connection.basic_auth 'user', 'pass'
     end
   end
 
@@ -24,7 +41,8 @@ describe CachedSearchApiConnection do
         expect(cache).to receive(:read).with(endpoint, params).and_return(response)
       end
 
-      specify { expect(connection.get(endpoint, params)).to eq(CachedSearchApiConnectionResponse.new(response, 'some_cache')) }
+      specify { expect(cached_connection.get(endpoint, params)).
+        to eq(CachedSearchApiConnectionResponse.new(response, 'some_cache')) }
     end
 
     context 'on cache miss' do
@@ -33,10 +51,11 @@ describe CachedSearchApiConnection do
       end
 
       it 'sends outbound request and cache response' do
-        expect(connection.connection).to receive(:get).with(endpoint, params).and_return(response)
+        expect(cached_connection.connection).to receive(:get).with(endpoint, params).and_return(response)
         expect(cache).to receive(:write).with(endpoint, params, response)
 
-        expect(connection.get(endpoint, params)).to eq(CachedSearchApiConnectionResponse.new(response, 'none'))
+        expect(cached_connection.get(endpoint, params)).
+          to eq(CachedSearchApiConnectionResponse.new(response, 'none'))
       end
     end
   end

--- a/spec/lib/faraday_middleware/exception_notifier_spec.rb
+++ b/spec/lib/faraday_middleware/exception_notifier_spec.rb
@@ -1,0 +1,38 @@
+describe FaradayMiddleware::ExceptionNotifier do
+  let(:connection) do
+    Faraday.new do |faraday|
+      faraday.use  FaradayMiddleware::ExceptionNotifier
+      faraday.adapter :net_http_persistent
+    end
+  end
+
+  context 'when the request fails' do
+    let(:error) { Faraday::ClientError.new('failure') }
+
+    before do
+      allow(ExceptionNotifier).to receive(:notify_exception)
+      stub_request(:any, 'fail.gov').to_raise(error)
+    end
+
+    it 'reports the error' do
+      connection.get 'http://fail.gov' rescue nil
+      expect(ExceptionNotifier).to have_received(:notify_exception).
+        with(error, tags: [])
+    end
+
+    context 'when tags are provided' do
+      let(:connection) do
+        Faraday.new do |faraday|
+          faraday.use  FaradayMiddleware::ExceptionNotifier, ['testing']
+          faraday.adapter :net_http_persistent
+        end
+      end
+
+      it 'sends the tags' do
+        connection.get 'http://fail.gov' rescue nil
+        expect(ExceptionNotifier).to have_received(:notify_exception).
+          with(error, tags: ['testing'])
+      end
+    end
+  end
+end

--- a/spec/lib/faraday_middleware/exception_notifier_spec.rb
+++ b/spec/lib/faraday_middleware/exception_notifier_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe FaradayMiddleware::ExceptionNotifier do
   let(:connection) do
     Faraday.new do |faraday|
@@ -15,7 +17,7 @@ describe FaradayMiddleware::ExceptionNotifier do
     end
 
     it 'reports the error' do
-      connection.get 'http://fail.gov' rescue nil
+      expect { connection.get 'http://fail.gov' }.to raise_error(Faraday::ClientError)
       expect(ExceptionNotifier).to have_received(:notify_exception).
         with(error, tags: [])
     end
@@ -29,7 +31,7 @@ describe FaradayMiddleware::ExceptionNotifier do
       end
 
       it 'sends the tags' do
-        connection.get 'http://fail.gov' rescue nil
+        expect { connection.get 'http://fail.gov' }.to raise_error(Faraday::ClientError)
         expect(ExceptionNotifier).to have_received(:notify_exception).
           with(error, tags: ['testing'])
       end

--- a/spec/models/i14y_search_spec.rb
+++ b/spec/models/i14y_search_spec.rb
@@ -231,7 +231,7 @@ describe I14ySearch do
       expect(a_request(
         :post,
         'https://api.datadoghq.com/api/v1/events?api_key=datadogapikey'
-      ).with { |request| request.body.match?(%r{problem.*i14y}) }).to have_been_made.once
+      ).with { |request| request.body.match?(/problem.*i14y/) }).to have_been_made.once
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -111,6 +111,8 @@ RSpec.configure do |config|
       to_return(status: 200, body: i14y_result)
     stub_request(:get, "#{i14y_api_url}#{i14y_facet_search_params.to_param}").
       to_return(status: 200, body: i14y_facet_result)
+    # Avoid making unnecessary requests to submit any errors encountered in integration tests
+    stub_request(:any, /api.datadoghq.com/)
     OmniAuth.config.mock_auth[:default] = OmniAuth::AuthHash.new({})
   end
 


### PR DESCRIPTION
## Summary
This PR ensures that error information is sent to Datadog when the search client is unable to reach the API host. The errors will be tagged with the namespace of the search API (`I14y`, `bing_v6`, etc.). It also ensures that search connection failures (such as 4xx, 5xx reponses from the various search APIs) will no longer be silent failures.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- ⚠️  Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
The failure is for too many lines of code in `i14y_search_spec.rb`.  The spec I added isn't absolutely necessary in that class, but I wanted at least one integration spec to cover the full stack. We might also disable the "too many lines" check for specs, as that is more appropriate for app code.
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
