### PR TITLE
SRCH-3494 Redirect to /search when SearchGov

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,10 @@ Rails.application.routes.draw do
   concern :active_scaffold_association, ActiveScaffold::Routing::Association.new
   concern :active_scaffold, ActiveScaffold::Routing::Basic.new(association: true)
   get '/search' => 'searches#index', as: :search
+  # SRCH-3494: Do not permit advanced search for sites using the SearchGov search engine
+  constraints(AdvancedSearchesConstraint.new) do
+    get '/search/advanced', to: redirect(path: '/search')
+  end
   get '/search/advanced' => 'searches#advanced', as: :advanced_search
   get '/search/images' => 'image_searches#index', as: :image_search
   get '/search/docs' => 'searches#docs', as: :docs_search

--- a/lib/advanced_searches_constraint.rb
+++ b/lib/advanced_searches_constraint.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class AdvancedSearchesConstraint
+  def matches?(request)
+    'SearchGov'.include?(requested_engine(request))
+  end
+
+  def requested_engine(request)
+    affiliate = request.query_parameters['affiliate']
+    Affiliate.find_by(name: affiliate).search_engine
+  end
+end

--- a/spec/requests/advanced_searches_constraint_spec.rb
+++ b/spec/requests/advanced_searches_constraint_spec.rb
@@ -7,19 +7,17 @@ describe AdvancedSearchesConstraint do
     let(:affiliate) { affiliates(:searchgov_affiliate).name }
 
     it 'issues a redirect' do
-      expect(response.status).to eq(301)
+      expect(response).to have_http_status(:moved_permanently)
     end
 
-    it 'redirects to /search' do
-      expect(response).to redirect_to("/search?affiliate=#{affiliate}")
-    end
+    it { is_expected.to redirect_to("/search?affiliate=#{affiliate}") }
   end
 
   context 'when a BingV7 site' do
     let(:affiliate) { affiliates(:bing_v7_affiliate).name }
 
     it 'does not issue a redirect' do
-      expect(response.status).to eq(200)
+      expect(response).to have_http_status(:ok)
     end
   end
 end

--- a/spec/requests/advanced_searches_constraint_spec.rb
+++ b/spec/requests/advanced_searches_constraint_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+describe AdvancedSearchesConstraint do
+  before { get '/search/advanced', params: { affiliate: affiliate } }
+
+  context 'when a SearchGov site' do
+    let(:affiliate) { affiliates(:searchgov_affiliate).name }
+
+    it 'issues a redirect' do
+      expect(response.status).to eq(301)
+    end
+
+    it 'redirects to /search' do
+      expect(response).to redirect_to("/search?affiliate=#{affiliate}")
+    end
+  end
+
+  context 'when a BingV7 site' do
+    let(:affiliate) { affiliates(:bing_v7_affiliate).name }
+
+    it 'does not issue a redirect' do
+      expect(response.status).to eq(200)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- Adds a constraint that redirects `/search/advanced` to `/search` when the affiliate is a SearchGov affiliate;
- Preserves parameters on redirect;
- Avoids known errors described in story.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
