### PR TITLE
SRCH-4469 Fix undefined method `search_engine`

### DIFF
--- a/lib/advanced_searches_constraint.rb
+++ b/lib/advanced_searches_constraint.rb
@@ -2,11 +2,8 @@
 
 class AdvancedSearchesConstraint
   def matches?(request)
-    'SearchGov'.include?(requested_engine(request))
-  end
-
-  def requested_engine(request)
     affiliate = request.query_parameters['affiliate']
-    Affiliate.find_by(name: affiliate).search_engine
+
+    Affiliate.exists?(name: affiliate, search_engine: 'SearchGov')
   end
 end

--- a/spec/requests/advanced_searches_constraint_spec.rb
+++ b/spec/requests/advanced_searches_constraint_spec.rb
@@ -20,4 +20,10 @@ describe AdvancedSearchesConstraint do
       expect(response).to have_http_status(:ok)
     end
   end
+
+  context 'when affiliate do not exists' do
+    let(:affiliate) { 'nonexistent' }
+
+    it { is_expected.not_to have_http_status(:internal_server_error) }
+  end
 end


### PR DESCRIPTION
Do not raise errors when affiliate doesn't exists.

## Summary

Instead of accessing the `search_engine` property on an affiliate that can not be found this change leverages the database to check if an affiliate with the specified name and "SearchGov" as `search_engine` exist. If affiliate doesn't exist it returns false.

Issue: [here](https://cm-jira.usa.gov/browse/SRCH-4469).
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
