### PR TITLE
SRCH-4528 mysql cpu optimization

### DIFF
--- a/app/jobs/searchgov_domain_indexer_job.rb
+++ b/app/jobs/searchgov_domain_indexer_job.rb
@@ -9,10 +9,8 @@ class SearchgovDomainIndexerJob < ApplicationJob
   unique :until_executing, lock_ttl: 30.minutes
 
   def perform(searchgov_domain:, delay:)
-    if url = searchgov_domain.searchgov_urls.fetch_required.first
-
-      SearchgovDomainIndexerJob.
-        set(wait: delay.seconds).
+    if (url = searchgov_domain.searchgov_urls.fetch_required.first)
+      SearchgovDomainIndexerJob.set(wait: delay.seconds).
         perform_later(searchgov_domain: searchgov_domain, delay: delay)
 
       url.fetch

--- a/app/jobs/searchgov_domain_indexer_job.rb
+++ b/app/jobs/searchgov_domain_indexer_job.rb
@@ -9,11 +9,13 @@ class SearchgovDomainIndexerJob < ApplicationJob
   unique :until_executing, lock_ttl: 30.minutes
 
   def perform(searchgov_domain:, delay:)
-    searchgov_domain.searchgov_urls.fetch_required.first&.fetch
+    if url = searchgov_domain.searchgov_urls.fetch_required.first
 
-    if searchgov_domain.searchgov_urls.fetch_required.any?
-      SearchgovDomainIndexerJob.set(wait: delay.seconds).
+      SearchgovDomainIndexerJob.
+        set(wait: delay.seconds).
         perform_later(searchgov_domain: searchgov_domain, delay: delay)
+
+      url.fetch
     else
       Rails.logger.info("Done indexing #{searchgov_domain.domain}")
       searchgov_domain.done_indexing!

--- a/app/models/searchgov_url.rb
+++ b/app/models/searchgov_url.rb
@@ -48,10 +48,10 @@ class SearchgovUrl < ApplicationRecord
 
   scope :fetch_required, lambda {
     where('last_crawled_at IS NULL
-           OR lastmod > last_crawled_at
            OR enqueued_for_reindex
+           OR lastmod > last_crawled_at
            OR (last_crawl_status = "OK" AND last_crawled_at < ?)', 1.month.ago).
-      order(last_crawl_status: :ASC, enqueued_for_reindex: :DESC, lastmod: :DESC)
+    order(Arel.sql('last_crawled_at IS NULL DESC'), enqueued_for_reindex: :DESC, lastmod: :DESC)
   }
 
   class SearchgovUrlError < StandardError; end

--- a/app/models/searchgov_url.rb
+++ b/app/models/searchgov_url.rb
@@ -51,7 +51,7 @@ class SearchgovUrl < ApplicationRecord
            OR enqueued_for_reindex
            OR lastmod > last_crawled_at
            OR (last_crawl_status = "OK" AND last_crawled_at < ?)', 1.month.ago).
-    order(Arel.sql('last_crawled_at IS NULL DESC'), enqueued_for_reindex: :DESC, lastmod: :DESC)
+      order(Arel.sql('last_crawled_at IS NULL DESC'), enqueued_for_reindex: :DESC, lastmod: :DESC)
   }
 
   class SearchgovUrlError < StandardError; end

--- a/db/migrate/20230926194650_remove_unused_searchgov_urls_indexes.rb
+++ b/db/migrate/20230926194650_remove_unused_searchgov_urls_indexes.rb
@@ -1,0 +1,7 @@
+class RemoveUnusedSearchgovUrlsIndexes < ActiveRecord::Migration[7.0]
+  def change
+    remove_index :searchgov_urls, [:searchgov_domain_id, :last_crawled_at], name: 'searchgov_urls_on_searchgov_domain_id_and_last_crawled_at'
+    remove_index :searchgov_urls, [:searchgov_domain_id, :lastmod], name: 'searchgov_urls_on_searchgov_domain_id_and_lastmod'
+    remove_index :searchgov_urls, [:searchgov_domain_id, :last_crawl_status], name: 'searchgov_urls_on_searchgov_domain_id_and_last_crawl_status'
+  end
+end

--- a/db/migrate/20230926203204_create_searchgov_urls_fetch_required_index.rb
+++ b/db/migrate/20230926203204_create_searchgov_urls_fetch_required_index.rb
@@ -1,0 +1,8 @@
+class CreateSearchgovUrlsFetchRequiredIndex < ActiveRecord::Migration[7.0]
+  def change
+   add_index :searchgov_urls,
+     %i[searchgov_domain_id last_crawled_at lastmod enqueued_for_reindex last_crawl_status],
+     order: {last_crawl_status: :asc, enqueued_for_reindex: :desc, lastmod: :desc},
+     name: :searchgov_urls_fetch_required
+  end
+end

--- a/db/migrate/20230926203204_create_searchgov_urls_fetch_required_index.rb
+++ b/db/migrate/20230926203204_create_searchgov_urls_fetch_required_index.rb
@@ -1,8 +1,8 @@
 class CreateSearchgovUrlsFetchRequiredIndex < ActiveRecord::Migration[7.0]
   def change
    add_index :searchgov_urls,
-     %i[searchgov_domain_id last_crawled_at lastmod enqueued_for_reindex last_crawl_status],
-     order: {last_crawl_status: :asc, enqueued_for_reindex: :desc, lastmod: :desc},
+     %i[searchgov_domain_id last_crawled_at enqueued_for_reindex lastmod last_crawl_status],
+     order: {enqueued_for_reindex: :desc, lastmod: :desc, last_crawl_status: :asc},
      name: :searchgov_urls_fetch_required
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -604,10 +604,8 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_27_213029) do
     t.index ["last_crawl_status"], name: "index_searchgov_urls_on_last_crawl_status"
     t.index ["searchgov_domain_id", "enqueued_for_reindex"], name: "searchgov_urls_on_searchgov_domain_id_and_enqueued_for_reindex"
     t.index ["searchgov_domain_id", "last_crawl_status"], name: "index_by_searchgov_domain_id_and_last_crawl_status"
-    t.index ["searchgov_domain_id", "last_crawl_status"], name: "searchgov_urls_on_searchgov_domain_id_and_last_crawl_status"
+    t.index ["searchgov_domain_id", "last_crawled_at", "lastmod", "enqueued_for_reindex", "last_crawl_status"], name: "searchgov_urls_fetch_required"
     t.index ["searchgov_domain_id", "last_crawled_at"], name: "index_searchgov_urls_on_searchgov_domain_id_and_last_crawled_at"
-    t.index ["searchgov_domain_id", "last_crawled_at"], name: "searchgov_urls_on_searchgov_domain_id_and_last_crawled_at"
-    t.index ["searchgov_domain_id", "lastmod"], name: "searchgov_urls_on_searchgov_domain_id_and_lastmod"
     t.index ["searchgov_domain_id"], name: "index_searchgov_urls_on_searchgov_domain_id"
     t.index ["url"], name: "index_searchgov_urls_on_url", length: 255
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -604,7 +604,7 @@ ActiveRecord::Schema[7.0].define(version: 2023_09_27_213029) do
     t.index ["last_crawl_status"], name: "index_searchgov_urls_on_last_crawl_status"
     t.index ["searchgov_domain_id", "enqueued_for_reindex"], name: "searchgov_urls_on_searchgov_domain_id_and_enqueued_for_reindex"
     t.index ["searchgov_domain_id", "last_crawl_status"], name: "index_by_searchgov_domain_id_and_last_crawl_status"
-    t.index ["searchgov_domain_id", "last_crawled_at", "lastmod", "enqueued_for_reindex", "last_crawl_status"], name: "searchgov_urls_fetch_required"
+    t.index ["searchgov_domain_id", "last_crawled_at", "enqueued_for_reindex", "lastmod", "last_crawl_status"], name: "searchgov_urls_fetch_required"
     t.index ["searchgov_domain_id", "last_crawled_at"], name: "index_searchgov_urls_on_searchgov_domain_id_and_last_crawled_at"
     t.index ["searchgov_domain_id"], name: "index_searchgov_urls_on_searchgov_domain_id"
     t.index ["url"], name: "index_searchgov_urls_on_url", length: 255

--- a/spec/jobs/searchgov_domain_indexer_job_spec.rb
+++ b/spec/jobs/searchgov_domain_indexer_job_spec.rb
@@ -31,7 +31,9 @@ describe SearchgovDomainIndexerJob do
       perform
       expect(searchgov_url.reload.last_crawl_status).not_to be_nil
     end
+  end
 
+  context 'when a domain do not have unfetched urls' do
     it 'transitions the domain activity back to "idle"' do
       expect { perform }.to change { searchgov_domain.activity }.
         from('indexing').to('idle')


### PR DESCRIPTION
## Summary
- Refactor `SearchgovDomainIndexerJob` to execute only one database query instead of two per execution
- Refactor `SearchgovUrl.fetch_required` to use `last_crawled_at` instead of `last_crawl_status` for ordering
- Create an specific index based for the `fetch_required` query executed in `SearchgovDomainIndexerJob`
- Remove unused indexes created for the same purpose
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
