### PR TITLE
"Multiple Locations" is not coming for jobs belonging to multiple locations for the SERP

### DIFF
--- a/app/javascript/components/Results/Jobs/Jobs.tsx
+++ b/app/javascript/components/Results/Jobs/Jobs.tsx
@@ -10,7 +10,7 @@ import './Jobs.css';
 type Job = {
   positionTitle: string;
   positionUri: string;
-  positionLocationDisplay: string;
+  positionLocation: string;
   organizationName: string;
   minimumPay: number;
   maximumPay: number;
@@ -103,7 +103,7 @@ export const Jobs = ({ jobs=[] }: JobsProps) => {
                       <div className='result-desc'>
                         <p>{job.organizationName}</p>
                         <ul className="list-horizontal">
-                          <li>{job.positionLocationDisplay}</li>
+                          <li>{job.positionLocation}</li>
                           {showSalary(job) && (<li>{formatSalary(job)}</li>)}
                           <li>Apply by {job.applicationCloseDate}</li>
                         </ul>
@@ -132,7 +132,7 @@ export const Jobs = ({ jobs=[] }: JobsProps) => {
                           <div className='result-desc'>
                             <p>{job.organizationName}</p>
                             <ul className="list-horizontal">
-                              <li>{job.positionLocationDisplay}</li>
+                              <li>{job.positionLocation}</li>
                               {showSalary(job) && (<li>{formatSalary(job)}</li>)}
                               <li>Apply by {job.applicationCloseDate}</li>
                             </ul>

--- a/app/javascript/components/Results/Results.tsx
+++ b/app/javascript/components/Results/Results.tsx
@@ -74,7 +74,7 @@ interface ResultsProps {
     jobs?: {
       positionTitle: string;
       positionUri: string;
-      positionLocationDisplay: string;
+      positionLocation: string;
       organizationName: string;
       minimumPay: number;
       maximumPay: number;

--- a/app/javascript/components/SearchResultsLayout.tsx
+++ b/app/javascript/components/SearchResultsLayout.tsx
@@ -83,7 +83,7 @@ interface SearchResultsLayoutProps {
     jobs?: {
       positionTitle: string;
       positionUri: string;
-      positionLocationDisplay: string;
+      positionLocation: string;
       organizationName: string;
       minimumPay: number;
       maximumPay: number;

--- a/app/javascript/test/Jobs.test.tsx
+++ b/app/javascript/test/Jobs.test.tsx
@@ -28,7 +28,7 @@ describe('Jobs component', () => {
       {
         positionTitle: 'Contract Specialist',
         positionUri: 'https://www.usajobs.gov/GetJob/ViewDetails/690037300',
-        positionLocationDisplay: 'Multiple Locations',
+        positionLocation: 'Multiple Locations',
         organizationName: 'Office of Acquisition and Logistics',
         minimumPay: 122000,
         maximumPay: 150000,
@@ -38,7 +38,7 @@ describe('Jobs component', () => {
       {
         positionTitle: 'Contract Specialist 2',
         positionUri: 'https://www.usajobs.gov/GetJob/ViewDetails/690037300',
-        positionLocationDisplay: 'Multiple Locations',
+        positionLocation: 'Multiple Locations',
         organizationName: 'Office of Acquisition and Logistics 2',
         minimumPay: 122000,
         maximumPay: 150000,
@@ -48,7 +48,7 @@ describe('Jobs component', () => {
       {
         positionTitle: 'Contract Specialist 3',
         positionUri: 'https://www.usajobs.gov/GetJob/ViewDetails/690037300',
-        positionLocationDisplay: 'Multiple Locations',
+        positionLocation: 'Multiple Locations',
         organizationName: 'Office of Acquisition and Logistics 3',
         minimumPay: 122000,
         maximumPay: 150000,
@@ -58,7 +58,7 @@ describe('Jobs component', () => {
       {
         positionTitle: 'Contract Specialist 4',
         positionUri: 'https://www.usajobs.gov/GetJob/ViewDetails/690037300',
-        positionLocationDisplay: 'Multiple Locations',
+        positionLocation: 'Multiple Locations',
         organizationName: 'Office of Acquisition and Logistics 4',
         minimumPay: 122000,
         maximumPay: 150000,
@@ -68,7 +68,7 @@ describe('Jobs component', () => {
       {
         positionTitle: 'Contract Specialist 5',
         positionUri: 'https://www.usajobs.gov/GetJob/ViewDetails/690037300',
-        positionLocationDisplay: 'Multiple Locations',
+        positionLocation: 'Multiple Locations',
         organizationName: 'Office of Acquisition and Logistics 5',
         minimumPay: 122000,
         maximumPay: 150000,
@@ -78,7 +78,7 @@ describe('Jobs component', () => {
       {
         positionTitle: 'Contract Specialist 6',
         positionUri: 'https://www.usajobs.gov/GetJob/ViewDetails/690037300',
-        positionLocationDisplay: 'Multiple Locations',
+        positionLocation: 'Multiple Locations',
         organizationName: 'Office of Acquisition and Logistics 5',
         minimumPay: 122000,
         maximumPay: 150000,
@@ -88,7 +88,7 @@ describe('Jobs component', () => {
       {
         positionTitle: 'Contract Specialist 7',
         positionUri: 'https://www.usajobs.gov/GetJob/ViewDetails/690037300',
-        positionLocationDisplay: 'Multiple Locations',
+        positionLocation: 'Multiple Locations',
         organizationName: 'Office of Acquisition and Logistics 5',
         minimumPay: 122000,
         maximumPay: 150000,
@@ -98,7 +98,7 @@ describe('Jobs component', () => {
       {
         positionTitle: 'Contract Specialist 8',
         positionUri: 'https://www.usajobs.gov/GetJob/ViewDetails/690037300',
-        positionLocationDisplay: 'Multiple Locations',
+        positionLocation: 'Multiple Locations',
         organizationName: 'Office of Acquisition and Logistics 5',
         minimumPay: 0,
         maximumPay: 150000,
@@ -119,7 +119,7 @@ describe('Jobs component', () => {
       {
         positionTitle: 'Contract Specialist 5',
         positionUri: 'https://www.usajobs.gov/GetJob/ViewDetails/690037300',
-        positionLocationDisplay: 'Multiple Locations',
+        positionLocation: 'Multiple Locations',
         organizationName: 'Office of Acquisition and Logistics 5',
         minimumPay: 122000,
         maximumPay: 150000,

--- a/app/models/govbox_set.rb
+++ b/app/models/govbox_set.rb
@@ -142,8 +142,13 @@ class GovboxSet
     return unless @affiliate.jobs_enabled?
 
     @jobs&.
-      map { |job| job.slice(:position_title, :position_uri, :position_location_display, :organization_name, :minimum_pay, :maximum_pay, :rate_interval_code, :application_close_date) }&.
-      each { |job| job[:application_close_date] = Date.parse(job[:application_close_date]).to_fs(:long) }
+      map { |job| job.slice(:position_title, :position_uri, :position_location, :organization_name, :minimum_pay, :maximum_pay, :rate_interval_code, :application_close_date) }&.
+      each { |job| job[:application_close_date] = Date.parse(job[:application_close_date]).to_fs(:long) }&.
+      each { |job| job[:position_location] = format_locations(job[:position_location]) }
+  end
+
+  def format_locations(locations)
+    locations.many? ? "Multiple Locations" : locations.first[:location_name]
   end
 
   def format_health_topic

--- a/app/models/govbox_set.rb
+++ b/app/models/govbox_set.rb
@@ -143,7 +143,10 @@ class GovboxSet
 
     @jobs&.
       map { |job| job.slice(:position_title, :position_uri, :position_location, :organization_name, :minimum_pay, :maximum_pay, :rate_interval_code, :application_close_date) }&.
-      each { |job| job[:application_close_date] = Date.parse(job[:application_close_date]).to_fs(:long), job[:position_location] = format_locations(job[:position_location]) }
+      each do |job|
+      job[:application_close_date] = Date.parse(job[:application_close_date]).to_fs(:long)
+      job[:position_location] = format_locations(job[:position_location])
+    end
   end
 
   def format_locations(locations)

--- a/app/models/govbox_set.rb
+++ b/app/models/govbox_set.rb
@@ -143,12 +143,11 @@ class GovboxSet
 
     @jobs&.
       map { |job| job.slice(:position_title, :position_uri, :position_location, :organization_name, :minimum_pay, :maximum_pay, :rate_interval_code, :application_close_date) }&.
-      each { |job| job[:application_close_date] = Date.parse(job[:application_close_date]).to_fs(:long) }&.
-      each { |job| job[:position_location] = format_locations(job[:position_location]) }
+      each { |job| job[:application_close_date] = Date.parse(job[:application_close_date]).to_fs(:long), job[:position_location] = format_locations(job[:position_location]) }
   end
 
   def format_locations(locations)
-    locations.many? ? "Multiple Locations" : locations.first[:location_name]
+    locations.many? ? 'Multiple Locations' : locations.first[:location_name]
   end
 
   def format_health_topic

--- a/spec/models/govbox_set_spec.rb
+++ b/spec/models/govbox_set_spec.rb
@@ -96,7 +96,7 @@ describe GovboxSet do
           described_class.new('jobs', affiliate, geoip_info, highlighting_options).as_json
         end
 
-        let(:job_attributes) { %w[application_close_date maximum_pay minimum_pay organization_name position_location_display position_title position_uri rate_interval_code] }
+        let(:job_attributes) { %w[application_close_date maximum_pay minimum_pay organization_name position_location position_title position_uri rate_interval_code] }
 
         before do
           allow(affiliate).to receive(:jobs_enabled?).and_return(true)
@@ -118,7 +118,7 @@ describe GovboxSet do
                                                        'maximum_pay' => 170_800.0,
                                                        'minimum_pay' => 64_660.0,
                                                        'organization_name' => 'Office of the Secretary of Health and Human Services',
-                                                       'position_location_display' => 'Multiple Locations',
+                                                       'position_location' => 'Multiple Locations',
                                                        'position_title' => 'General Attorney Advisor',
                                                        'position_uri' => 'https://www.usajobs.gov:443/GetJob/ViewDetails/523056100',
                                                        'rate_interval_code' => 'PA'


### PR DESCRIPTION
## Summary
- Replace `position_location_display` with `position_location` value in jobs. Using existing logic to display multiple locations count is > 1.  
- Currently, `position_location_display` is using location different than existing SERP.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
