### PR TITLE
Fix/update flaky tests

### DIFF
--- a/features/step_definitions/web_ext_steps.rb
+++ b/features/step_definitions/web_ext_steps.rb
@@ -81,6 +81,24 @@ And /^the "([^"]*)" field should be blank$/ do |field|
   field_value.should be_blank
 end
 
+Then /^the "([^"]*)" radio button should be checked$/ do |label|
+  field_checked = find_field(label)['checked']
+  if field_checked.respond_to?(:should)
+    field_checked.should(be_truthy)
+  else
+    assert field_checked
+  end
+end
+
+Then /^the "([^"]*)" radio button should not be checked$/ do |label|
+  field_checked = find_field(label)['checked']
+  if field_checked.respond_to?(:should)
+    field_checked.should(be_falsey)
+  else
+    assert !field_checked
+  end
+end
+
 Then /^the page body should (contain|match) "([^"]*)"$/ do |matcher, content|
   page.body.should include(content) if matcher == 'contain'
   page.body.should match(/#{content}/) if matcher == 'match'

--- a/features/step_definitions/web_ext_steps.rb
+++ b/features/step_definitions/web_ext_steps.rb
@@ -81,14 +81,6 @@ And /^the "([^"]*)" field should be blank$/ do |field|
   field_value.should be_blank
 end
 
-Then /^the "([^"]*)" radio button should be checked$/ do |label|
-  find_field(label)['checked'].should(be_truthy)
-end
-
-Then /^the "([^"]*)" radio button should not be checked$/ do |label|
-  find_field(label)['checked'].should(be_falsey)
-end
-
 Then /^the page body should (contain|match) "([^"]*)"$/ do |matcher, content|
   page.body.should include(content) if matcher == 'contain'
   page.body.should match(/#{content}/) if matcher == 'match'

--- a/spec/helpers/react_helper_spec.rb
+++ b/spec/helpers/react_helper_spec.rb
@@ -262,11 +262,12 @@ describe ReactHelper do
     end
 
     context 'when an affiliate has news label and news items' do
+      let(:twelve_years_ago) { DateTime.now - 12.years }
       let(:news_items) do
         instance_double(ElasticNewsItemResults,
                         results: [
-                          mock_model(NewsItem, title: 'GSA News Item 1', description: true, link: 'http://search.gov/1', published_at: DateTime.parse('2011-09-26 21:33:05'), rss_feed_url_id: rss_feed.rss_feed_urls.first.id),
-                          mock_model(NewsItem, title: 'GSA News Item 2', description: true, link: 'http://search.gov/2', published_at: DateTime.parse('2011-09-26 21:33:05'), rss_feed_url_id: rss_feed.rss_feed_urls.first.id)
+                          mock_model(NewsItem, title: 'GSA News Item 1', description: true, link: 'http://search.gov/1', published_at: twelve_years_ago, rss_feed_url_id: rss_feed.rss_feed_urls.first.id),
+                          mock_model(NewsItem, title: 'GSA News Item 2', description: true, link: 'http://search.gov/2', published_at: twelve_years_ago, rss_feed_url_id: rss_feed.rss_feed_urls.first.id)
                         ])
       end
       let(:rss_feed) do

--- a/spec/models/results_with_body_and_description_post_processor_spec.rb
+++ b/spec/models/results_with_body_and_description_post_processor_spec.rb
@@ -23,9 +23,10 @@ describe ResultsWithBodyAndDescriptionPostProcessor do
     context 'when there are video results' do
       subject(:normalized_results) { described_class.new(results, _val: nil, youtube: true).normalized_results(5) }
 
+      let(:twelve_years_ago) { DateTime.now - 12.years }
       let(:results) do
         results = []
-        5.times { |index| results << Hashie::Mash::Rash.new(title: "title #{index}", description: "content #{index}", url: "http://foo.gov/#{index}", published_at: DateTime.parse('2011-09-26'), youtube_thumbnail_url: "http://youtube.com/#{index}", duration: '1:23') }
+        5.times { |index| results << Hashie::Mash::Rash.new(title: "title #{index}", description: "content #{index}", url: "http://foo.gov/#{index}", published_at: twelve_years_ago, youtube_thumbnail_url: "http://youtube.com/#{index}", duration: '1:23') }
         results
       end
 
@@ -36,7 +37,7 @@ describe ResultsWithBodyAndDescriptionPostProcessor do
           expect(result[:url]).to eq("http://foo.gov/#{index}")
           expect(result[:publishedAt]).to eq('about 12 years ago')
           expect(result[:youtube]).to be true
-          expect(result[:youtubePublishedAt]).to eq(DateTime.parse('2011-09-26'))
+          expect(result[:youtubePublishedAt]).to eq(twelve_years_ago)
           expect(result[:youtubeThumbnailUrl]).to eq("http://youtube.com/#{index}")
           expect(result[:youtubeDuration]).to eq('1:23')
         end


### PR DESCRIPTION
## Summary
- Removes hardcoded dates and human-language date matchers for `spec/helpers/react_helper_spec.rb` and `spec/helpers/react_helper_spec.rb`
- Removes duplicative and flaky radio button web steps from `features/step_definitions/web_ext_steps.rb` which was causing transient failures in the "Editing the Visual Design Settings when "Show Redesign Display Settings" is true" test like: https://app.circleci.com/pipelines/github/lorawoodford/search-gov/1224/workflows/879b184d-b28d-414b-8c0f-113f267facb7/jobs/8249/tests#failed-test-0.  There was already an existing set of radio button web steps [here](https://github.com/lorawoodford/search-gov/blob/0a6b23f9d405147b30836df0c72f38cc63b69da7/features/step_definitions/web_steps.rb#L174-L194) and these flakier ones didn't need to be added.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
