### PR TITLE
SRCH-4714 Set crossorigin to anonymous

### DIFF
--- a/app/views/layouts/searches_redesign.html.haml
+++ b/app/views/layouts/searches_redesign.html.haml
@@ -12,8 +12,8 @@
 
     %title #{@page_title}
 
-    = javascript_pack_tag 'application'
-    = stylesheet_pack_tag 'application'
+    = javascript_pack_tag 'application', crossorigin: 'anonymous'
+    = stylesheet_pack_tag 'application', crossorigin: 'anonymous'
   %body
     #main-content= yield
     = render "/shared/google_tag_manager_noscript"


### PR DESCRIPTION
## Summary
- Set crossorigin tag on assets to avoid CORS errors.

## NOTE
- The [Docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#crossorigin) indicate that this will fix the error but since the error is not happening either locally nor on staging it's hard to know if it will actually fix it but regardless we need this for security reasons anyway.