### PR TITLE
Revert "SRCH-4714 Set crossorigin to anonymous (#1399)"

### DIFF
--- a/app/views/layouts/searches_redesign.html.haml
+++ b/app/views/layouts/searches_redesign.html.haml
@@ -12,8 +12,8 @@
 
     %title #{@page_title}
 
-    = javascript_pack_tag 'application', crossorigin: 'anonymous'
-    = stylesheet_pack_tag 'application', crossorigin: 'anonymous'
+    = javascript_pack_tag 'application'
+    = stylesheet_pack_tag 'application'
   %body
     #main-content= yield
     = render "/shared/google_tag_manager_noscript"


### PR DESCRIPTION
This reverts commit 0601871c1cc84056ab77c3ee7c119b6da0e2aa94 due new SERP being completely broken