### PR TITLE
SRCH-4854, SRCH-4852: updated bg color to be transparent for identfier and remove 0 from results count

### DIFF
--- a/app/javascript/components/Identifier/Identifier.css
+++ b/app/javascript/components/Identifier/Identifier.css
@@ -1,0 +1,3 @@
+.usa-identifier{
+  background-color: transparent;
+}

--- a/app/javascript/components/Identifier/Identifier.tsx
+++ b/app/javascript/components/Identifier/Identifier.tsx
@@ -5,6 +5,7 @@ import { LanguageContext } from '../../contexts/LanguageContext';
 import { StyleContext } from '../../contexts/StyleContext';
 
 import { IdentifierLogoWrapper } from './IdentifierLogoWrapper';
+import './Identifier.css';
 
 interface IdentifierProps {
   identifierContent?: {

--- a/app/javascript/components/Results/Results.tsx
+++ b/app/javascript/components/Results/Results.tsx
@@ -182,7 +182,7 @@ export const Results = ({ query = '', results = null, additionalResults = null, 
           <SiteLimitAlert {...sitelimit} query={query} />
         )}
 
-        {total && <ResultsCount total={total}/>}
+        {total && total > 0 ? <ResultsCount total={total}/>  : <></>}
 
         {spellingSuggestion && (
           <SpellingSuggestion {...spellingSuggestion}/>


### PR DESCRIPTION
## Summary
- [SRCH-4854](https://cm-jira.usa.gov/browse/SRCH-4854) Identifier background color on usa-identifier class should not be black
- [SRCH-4852](https://cm-jira.usa.gov/browse/SRCH-4852) There's a random "0" character showing at the extreme left of the No Results page for i14y-powered search results
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
