### PR TITLE
SRCH-589 Stop Indexing

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,6 +3,9 @@
 inherit_from:
   - https://raw.githubusercontent.com/GSA/searchgov_style/main/.default.yml
 
+Layout/DotPosition:
+  EnforcedStyle: trailing
+
 inherit_mode:
   merge:
     - Exclude

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,9 +3,6 @@
 inherit_from:
   - https://raw.githubusercontent.com/GSA/searchgov_style/main/.default.yml
 
-Layout/DotPosition:
-  EnforcedStyle: trailing
-
 inherit_mode:
   merge:
     - Exclude

--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -53,7 +53,7 @@ class Admin::SearchgovDomainsController < Admin::AdminController
     process_action_link_action do |searchgov_domain|
       SearchgovDomainReindexerJob.perform_later(searchgov_domain: searchgov_domain)
 
-      searchgov_domain.update(status: 'reindexing started')
+      searchgov_domain.update(status: SearchgovDomain::INDEXING_STARTED)
 
       flash[:info] = "Reindexing has been enqueued for #{searchgov_domain.domain}"
     end

--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -36,8 +36,7 @@ class Admin::SearchgovDomainsController < Admin::AdminController
   end
 
   def stop_indexing
-    @searchgov_domain = SearchDomain.find(params[:id])
-    @searchgov_domain.stop_indexing!
+    SearchDomain.find(params[:id]).stop_indexing!
   end
 
   def after_create_save(record)

--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -36,9 +36,11 @@ class Admin::SearchgovDomainsController < Admin::AdminController
   end
 
   def stop_indexing
-    SearchgovDomain.find(params[:id]).stop_indexing!
+    process_action_link_action do |searchgov_domain|
+      searchgov_domain.stop_indexing!
 
-    flash[:info] = t(:'.indexing_stopped', name: searchgov_domain.domain)
+      flash[:info] = t(:'.indexing_stopped', name: searchgov_domain.domain)
+    end
   end
 
   def after_create_save(record)

--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -36,7 +36,9 @@ class Admin::SearchgovDomainsController < Admin::AdminController
   end
 
   def stop_indexing
-    SearchDomain.find(params[:id]).stop_indexing!
+    SearchgovDomain.find(params[:id]).stop_indexing!
+
+    flash[:info] = t(:'.indexing_stopped', name: searchgov_domain.domain)
   end
 
   def after_create_save(record)

--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -22,7 +22,8 @@ class Admin::SearchgovDomainsController < Admin::AdminController
       confirm: 'Are you sure you want to reindex this entire domain?'
     )
 
-    config.action_links.add('stop_indexing',
+    config.action_links.add(
+      'stop_indexing',
       confirm:   'Are you sure you want to stop indexing this domain?',
       crud_type: :update,
       inline:    true,

--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -21,8 +21,23 @@ class Admin::SearchgovDomainsController < Admin::AdminController
       inline: true,
       confirm: 'Are you sure you want to reindex this entire domain?'
     )
+    config.action_links.add(
+      'stop_indexing',
+      label: 'stop indexing',
+      type: :member,
+      crud_type: :update,
+      method: :post,
+      position: false,
+      inline: true,
+      confirm: 'Are you sure you want to stop indexing this domain?'
+    )
     config.update.columns = %i[js_renderer]
     config.columns[:js_renderer].label = 'Render Javascript'
+  end
+
+  def stop_indexing
+    @searchgov_domain = SearchDomain.find(params[:id])
+    @searchgov_domain.stop_indexing!
   end
 
   def after_create_save(record)

--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -21,16 +21,17 @@ class Admin::SearchgovDomainsController < Admin::AdminController
       inline: true,
       confirm: 'Are you sure you want to reindex this entire domain?'
     )
-    config.action_links.add(
-      'stop_indexing',
-      label: 'stop indexing',
-      type: :member,
+
+    config.action_links.add('stop_indexing',
+      confirm:   'Are you sure you want to stop indexing this domain?',
       crud_type: :update,
-      method: :post,
-      position: false,
-      inline: true,
-      confirm: 'Are you sure you want to stop indexing this domain?'
+      inline:    true,
+      label:     'stop indexing',
+      method:    :post,
+      position:  false,
+      type:      :member
     )
+
     config.update.columns = %i[js_renderer]
     config.columns[:js_renderer].label = 'Render Javascript'
   end

--- a/app/controllers/admin/searchgov_domains_controller.rb
+++ b/app/controllers/admin/searchgov_domains_controller.rb
@@ -53,6 +53,8 @@ class Admin::SearchgovDomainsController < Admin::AdminController
     process_action_link_action do |searchgov_domain|
       SearchgovDomainReindexerJob.perform_later(searchgov_domain: searchgov_domain)
 
+      searchgov_domain.update(status: 'reindexing started')
+
       flash[:info] = "Reindexing has been enqueued for #{searchgov_domain.domain}"
     end
   end

--- a/app/jobs/searchgov_domain_indexer_job.rb
+++ b/app/jobs/searchgov_domain_indexer_job.rb
@@ -9,7 +9,7 @@ class SearchgovDomainIndexerJob < ApplicationJob
   unique :until_executing, lock_ttl: 30.minutes
 
   def perform(searchgov_domain:, delay:)
-    if (url = searchgov_domain.searchgov_urls.fetch_required.first)
+    if searchgov_domain.indexing? && (url = searchgov_domain.searchgov_urls.fetch_required.first)
       SearchgovDomainIndexerJob.set(wait: delay.seconds).
         perform_later(searchgov_domain: searchgov_domain, delay: delay)
 

--- a/app/models/searchgov_domain.rb
+++ b/app/models/searchgov_domain.rb
@@ -71,6 +71,16 @@ class SearchgovDomain < ApplicationRecord
     urls.presence || ["#{url}sitemap.xml"]
   end
 
+  def stop_indexing!
+    Resque::Job.destroy(:searchgov, 'SearchgovDomainIndexerJob', searchgov_domain: self, delay: delay)
+
+    self.status = 'indexing stopped'
+
+    done_indexing
+
+    save
+  end
+
   private
 
   def robotex

--- a/app/models/searchgov_domain.rb
+++ b/app/models/searchgov_domain.rb
@@ -76,8 +76,6 @@ class SearchgovDomain < ApplicationRecord
   end
 
   def stop_indexing!
-    Resque::Job.destroy(:searchgov, 'SearchgovDomainIndexerJob', searchgov_domain: self, delay: delay)
-
     done_indexing
     self.status = INDEXING_STOPPED
 

--- a/app/models/searchgov_domain.rb
+++ b/app/models/searchgov_domain.rb
@@ -74,9 +74,8 @@ class SearchgovDomain < ApplicationRecord
   def stop_indexing!
     Resque::Job.destroy(:searchgov, 'SearchgovDomainIndexerJob', searchgov_domain: self, delay: delay)
 
-    self.status = 'indexing stopped'
-
     done_indexing
+    self.status = 'indexing stopped'
 
     save
   end

--- a/app/models/searchgov_domain.rb
+++ b/app/models/searchgov_domain.rb
@@ -7,8 +7,8 @@ class SearchgovDomain < ApplicationRecord
   class DomainError < StandardError; end
 
   OK_STATUS        = '200 OK'
-  INDEXING_STARTED = 'indexing started'
-  INDEXING_STOPPED = 'indexing stopped'
+  INDEXING_STARTED = 'indexing started manually'
+  INDEXING_STOPPED = 'indexing stopped manually'
 
   GOOD_STATUS = [OK_STATUS, INDEXING_STARTED, INDEXING_STOPPED].freeze
 

--- a/app/models/searchgov_domain.rb
+++ b/app/models/searchgov_domain.rb
@@ -10,7 +10,7 @@ class SearchgovDomain < ApplicationRecord
   INDEXING_STARTED = 'indexing started'
   INDEXING_STOPPED = 'indexing stopped'
 
-  GOOD_STATUS = [OK_STATUS, INDEXING_STARTED, INDEXING_STOPPED]
+  GOOD_STATUS = [OK_STATUS, INDEXING_STARTED, INDEXING_STOPPED].freeze
 
   before_validation(on: :create) { self.domain = domain&.downcase&.strip }
 
@@ -47,7 +47,7 @@ class SearchgovDomain < ApplicationRecord
   end
 
   def available?
-     GOOD_STATUS.include? (status || check_status)
+    GOOD_STATUS.include?(status || check_status)
   end
 
   def check_status

--- a/config/locales/super_admin/en.yml
+++ b/config/locales/super_admin/en.yml
@@ -1,5 +1,9 @@
 ---
 en:
+  admin:
+    searchgov_domains:
+      stop_indexing:
+        indexing_stopped: Indexing has been stopped for %{name}
   super_admin:
     admin:
       odie_url_source_update:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -228,6 +228,7 @@ Rails.application.routes.draw do
     resources :searchgov_domains, concerns: :active_scaffold do
       member do
         post 'reindex'
+        post 'stop_indexing'
       end
       resources :searchgov_urls, concerns: :active_scaffold do
         member do

--- a/spec/controllers/admin/searchgov_domains_controller_spec.rb
+++ b/spec/controllers/admin/searchgov_domains_controller_spec.rb
@@ -2,13 +2,16 @@
 
 describe Admin::SearchgovDomainsController do
   fixtures :users, :searchgov_domains
+
   let(:config) { described_class.active_scaffold_config }
 
+  before do
+    activate_authlogic
+
+    UserSession.create(users(:affiliate_admin))
+  end
+
   describe '#update' do
-    before do
-      activate_authlogic
-      UserSession.create(users(:affiliate_admin))
-    end
 
     context 'when configuring Active Scaffold' do
       let(:update_columns) { config.update.columns }
@@ -17,6 +20,18 @@ describe Admin::SearchgovDomainsController do
       it 'contains the specified columns' do
         expect(update_columns.to_a).to match_array(enable_disable_columns)
       end
+    end
+  end
+
+  describe 'stop_indexing' do
+    let(:domain) { searchgov_domains(:agency_gov) }
+ 
+    it 'calls stop_indexing! on domain' do
+      allow(SearchDomain).to receive(:find).and_return(domain)
+
+      post stop_indexing_admin_searchgov_domain_path(domain)
+
+      expect(domain).to receive(:stop_indexing!)
     end
   end
 end

--- a/spec/controllers/admin/searchgov_domains_controller_spec.rb
+++ b/spec/controllers/admin/searchgov_domains_controller_spec.rb
@@ -3,8 +3,6 @@
 describe Admin::SearchgovDomainsController do
   fixtures :users, :searchgov_domains
 
-  let(:config) { described_class.active_scaffold_config }
-
   before do
     activate_authlogic
 
@@ -12,6 +10,7 @@ describe Admin::SearchgovDomainsController do
   end
 
   describe '#update' do
+    let(:config) { described_class.active_scaffold_config }
 
     context 'when configuring Active Scaffold' do
       let(:update_columns) { config.update.columns }
@@ -27,11 +26,9 @@ describe Admin::SearchgovDomainsController do
     let(:domain) { searchgov_domains(:agency_gov) }
  
     it 'calls stop_indexing! on domain' do
-      allow(SearchDomain).to receive(:find).and_return(domain)
+      expect_any_instance_of(SearchgovDomain).to receive(:stop_indexing!)
 
-      post stop_indexing_admin_searchgov_domain_path(domain)
-
-      expect(domain).to receive(:stop_indexing!)
+      post :stop_indexing, params: {id: domain.id}
     end
   end
 end

--- a/spec/controllers/admin/searchgov_domains_controller_spec.rb
+++ b/spec/controllers/admin/searchgov_domains_controller_spec.rb
@@ -22,13 +22,15 @@ describe Admin::SearchgovDomainsController do
     end
   end
 
+  # rubocop:disable RSpec/AnyInstance
   describe 'stop_indexing' do
     let(:domain) { searchgov_domains(:agency_gov) }
- 
+
     it 'calls stop_indexing! on domain' do
       expect_any_instance_of(SearchgovDomain).to receive(:stop_indexing!)
 
-      post :stop_indexing, params: {id: domain.id}
+      post :stop_indexing, params: { id: domain.id }
     end
   end
+  # rubocop:enable RSpec/AnyInstance
 end

--- a/spec/jobs/searchgov_domain_indexer_job_spec.rb
+++ b/spec/jobs/searchgov_domain_indexer_job_spec.rb
@@ -81,7 +81,7 @@ describe SearchgovDomainIndexerJob do
 
     context 'when a domain is not indexing' do
       before do
-        SearchgovUrl.create(url: 'https://agency.gov/') 
+        SearchgovUrl.create(url: 'https://agency.gov/')
         searchgov_domain.done_indexing
       end
 

--- a/spec/jobs/searchgov_domain_indexer_job_spec.rb
+++ b/spec/jobs/searchgov_domain_indexer_job_spec.rb
@@ -78,5 +78,15 @@ describe SearchgovDomainIndexerJob do
           with(searchgov_domain: searchgov_domain, delay: 10).at(10.seconds.from_now)
       end
     end
+
+    context 'when a domain is not indexing' do
+      let!(:searchgov_url) { SearchgovUrl.create(url: 'https://agency.gov/') }
+
+      before do
+        searchgov_domain.done_indexing
+      end
+
+      it { expect { perform }.not_to have_enqueued_job(described_class) }
+    end
   end
 end

--- a/spec/jobs/searchgov_domain_indexer_job_spec.rb
+++ b/spec/jobs/searchgov_domain_indexer_job_spec.rb
@@ -80,9 +80,8 @@ describe SearchgovDomainIndexerJob do
     end
 
     context 'when a domain is not indexing' do
-      let!(:searchgov_url) { SearchgovUrl.create(url: 'https://agency.gov/') }
-
       before do
+        SearchgovUrl.create(url: 'https://agency.gov/') 
         searchgov_domain.done_indexing
       end
 

--- a/spec/models/searchgov_domain_spec.rb
+++ b/spec/models/searchgov_domain_spec.rb
@@ -477,8 +477,8 @@ describe SearchgovDomain do
 
       searchgov_domain.stop_indexing!
 
-      expect(resque_job).to have_received(:destroy)
-        .with(:searchgov, 'SearchgovDomainIndexerJob', searchgov_domain: searchgov_domain, delay: searchgov_domain.delay)
+      expect(resque_job).to have_received(:destroy).
+        with(:searchgov, 'SearchgovDomainIndexerJob', searchgov_domain: searchgov_domain, delay: searchgov_domain.delay)
 
       expect(searchgov_domain.status).to eq('indexing stopped')
       expect(searchgov_domain).to be_idle

--- a/spec/models/searchgov_domain_spec.rb
+++ b/spec/models/searchgov_domain_spec.rb
@@ -470,4 +470,19 @@ describe SearchgovDomain do
       it { is_expected.to eq ['https://searchgov.gov/sitemap_record.xml'] }
     end
   end
+
+  describe '#stop_indexing!' do
+    it 'stops indexing job and updates statuses' do
+      resque_job = class_spy(Resque::Job).as_stubbed_const
+
+      searchgov_domain.stop_indexing!
+
+      expect(resque_job).to have_received(:destroy)
+        .with(:searchgov, 'SearchgovDomainIndexerJob', searchgov_domain: searchgov_domain, delay: searchgov_domain.delay)
+
+      expect(searchgov_domain.status).to eq('indexing stopped')
+      expect(searchgov_domain).to be_idle
+      expect(searchgov_domain).to be_persisted
+    end
+  end
 end

--- a/spec/models/searchgov_domain_spec.rb
+++ b/spec/models/searchgov_domain_spec.rb
@@ -475,7 +475,7 @@ describe SearchgovDomain do
     it 'stops indexing job and updates statuses' do
       searchgov_domain.stop_indexing!
 
-      expect(searchgov_domain.status).to eq('indexing stopped')
+      expect(searchgov_domain.status).to eq('indexing stopped manually')
       expect(searchgov_domain).to be_idle
       expect(searchgov_domain).to be_persisted
     end

--- a/spec/models/searchgov_domain_spec.rb
+++ b/spec/models/searchgov_domain_spec.rb
@@ -473,12 +473,7 @@ describe SearchgovDomain do
 
   describe '#stop_indexing!' do
     it 'stops indexing job and updates statuses' do
-      resque_job = class_spy(Resque::Job).as_stubbed_const
-
       searchgov_domain.stop_indexing!
-
-      expect(resque_job).to have_received(:destroy).
-        with(:searchgov, 'SearchgovDomainIndexerJob', searchgov_domain: searchgov_domain, delay: searchgov_domain.delay)
 
       expect(searchgov_domain.status).to eq('indexing stopped')
       expect(searchgov_domain).to be_idle


### PR DESCRIPTION
## Summary
- Adds link to stop indexing
- When the link is clicked the domain's activity goes to idle
- SearchgovDomainIndexerJob won't index if job is in idle 