### PR TITLE
SRCH-4858, SRCH-4849: remove the hover from the css for the identifier and Search tab dropdown underline hover color

### DIFF
--- a/app/javascript/components/Identifier/Identifier.tsx
+++ b/app/javascript/components/Identifier/Identifier.tsx
@@ -31,7 +31,11 @@ const StyledUswdsIdentifier = styled(UswdsIdentifier).attrs<{ styles: FontsAndCo
   .usa-identifier__container, .usa-identifier__container > a, .usa-identifier__identity-disclaimer, .usa-identifier__identity-disclaimer > a {
     color: ${(props) => props.styles.identifierHeadingColor};
   }
-  .usa-identifier__required-links-item > a, .usa-identifier__identity-domain {
+  .usa-identifier__required-link, .usa-identifier__identity-domain {
+    color: ${(props) => props.styles.identifierLinkColor};
+  }
+  .usa-identifier__required-link:hover, .usa-identifier__required-link:active, 
+  .usa-identifier__required-link:visited {
     color: ${(props) => props.styles.identifierLinkColor};
   }
 `;

--- a/app/javascript/components/VerticalNav/VerticalNav.tsx
+++ b/app/javascript/components/VerticalNav/VerticalNav.tsx
@@ -16,6 +16,10 @@ const StyledPrimaryNav = styled(PrimaryNav).attrs<{ styles: FontsAndColors }>((p
     color: ${(props) => props.styles.searchTabNavigationLinkColor} !important;
   }
 
+  .usa-nav__primary > .usa-nav__primary-item .usa-nav__link:hover::after{
+    background-color: ${(props) => props.styles.searchTabNavigationLinkColor} !important;
+  }
+
   .usa-current::after,
   .usa-nav__primary > .usa-nav__primary-item button[aria-expanded=true] {
     background-color: ${(props) => props.styles.searchTabNavigationLinkColor} !important;

--- a/app/javascript/test/__snapshots__/SearchResultsLayout.test.tsx.snap
+++ b/app/javascript/test/__snapshots__/SearchResultsLayout.test.tsx.snap
@@ -15,9 +15,10 @@ exports[`SearchResultsLayout renders basic header styles properly 1`] = `
     .iEGEJu button.usa-menu-btn:hover{background-color:#9d9b02;}
     .fLKlZC .usa-banner__header,.fLKlZC .usa-banner__button-text{background-color:#643617;color:#dacb1b;}
     .fLKlZC .usa-banner__button::after,.fLKlZC .usa-banner__button[aria-expanded=true]:hover::after{background-color:#dacb1b;}
-    .eaGpdP li.usa-nav__primary-item:not(li.usa-nav__submenu-item)&gt;a,.eaGpdP .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=false]{color:#aea9f7!important;}
-    .eaGpdP .usa-current::after,.eaGpdP .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=true]{background-color:#aea9f7!important;}
-    .eaGpdP .vertical-wrapper .usa-nav__submenu{background-color:#aea9f7!important;}
+    .ehHJvD li.usa-nav__primary-item:not(li.usa-nav__submenu-item)&gt;a,.ehHJvD .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=false]{color:#aea9f7!important;}
+    .ehHJvD .usa-nav__primary&gt;.usa-nav__primary-item .usa-nav__link:hover::after{background-color:#aea9f7!important;}
+    .ehHJvD .usa-current::after,.ehHJvD .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=true]{background-color:#aea9f7!important;}
+    .ehHJvD .vertical-wrapper .usa-nav__submenu{background-color:#aea9f7!important;}
     .hVQcvF{font-family:"Helvetica Neue","Helvetica","Roboto","Arial",sans-serif;}
     .hVQcvF .result-title-label&gt;.result-title-link{color:#33f0aa;}
     .hVQcvF .result-title-label&gt;.result-title-link:visited{color:#4a97ad;}
@@ -25,9 +26,10 @@ exports[`SearchResultsLayout renders basic header styles properly 1`] = `
     .hVQcvF .result-desc .result-url-text{color:#475830;}
     .eKmfZT{font-family:"Helvetica Neue","Helvetica","Roboto","Arial",sans-serif;background-color:#5fcfc5;}
     .eKmfZT .usa-footer__return-to-top&gt;a,.eKmfZT a.usa-footer__primary-link{color:#46f966;}
-    .hsppyX{background-color:#be1c21;font-family:"Public Sans Web"!important;}
-    .hsppyX .usa-identifier__container,.hsppyX .usa-identifier__container&gt;a,.hsppyX .usa-identifier__identity-disclaimer,.hsppyX .usa-identifier__identity-disclaimer&gt;a{color:#f48a4c;}
-    .hsppyX .usa-identifier__required-links-item&gt;a,.hsppyX .usa-identifier__identity-domain{color:#5d5a6f;}
+    .eCEuKZ{background-color:#be1c21;font-family:"Public Sans Web"!important;}
+    .eCEuKZ .usa-identifier__container,.eCEuKZ .usa-identifier__container&gt;a,.eCEuKZ .usa-identifier__identity-disclaimer,.eCEuKZ .usa-identifier__identity-disclaimer&gt;a{color:#f48a4c;}
+    .eCEuKZ .usa-identifier__required-link,.eCEuKZ .usa-identifier__identity-domain{color:#5d5a6f;}
+    .eCEuKZ .usa-identifier__required-link:hover,.eCEuKZ .usa-identifier__required-link:active,.eCEuKZ .usa-identifier__required-link:visited{color:#5d5a6f;}
     .serp-result-wrapper{background-color:#761816;}
     .usa-button{background-color:#cfcd03;}
     .usa-button:hover{background-color:#9d9b02;}
@@ -58,9 +60,10 @@ exports[`SearchResultsLayout renders extended header styles properly 1`] = `
     .hhshoz button.usa-menu-btn:hover{background-color:#9d9b02;}
     .fLKlZC .usa-banner__header,.fLKlZC .usa-banner__button-text{background-color:#643617;color:#dacb1b;}
     .fLKlZC .usa-banner__button::after,.fLKlZC .usa-banner__button[aria-expanded=true]:hover::after{background-color:#dacb1b;}
-    .eaGpdP li.usa-nav__primary-item:not(li.usa-nav__submenu-item)&gt;a,.eaGpdP .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=false]{color:#aea9f7!important;}
-    .eaGpdP .usa-current::after,.eaGpdP .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=true]{background-color:#aea9f7!important;}
-    .eaGpdP .vertical-wrapper .usa-nav__submenu{background-color:#aea9f7!important;}
+    .ehHJvD li.usa-nav__primary-item:not(li.usa-nav__submenu-item)&gt;a,.ehHJvD .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=false]{color:#aea9f7!important;}
+    .ehHJvD .usa-nav__primary&gt;.usa-nav__primary-item .usa-nav__link:hover::after{background-color:#aea9f7!important;}
+    .ehHJvD .usa-current::after,.ehHJvD .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=true]{background-color:#aea9f7!important;}
+    .ehHJvD .vertical-wrapper .usa-nav__submenu{background-color:#aea9f7!important;}
     .hVQcvF{font-family:"Helvetica Neue","Helvetica","Roboto","Arial",sans-serif;}
     .hVQcvF .result-title-label&gt;.result-title-link{color:#33f0aa;}
     .hVQcvF .result-title-label&gt;.result-title-link:visited{color:#4a97ad;}
@@ -68,9 +71,10 @@ exports[`SearchResultsLayout renders extended header styles properly 1`] = `
     .hVQcvF .result-desc .result-url-text{color:#475830;}
     .eKmfZT{font-family:"Helvetica Neue","Helvetica","Roboto","Arial",sans-serif;background-color:#5fcfc5;}
     .eKmfZT .usa-footer__return-to-top&gt;a,.eKmfZT a.usa-footer__primary-link{color:#46f966;}
-    .hsppyX{background-color:#be1c21;font-family:"Public Sans Web"!important;}
-    .hsppyX .usa-identifier__container,.hsppyX .usa-identifier__container&gt;a,.hsppyX .usa-identifier__identity-disclaimer,.hsppyX .usa-identifier__identity-disclaimer&gt;a{color:#f48a4c;}
-    .hsppyX .usa-identifier__required-links-item&gt;a,.hsppyX .usa-identifier__identity-domain{color:#5d5a6f;}
+    .eCEuKZ{background-color:#be1c21;font-family:"Public Sans Web"!important;}
+    .eCEuKZ .usa-identifier__container,.eCEuKZ .usa-identifier__container&gt;a,.eCEuKZ .usa-identifier__identity-disclaimer,.eCEuKZ .usa-identifier__identity-disclaimer&gt;a{color:#f48a4c;}
+    .eCEuKZ .usa-identifier__required-link,.eCEuKZ .usa-identifier__identity-domain{color:#5d5a6f;}
+    .eCEuKZ .usa-identifier__required-link:hover,.eCEuKZ .usa-identifier__required-link:active,.eCEuKZ .usa-identifier__required-link:visited{color:#5d5a6f;}
     .serp-result-wrapper{background-color:#761816;}
     .usa-button{background-color:#cfcd03;}
     .usa-button:hover{background-color:#9d9b02;}
@@ -101,9 +105,10 @@ exports[`SearchResultsLayout renders search with results styles properly 1`] = `
     .hhshoz button.usa-menu-btn:hover{background-color:#9d9b02;}
     .fLKlZC .usa-banner__header,.fLKlZC .usa-banner__button-text{background-color:#643617;color:#dacb1b;}
     .fLKlZC .usa-banner__button::after,.fLKlZC .usa-banner__button[aria-expanded=true]:hover::after{background-color:#dacb1b;}
-    .eaGpdP li.usa-nav__primary-item:not(li.usa-nav__submenu-item)&gt;a,.eaGpdP .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=false]{color:#aea9f7!important;}
-    .eaGpdP .usa-current::after,.eaGpdP .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=true]{background-color:#aea9f7!important;}
-    .eaGpdP .vertical-wrapper .usa-nav__submenu{background-color:#aea9f7!important;}
+    .ehHJvD li.usa-nav__primary-item:not(li.usa-nav__submenu-item)&gt;a,.ehHJvD .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=false]{color:#aea9f7!important;}
+    .ehHJvD .usa-nav__primary&gt;.usa-nav__primary-item .usa-nav__link:hover::after{background-color:#aea9f7!important;}
+    .ehHJvD .usa-current::after,.ehHJvD .usa-nav__primary&gt;.usa-nav__primary-item button[aria-expanded=true]{background-color:#aea9f7!important;}
+    .ehHJvD .vertical-wrapper .usa-nav__submenu{background-color:#aea9f7!important;}
     .hVQcvF{font-family:"Helvetica Neue","Helvetica","Roboto","Arial",sans-serif;}
     .hVQcvF .result-title-label&gt;.result-title-link{color:#33f0aa;}
     .hVQcvF .result-title-label&gt;.result-title-link:visited{color:#4a97ad;}
@@ -111,9 +116,10 @@ exports[`SearchResultsLayout renders search with results styles properly 1`] = `
     .hVQcvF .result-desc .result-url-text{color:#475830;}
     .eKmfZT{font-family:"Helvetica Neue","Helvetica","Roboto","Arial",sans-serif;background-color:#5fcfc5;}
     .eKmfZT .usa-footer__return-to-top&gt;a,.eKmfZT a.usa-footer__primary-link{color:#46f966;}
-    .hsppyX{background-color:#be1c21;font-family:"Public Sans Web"!important;}
-    .hsppyX .usa-identifier__container,.hsppyX .usa-identifier__container&gt;a,.hsppyX .usa-identifier__identity-disclaimer,.hsppyX .usa-identifier__identity-disclaimer&gt;a{color:#f48a4c;}
-    .hsppyX .usa-identifier__required-links-item&gt;a,.hsppyX .usa-identifier__identity-domain{color:#5d5a6f;}
+    .eCEuKZ{background-color:#be1c21;font-family:"Public Sans Web"!important;}
+    .eCEuKZ .usa-identifier__container,.eCEuKZ .usa-identifier__container&gt;a,.eCEuKZ .usa-identifier__identity-disclaimer,.eCEuKZ .usa-identifier__identity-disclaimer&gt;a{color:#f48a4c;}
+    .eCEuKZ .usa-identifier__required-link,.eCEuKZ .usa-identifier__identity-domain{color:#5d5a6f;}
+    .eCEuKZ .usa-identifier__required-link:hover,.eCEuKZ .usa-identifier__required-link:active,.eCEuKZ .usa-identifier__required-link:visited{color:#5d5a6f;}
     .serp-result-wrapper{background-color:#761816;}
     .usa-button{background-color:#cfcd03;}
     .usa-button:hover{background-color:#9d9b02;}


### PR DESCRIPTION
## Summary
- Fix for [SRCH-4858](https://cm-jira.usa.gov/browse/SRCH-4858) Search tab dropdown underline hover color should use the navigation link color
- Fix for [SRCH-4849](https://cm-jira.usa.gov/browse/SRCH-4849) remove the hover from the css for the identifier
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
