### PR TITLE
SRCH-4921 Implement RSS News click tracking

### DIFF
--- a/app/javascript/components/Results/Results.tsx
+++ b/app/javascript/components/Results/Results.tsx
@@ -233,6 +233,9 @@ export const Results = ({ page, query = '', results = null, additionalResults = 
               <RssNews 
                 news={additionalResults.newNews} 
                 newsLabel={newsAboutQuery}
+                affiliate={page?.affiliate ?? ''}
+                query={query}
+                vertical={vertical}
               />
             }
 
@@ -297,6 +300,9 @@ export const Results = ({ page, query = '', results = null, additionalResults = 
               <RssNews 
                 news={additionalResults.oldNews} 
                 newsLabel={newsAboutQuery}
+                affiliate={page?.affiliate ?? ''}
+                query={query}
+                vertical={vertical}
               />
             }
 

--- a/app/javascript/components/Results/RssNews/RssNews.tsx
+++ b/app/javascript/components/Results/RssNews/RssNews.tsx
@@ -34,9 +34,7 @@ const StyledWrapper = styled.div.attrs<{ styles: FontsAndColors; }>((props) => (
 export const RssNews = ({ affiliate, newsLabel, news=[], query, vertical }: RssNewsProps) => {
   const styles = useContext(StyleContext);
 
-  const module = (() => {
-    return moduleCode.rssFeeds;
-  })();
+  const module = moduleCode.rssFeeds;
 
   return (
     <>

--- a/app/javascript/components/Results/RssNews/RssNews.tsx
+++ b/app/javascript/components/Results/RssNews/RssNews.tsx
@@ -5,8 +5,13 @@ import { GridContainer, Grid } from '@trussworks/react-uswds';
 import parse from 'html-react-parser';
 import { StyleContext } from '../../../contexts/StyleContext';
 import { FontsAndColors } from '../../SearchResultsLayout';
+import { clickTracking } from '../../../utils';
+import { moduleCode } from '../../../utils/constants';
+import ResultGridWrapper from '../ResultGrid/ResultGridWrapper';
+import ResultTitle from '../ResultGrid/ResultTitle';
 
 interface RssNewsProps {
+  affiliate: string;
   newsLabel: string;
   news?: {
     title: string;
@@ -14,6 +19,8 @@ interface RssNewsProps {
     description: string;
     publishedAt: string;
   }[];
+  query: string;
+  vertical: string;
 }
 
 const StyledWrapper = styled.div.attrs<{ styles: FontsAndColors; }>((props) => ({
@@ -24,8 +31,12 @@ const StyledWrapper = styled.div.attrs<{ styles: FontsAndColors; }>((props) => (
   }
 `;
 
-export const RssNews = ({ newsLabel, news=[] }: RssNewsProps) => {
+export const RssNews = ({ affiliate, newsLabel, news=[], query, vertical }: RssNewsProps) => {
   const styles = useContext(StyleContext);
+
+  const module = (() => {
+    return moduleCode.rssFeeds;
+  })();
 
   return (
     <>
@@ -43,16 +54,21 @@ export const RssNews = ({ newsLabel, news=[] }: RssNewsProps) => {
             {news?.map((newsItem, index) => {
               return (
                 <GridContainer className='result search-result-item' key={index}>
-                  <Grid row gap="md">
+                  <ResultGridWrapper
+                    url={newsItem.link}
+                    clickTracking={() => clickTracking(affiliate, module, query, index+1, newsItem.link, vertical)}>
                     <Grid col={true} className='result-meta-data'>
                       <span className='published-date'>
                         <Moment fromNow>{newsItem.publishedAt}</Moment>
                       </span>
                       <div className='result-title'>
                         <h2 className='result-title-label'>
-                          <a href={newsItem.link} className='result-title-link'>
+                          <ResultTitle 
+                              url={newsItem.link}
+                              className='result-title-link'
+                              clickTracking={() => clickTracking(affiliate, module, query, index+1, newsItem.link, vertical)}>
                             {parse(newsItem.title)}
-                          </a>
+                          </ResultTitle>
                         </h2> 
                       </div>
                       <div className='result-desc'>
@@ -60,7 +76,7 @@ export const RssNews = ({ newsLabel, news=[] }: RssNewsProps) => {
                         <div className='result-url-text'>{newsItem.link}</div>
                       </div>
                     </Grid>
-                  </Grid>
+                  </ResultGridWrapper>
                   <Grid row className="row-mobile-divider"></Grid>
                 </GridContainer>
               );

--- a/app/javascript/components/Results/RssNews/RssNews.tsx
+++ b/app/javascript/components/Results/RssNews/RssNews.tsx
@@ -64,9 +64,9 @@ export const RssNews = ({ affiliate, newsLabel, news=[], query, vertical }: RssN
                       <div className='result-title'>
                         <h2 className='result-title-label'>
                           <ResultTitle 
-                              url={newsItem.link}
-                              className='result-title-link'
-                              clickTracking={() => clickTracking(affiliate, module, query, index+1, newsItem.link, vertical)}>
+                            url={newsItem.link}
+                            className='result-title-link'
+                            clickTracking={() => clickTracking(affiliate, module, query, index+1, newsItem.link, vertical)}>
                             {parse(newsItem.title)}
                           </ResultTitle>
                         </h2> 

--- a/app/javascript/test/RssNews.test.tsx
+++ b/app/javascript/test/RssNews.test.tsx
@@ -1,3 +1,5 @@
+/* eslint-disable camelcase */
+
 import '@testing-library/jest-dom';
 import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';

--- a/app/javascript/test/RssNews.test.tsx
+++ b/app/javascript/test/RssNews.test.tsx
@@ -1,11 +1,25 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import React from 'react';
+import { enableFetchMocks } from 'jest-fetch-mock';
+enableFetchMocks();
 
 import { RssNews } from '../components/Results/RssNews/RssNews';
 
 describe('Rss News component', () => {
+  const headers = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json'
+  };
+
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({})
+    })
+  ) as jest.Mock;
+
   const newsProps = {
+    affiliate: 'test_affiliate',
     news: [
       {
         title: '<strong>GSA</strong> title',
@@ -14,7 +28,9 @@ describe('Rss News component', () => {
         publishedAt: '2023-08-17'
       }
     ],
-    newsLabel: 'News about gsa'
+    newsLabel: 'News about gsa',
+    query: 'news',
+    vertical: 'web'
   };
 
   it('renders rss news component', () => {
@@ -28,5 +44,83 @@ describe('Rss News component', () => {
       <RssNews {...newsProps}/>
     );
     expect(screen.getByText('News about gsa')).toBeInTheDocument();
+  });
+
+  it('calls fetch with correct rss news click data', () => {
+    render(<RssNews {...newsProps}/>);
+
+    const link = screen.getByText(/title/i);
+    fireEvent.click(link);
+    const clickBody = {
+      affiliate: 'test_affiliate',
+      url: 'https://test.com',
+      module_code: 'NEWS',
+      position: 1,
+      query: 'news',
+      vertical: 'web'
+    };
+
+    expect(fetch).toHaveBeenCalledWith('/clicked', {
+      body: JSON.stringify(clickBody),
+      headers,
+      method: 'POST',
+      mode: 'cors'
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('Mobile view: RSS news clicking the content div', () => {
+  beforeAll(() => {
+    window.innerWidth = 450;
+  });
+
+  const newsProps = {
+    affiliate: 'test_affiliate',
+    news: [
+      {
+        title: '<strong>GSA</strong> title',
+        description: 'test description',
+        link: 'https://test.com',
+        publishedAt: '2023-08-17'
+      }
+    ],
+    newsLabel: 'News about gsa',
+    query: 'news',
+    vertical: 'web'
+  };
+
+  const headers = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json'
+  };
+
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({})
+    })
+  ) as jest.Mock;
+
+  it('calls fetch with correct federal reg document click data', () => {
+    render(<RssNews {...newsProps}/>);
+
+    const desc = screen.getByText(/test description/i);
+    fireEvent.click(desc);
+    const clickBody = {
+      affiliate: 'test_affiliate',
+      url: 'https://test.com',
+      module_code: 'NEWS',
+      position: 1,
+      query: 'news',
+      vertical: 'web'
+    };
+
+    expect(fetch).toHaveBeenCalledWith('/clicked', {
+      body: JSON.stringify(clickBody),
+      headers,
+      method: 'POST',
+      mode: 'cors'
+    });
+    expect(fetch).toHaveBeenCalledTimes(1);
   });
 });

--- a/app/javascript/utils/constants.ts
+++ b/app/javascript/utils/constants.ts
@@ -15,5 +15,6 @@ export const moduleCode = {
   spellingSuggestionsSearch: 'SPEL',
   videos: 'VIDS',
   webI14y: 'I14Y',
+  webNews: 'NEWS',
   webWeb: 'BWEB'
 } as const;


### PR DESCRIPTION
## Summary
- Adds click tracking for RSS News items in both the primary and news verticals;
- Builds upon prior click tracking work like: #1488, #1490, #1493 , etc.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
