### PR TITLE
SRCH-5141 Removing Ruby 3.0 and MySQL 5.7 from Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -288,6 +288,8 @@ jobs:
         type: string
       mysql_version:
         type: string
+      node_version:
+        type: string
 
     executor: 
       name: test_executor

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -322,13 +322,11 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - 3.0.6
                 - 3.1.4
               elasticsearch_version:
                 - 7.17.7
                 # not yet compatible with Elasticsearch 8
               mysql_version:
-                - "5.7"
                 - "8.0"
 
       - rspec:
@@ -338,12 +336,10 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - 3.0.6
                 - 3.1.4
               elasticsearch_version:
                 - 7.17.7
               mysql_version:
-                - "5.7"
                 - "8.0"
 
       - cucumber:
@@ -353,12 +349,10 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - 3.0.6
                 - 3.1.4
               elasticsearch_version:
                 - 7.17.7
               mysql_version:
-                - "5.7"
                 - "8.0"
 
       - jest:
@@ -368,7 +362,6 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - 3.0.6
                 - 3.1.4
               elasticsearch_version:
                 - 7.17.7
@@ -386,10 +379,8 @@ workflows:
           matrix:
             parameters:
               ruby_version:
-                - 3.0.6
                 - 3.1.4
               elasticsearch_version:
                 - 7.17.7
               mysql_version:
-                - "5.7"
                 - "8.0"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -366,7 +366,7 @@ workflows:
               elasticsearch_version:
                 - 7.17.7
               mysql_version:
-                - "5.7"
+                - "8.0"
               node_version:
                 - 16.20.2
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -372,10 +372,10 @@ workflows:
 
       - report_coverage:
           requires:
-            - rspec
-            - cucumber
-            - jest
-          name: "report coverage: Ruby << matrix.ruby_version >>, ES << matrix.elasticsearch_version >>, MySQL << matrix.mysql_version >>"
+            - "rspec: Ruby << matrix.ruby_version >>, ES << matrix.elasticsearch_version >>, MySQL << matrix.mysql_version >>"
+            - "cucumber: Ruby << matrix.ruby_version >>, ES << matrix.elasticsearch_version >>, MySQL << matrix.mysql_version >>"
+            - "jest: NodeJS << matrix.node_version >>, Ruby << matrix.ruby_version >>, MySQL << matrix.mysql_version >>"
+          name: "report coverage: Ruby << matrix.ruby_version >>, ES << matrix.elasticsearch_version >>, MySQL << matrix.mysql_version >>, NodeJS << matrix.node_version >>"
           matrix:
             parameters:
               ruby_version:
@@ -384,3 +384,5 @@ workflows:
                 - 7.17.7
               mysql_version:
                 - "8.0"
+              node_version:
+                - 16.20.2

--- a/lib/url_status_code_fetcher.rb
+++ b/lib/url_status_code_fetcher.rb
@@ -29,8 +29,6 @@ module UrlStatusCodeFetcher
 
   def self.load_config
     YAML.load_file(Rails.root.join('config/url_status_code_fetcher.yml'), aliases: true)
-  rescue ArgumentError
-    YAML.load_file(Rails.root.join('config/url_status_code_fetcher.yml'))
   end
 
   def self.fetch_with_timeout(timeout_in_seconds, &block)


### PR DESCRIPTION
SRCH-5141 Removing Ruby 3.0 and MySQL 5.7 from Circle CI

## Summary
- Updating CircleCI to only use Ruby 3.1.4
- Updating CircleCI to only use MySQL 8.0

 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
