### PR TITLE
Make Docker build fail if curl fails

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM public.ecr.aws/docker/library/ruby:$RUBY_VERSION-slim as base
 # Rails app lives here
 WORKDIR /rails
 
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+
 # Install base packages
 RUN apt-get update -qq && \
     apt-get install --no-install-recommends -y \


### PR DESCRIPTION
## Summary

Use `-o pipefail` to make the piped command exit with error if curl fails.

tar should fail as well when the stdin is not what it's expecting, but hey, let's be preemptive.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [ ] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [ ] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [ ] You have specified at least one "Reviewer".
