### PR TITLE
SRCH-5549 Remove hardcoded ruby version from deploy.rb

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -14,7 +14,6 @@ set :puma_error_log,          "#{release_path}/log/puma.error.log"
 set :puma_threads,            [ENV.fetch('SEARCHGOV_MIN_THREADS', SEARCHGOV_THREADS), SEARCHGOV_THREADS]
 set :puma_workers,            ENV.fetch('SEARCHGOV_WORKERS') { 0 }
 set :rails_env,               'production'
-set :rbenv_ruby,              '3.1.4'
 set :rbenv_type,              :user
 set :repo_url,                'https://github.com/GSA/search-gov'
 set :resque_environment_task, true


### PR DESCRIPTION
## Summary
- Remove hardcoded ruby version from deploy.rb. Capistrano will use the default ruby version comming from .ruby-version
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
