### PR TITLE
SRCH-6066 Allow api endpoint to respect affiliate's engine selection.

### DIFF
--- a/app/controllers/api/v2/searches_controller.rb
+++ b/app/controllers/api/v2/searches_controller.rb
@@ -17,7 +17,7 @@ module Api
       end
 
       def i14y
-        @search = ApiI14ySearch.new(@search_options.attributes)
+        @search = selected_engine.new(@search_options.attributes)
         @search.run
         respond_with(@search)
       end
@@ -38,6 +38,14 @@ module Api
       end
 
       private
+
+      def selected_engine
+        if @search_options.site.search_elastic_engine?
+          ApiSearchElastic
+        else
+          ApiI14ySearch
+        end
+      end
 
       def handle_query_routing
         affiliate = @search_options.site

--- a/app/models/api_search_elastic.rb
+++ b/app/models/api_search_elastic.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+class ApiSearchElastic < SearchElasticEngine
+  include ApiSearch
+
+  def as_json_result_hash(result)
+    super.merge(thumbnail_url: result.thumbnail_url)
+  end
+end

--- a/spec/models/api_search_elastic_spec.rb
+++ b/spec/models/api_search_elastic_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe ApiSearchElastic do
+  let(:affiliate) { affiliates(:basic_affiliate) }
+  subject(:search) { described_class.new(affiliate: affiliate) }
+
+  describe '#as_json_result_hash' do
+    let(:result) { double('result', thumbnail_url: 'https://search.gov/thumbnail.jpg') }
+    let(:parent_result_hash) { { title: 'parent title', url: 'https://search.gov/parent_url' } }
+
+    before do
+      # To isolate the test to only the logic in ApiSearchElastic, we stub the
+      # method on the parent class (SearchElasticEngine).
+      allow_any_instance_of(SearchElasticEngine).to receive(:as_json_result_hash).with(result).and_return(parent_result_hash)
+    end
+
+    it 'merges the thumbnail_url into the hash from the parent class' do
+      # We create an instance of the class we are testing
+      instance = described_class.new(affiliate: affiliate)
+      # We call the method, which will in turn call `super` (which is stubbed)
+      final_hash = instance.as_json_result_hash(result)
+
+      # We expect the final hash to be a merge of the parent's hash and the new key
+      expect(final_hash).to eq({
+        title: 'parent title',
+        url: 'https://search.gov/parent_url',
+        thumbnail_url: 'https://search.gov/thumbnail.jpg'
+      })
+    end
+  end
+end


### PR DESCRIPTION
Use a `selected_engine` method to select the appropriate search affiliate search engine.