### PR TITLE
[SRCH-6233] Update the mark_inactive_as_timed_out!

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -85,7 +85,7 @@ class User < ApplicationRecord
   # end
 
   def self.mark_inactive_as_timed_out!
-    not_active.update_all(approval_status: 'timed_out', updated_at: Time.current)
+    approved.not_active.update_all(approval_status: 'timed_out', updated_at: Time.current)
   end
 
   def timed_out?


### PR DESCRIPTION
JIRA TICKET: https://cm-jira.usa.gov/browse/SRCH-6233

## Details
- Replaces the broad query with a targeted update:
    - From: all users `not_active`
    - To: only users `approved.not_active`

- Keeps acceptance criteria intact:
    - Only approved users can time out after 90 days.
    - Non-gov/mil users who have never been approved remain . `pending_approval`

## Operational Notes
- Rake task now uses the corrected logic via . `usasearch:user:update_not_active_approval_status``User.mark_inactive_as_timed_out!`
- No data migrations included; this change impacts future runs.
