### PR TITLE
SRCH-6250 Revert fetch_env_vars script

### DIFF
--- a/cicd-scripts/fetch_env_vars.sh
+++ b/cicd-scripts/fetch_env_vars.sh
@@ -43,7 +43,7 @@ cat .env
 cp /home/search/cicd_temp/.env /home/search/searchgov/shared/
 
 # Fetch a specific parameter and save it to a file
-aws ssm get-parameter --name "LOGIN_DOT_GOV_PEM" --region us-east-2 --with-decryption --query "Parameter.Value" --output text > /home/search/searchgov/logindotgov.pem
+aws ssm get-parameter --name "LOGIN_DOT_GOV_PEM" --region us-east-2 --with-decryption --query "Parameter.Value" --output text > /home/search/searchgov/shared/config/logindotgov.pem
 
 # create puma folders and files
 
@@ -58,10 +58,10 @@ aws ssm get-parameter --name "LOGIN_DOT_GOV_PEM" --region us-east-2 --with-decry
 
 # Set ownership and permissions
 chown -R search:search /home/search/searchgov/
-chmod -R 777 /home/search/searchgov/
+chmod -R 755 /home/search/searchgov/
 
-find /home/search/searchgov/ -type d -exec chmod 2777 {} \;
+find /home/search/searchgov/ -type d -exec chmod 2755 {} \;
 
-umask 000
+umask 022
 
 sudo rm -rf /home/search/cicd_temp/*


### PR DESCRIPTION
## Summary
- I don't know how but this file is different in main than it is in [staging](https://github.com/GSA/search-gov/blob/staging/cicd-scripts/fetch_env_vars.sh) and [production](https://github.com/GSA/search-gov/blob/production/cicd-scripts/fetch_env_vars.sh).  
- Running the deploy with this file in main causes error related to the `chmod 777` present here but not in prod and staging.
- This does not appear to fix the dev deploy but does fix this one error and really this file should be the same as it is in staging and prod.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [X] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [X] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [X] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
