### PR TITLE
SRCH-6449: Build OpenSearch document indexing service

### DIFF
--- a/app/models/legacy_opensearch/document_indexer.rb
+++ b/app/models/legacy_opensearch/document_indexer.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class LegacyOpenSearch::DocumentIndexer
+  class DocumentIndexerError < StandardError; end
+  class DuplicateID < DocumentIndexerError; end
+
+  INDEX_NAME = ENV.fetch('LEGACY_OPENSEARCH_INDEX')
+
+  # Indexes a document into OpenSearch. Accepts the same params shape as
+  # SearchgovUrl#i14y_params. Uses Serde.serialize_hash to transform fields
+  # (language-suffix renaming, HTML sanitization, array conversion, etc.)
+  # before writing.
+  #
+  # This is an upsert: it creates the document if it doesn't exist, or
+  # replaces it if it does. The i14y create/update distinction is unnecessary
+  # here because SearchgovUrl#i14y_params always sends the full field set.
+  def self.index(params)
+    params = ActiveSupport::HashWithIndifferentAccess.new(params.deep_dup)
+    document_id = params.delete(:document_id)
+    language = params.delete(:language) || 'en'
+    params.delete(:handle)
+
+    raise DocumentIndexerError, 'document_id is required' if document_id.blank?
+
+    params[:created_at] ||= Time.now.utc
+
+    body = Serde.serialize_hash(params, language)
+    body[:language] = language
+
+    client.index(
+      index: INDEX_NAME,
+      id: document_id,
+      body: body
+    )
+  rescue Elasticsearch::Transport::Transport::Errors::Conflict => e
+    raise DuplicateID, e.message
+  rescue Elasticsearch::Transport::Transport::Error => e
+    Rails.logger.error "[LegacyOpenSearch::DocumentIndexer] Failed to index document #{document_id}: #{e.message}"
+    raise DocumentIndexerError, e.message
+  end
+
+  def self.delete(document_id:, **_)
+    client.delete(
+      index: INDEX_NAME,
+      id: document_id
+    )
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    Rails.logger.warn "[LegacyOpenSearch::DocumentIndexer] Document not found for deletion: #{document_id}"
+  rescue Elasticsearch::Transport::Transport::Error => e
+    Rails.logger.error "[LegacyOpenSearch::DocumentIndexer] Failed to delete document #{document_id}: #{e.message}"
+    raise DocumentIndexerError, e.message
+  end
+
+  def self.client
+    OpenSearchConfig.search_client
+  end
+  private_class_method :client
+end

--- a/config/initializers/extensions/string.rb
+++ b/config/initializers/extensions/string.rb
@@ -8,4 +8,7 @@ class String
     gsub(/(\b|')[a-z]+/) { |w| NON_CAPITALIZED.include?(w) ? w : w.capitalize }.sub(/^[a-z]/) { |l| l.upcase }
   end
 
+  def extract_array
+    split(',').map(&:strip).map(&:downcase)
+  end
 end

--- a/spec/lib/serde_spec.rb
+++ b/spec/lib/serde_spec.rb
@@ -1,0 +1,335 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Serde do
+  describe '.serialize_hash' do
+    subject(:serialize_hash) do
+      described_class.serialize_hash(original_hash, 'en')
+    end
+
+    let(:original_hash) do
+      ActiveSupport::HashWithIndifferentAccess.new(
+        { 'title' => 'my title',
+          'description' => 'my description',
+          'content' => 'my content',
+          'path' => 'http://www.foo.gov/bar.html',
+          'promote' => false,
+          'audience' => 'Everyone',
+          'content_type' => 'EVENT',
+          'tags' => 'this that',
+          'searchgov_custom1' => 'this, Custom, CONTENT',
+          'searchgov_custom2' => 'That custom, Content',
+          'searchgov_custom3' => '123',
+          'created' => '2018-01-01T12:00:00Z',
+          'changed' => '2018-02-01T12:00:00Z',
+          'created_at' => '2018-01-01T12:00:00Z',
+          'updated_at' => '2018-02-01T12:00:00Z' }
+      )
+    end
+
+    it 'stores the language fields with the language suffix' do
+      expect(serialize_hash).to match(hash_including(
+                                        { 'title_en' => 'my title',
+                                          'description_en' => 'my description',
+                                          'content_en' => 'my content' }
+                                      ))
+    end
+
+    it 'removes the original language field keys' do
+      expect(serialize_hash).not_to have_key('title')
+      expect(serialize_hash).not_to have_key('description')
+      expect(serialize_hash).not_to have_key('content')
+    end
+
+    it 'stores downcased audience' do
+      expect(serialize_hash).to match(hash_including({ 'audience' => 'everyone' }))
+    end
+
+    it 'stores downcased content_type' do
+      expect(serialize_hash).to match(hash_including({ 'content_type' => 'event' }))
+    end
+
+    it 'stores tags as a downcased array' do
+      expect(serialize_hash).to match(hash_including({ 'tags' => ['this that'] }))
+    end
+
+    it 'stores searchgov_custom fields as downcased arrays' do
+      expect(serialize_hash).to match(hash_including(
+                                        { 'searchgov_custom1' => %w[this custom content],
+                                          'searchgov_custom2' => ['that custom', 'content'],
+                                          'searchgov_custom3' => ['123'] }
+                                      ))
+    end
+
+    it 'updates the updated_at value' do
+      expect(serialize_hash[:updated_at]).to be > 1.second.ago
+    end
+
+    it 'extracts URI params from the path' do
+      expect(serialize_hash).to match(hash_including(
+                                        basename: 'bar',
+                                        extension: 'html',
+                                        url_path: '/bar.html',
+                                        domain_name: 'www.foo.gov'
+                                      ))
+    end
+
+    context 'when language fields contain HTML/CSS' do
+      let(:html) do
+        <<~HTML
+          <div style="height: 100px; width: 100px;"></div>
+          <p>hello & goodbye!</p>
+        HTML
+      end
+
+      let(:original_hash) do
+        ActiveSupport::HashWithIndifferentAccess.new(
+          title: '<b><a href="http://foo.com/">foo</a></b><img src="bar.jpg">',
+          description: html,
+          content: "this <b>is</b> <a href='http://gov.gov/url.html'>html</a>"
+        )
+      end
+
+      it 'sanitizes the language fields' do
+        expect(serialize_hash).to match(hash_including(
+                                          title_en: 'foo',
+                                          description_en: 'hello & goodbye!',
+                                          content_en: 'this is html'
+                                        ))
+      end
+    end
+
+    context 'with Spanish language' do
+      subject(:serialize_hash) do
+        described_class.serialize_hash(original_hash, 'es')
+      end
+
+      let(:original_hash) do
+        ActiveSupport::HashWithIndifferentAccess.new(
+          title: 'Título de la página',
+          description: 'Descripción en español',
+          content: 'Contenido principal'
+        )
+      end
+
+      it 'stores fields with the es suffix' do
+        expect(serialize_hash).to match(hash_including(
+                                          'title_es' => 'Título de la página',
+                                          'description_es' => 'Descripción en español',
+                                          'content_es' => 'Contenido principal'
+                                        ))
+      end
+
+      it 'does not create en-suffixed fields' do
+        expect(serialize_hash).not_to have_key('title_en')
+      end
+    end
+
+    context 'when language fields contain special characters' do
+      let(:original_hash) do
+        ActiveSupport::HashWithIndifferentAccess.new(
+          title: 'Quotes "double" & \'single\' + ampersands',
+          description: 'Unicode: café résumé naïve',
+          content: 'Symbols: <em>©</em> ® ™ — –'
+        )
+      end
+
+      it 'sanitizes HTML and preserves non-HTML special characters' do
+        expect(serialize_hash).to match(hash_including(
+                                          'title_en' => 'Quotes "double" & \'single\' + ampersands',
+                                          'description_en' => 'Unicode: café résumé naïve',
+                                          'content_en' => 'Symbols: © ® ™ — –'
+                                        ))
+      end
+    end
+
+    context 'when the tags are a comma-delimited list' do
+      let(:original_hash) do
+        { tags: 'this, that' }
+      end
+
+      it 'converts the tags to an array' do
+        expect(serialize_hash).to match(hash_including(tags: %w[this that]))
+      end
+    end
+
+    context 'when array fields are already arrays' do
+      let(:original_hash) do
+        { tags: %w[already an array],
+          searchgov_custom1: %w[pre split] }
+      end
+
+      it 'leaves them unchanged' do
+        expect(serialize_hash).to match(hash_including(
+                                          tags: %w[already an array],
+                                          searchgov_custom1: %w[pre split]
+                                        ))
+      end
+    end
+
+    context 'when optional fields are missing' do
+      let(:original_hash) do
+        ActiveSupport::HashWithIndifferentAccess.new(
+          title: 'Just a title',
+          path: 'http://www.example.gov/page.html'
+        )
+      end
+
+      it 'does not add nil audience or content_type' do
+        expect(serialize_hash).not_to have_key(:audience)
+        expect(serialize_hash).not_to have_key(:content_type)
+      end
+
+      it 'does not add nil tags or custom fields' do
+        expect(serialize_hash[:tags]).to be_nil
+        expect(serialize_hash[:searchgov_custom1]).to be_nil
+      end
+
+      it 'still processes language fields and URI params' do
+        expect(serialize_hash).to match(hash_including(
+                                          'title_en' => 'Just a title',
+                                          basename: 'page',
+                                          extension: 'html'
+                                        ))
+      end
+    end
+
+    context 'when path is missing' do
+      let(:original_hash) do
+        { title: 'No path document' }
+      end
+
+      it 'does not add URI params' do
+        expect(serialize_hash).not_to have_key(:basename)
+        expect(serialize_hash).not_to have_key(:extension)
+        expect(serialize_hash).not_to have_key(:url_path)
+        expect(serialize_hash).not_to have_key(:domain_name)
+      end
+    end
+  end
+
+  describe '.deserialize_hash' do
+    subject(:deserialize_hash) do
+      described_class.deserialize_hash(original_hash, :en)
+    end
+
+    let(:original_hash) do
+      ActiveSupport::HashWithIndifferentAccess.new(
+        { 'created_at' => '2018-08-09T21:36:50.087Z',
+          'updated_at' => '2018-08-09T21:36:50.087Z',
+          'path' => 'http://www.foo.gov/bar.html',
+          'language' => 'en',
+          'created' => '2018-08-09T19:36:50.087Z',
+          'updated' => '2018-08-09T14:36:50.087-07:00',
+          'changed' => '2018-08-09T14:36:50.087-07:00',
+          'promote' => true,
+          'tags' => 'this that',
+          'title_en' => 'my title',
+          'description_en' => 'my description',
+          'content_en' => 'my content',
+          'basename' => 'bar',
+          'extension' => 'html',
+          'url_path' => '/bar.html',
+          'domain_name' => 'www.foo.gov' }
+      )
+    end
+
+    it 'removes the language suffix from the text fields' do
+      expect(deserialize_hash).to include(
+        'title' => 'my title',
+        'description' => 'my description',
+        'content' => 'my content'
+      )
+    end
+
+    it 'removes derivative fields' do
+      expect(deserialize_hash).not_to have_key('basename')
+      expect(deserialize_hash).not_to have_key('extension')
+      expect(deserialize_hash).not_to have_key('url_path')
+      expect(deserialize_hash).not_to have_key('domain_name')
+      expect(deserialize_hash).not_to have_key('bigrams')
+    end
+
+    it 'removes language-suffixed keys' do
+      expect(deserialize_hash).not_to have_key('title_en')
+      expect(deserialize_hash).not_to have_key('description_en')
+      expect(deserialize_hash).not_to have_key('content_en')
+    end
+
+    it 'preserves non-language, non-derivative fields' do
+      expect(deserialize_hash).to include(
+        'path' => 'http://www.foo.gov/bar.html',
+        'language' => 'en',
+        'promote' => true,
+        'tags' => 'this that'
+      )
+    end
+  end
+
+  describe '.uri_params_hash' do
+    subject(:result) { described_class.uri_params_hash(path) }
+
+    let(:path) { 'https://www.agency.gov/directory/page1.html' }
+
+    it 'computes basename' do
+      expect(result[:basename]).to eq('page1')
+    end
+
+    it 'computes filename extension' do
+      expect(result[:extension]).to eq('html')
+    end
+
+    it 'computes url_path' do
+      expect(result[:url_path]).to eq('/directory/page1.html')
+    end
+
+    it 'computes domain_name' do
+      expect(result[:domain_name]).to eq('www.agency.gov')
+    end
+
+    context 'when the extension has uppercase characters' do
+      let(:path) { 'https://www.agency.gov/directory/PAGE1.PDF' }
+
+      it 'computes a downcased version of filename extension' do
+        expect(result[:extension]).to eq('pdf')
+      end
+    end
+
+    context 'when there is no filename extension' do
+      let(:path) { 'https://www.agency.gov/directory/page1' }
+
+      it 'computes an empty filename extension' do
+        expect(result[:extension]).to eq('')
+      end
+    end
+
+    context 'when the URL has query parameters' do
+      let(:path) { 'https://www.agency.gov/search?q=test&page=2' }
+
+      it 'extracts the path without query string' do
+        expect(result[:url_path]).to eq('/search')
+      end
+
+      it 'extracts basename from the path portion' do
+        expect(result[:basename]).to eq('search')
+      end
+    end
+
+    context 'when the URL has a fragment' do
+      let(:path) { 'https://www.agency.gov/page.html#section-2' }
+
+      it 'extracts the path without fragment' do
+        expect(result[:url_path]).to eq('/page.html')
+      end
+    end
+
+    context 'when the URL is a root path' do
+      let(:path) { 'https://www.agency.gov/' }
+
+      it 'extracts the root path' do
+        expect(result[:url_path]).to eq('/')
+      end
+    end
+  end
+end

--- a/spec/models/legacy_opensearch/document_indexer_spec.rb
+++ b/spec/models/legacy_opensearch/document_indexer_spec.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe LegacyOpenSearch::DocumentIndexer do
+  let(:client) { double('opensearch_client') }
+  let(:index_name) { ENV.fetch('LEGACY_OPENSEARCH_INDEX') }
+
+  before do
+    allow(OpenSearchConfig).to receive(:search_client).and_return(client)
+  end
+
+  describe '.index' do
+    let(:params) do
+      {
+        audience: 'Everyone',
+        changed: '2024-01-15T12:00:00Z',
+        content: 'Full page content here',
+        content_type: 'article',
+        created: '2024-01-01T00:00:00Z',
+        description: 'A test document',
+        document_id: 'abc123',
+        handle: 'searchgov',
+        thumbnail_url: 'https://example.gov/thumb.png',
+        language: 'en',
+        mime_type: 'text/html',
+        path: 'https://www.example.gov/page.html',
+        searchgov_custom1: 'custom, values',
+        searchgov_custom2: nil,
+        searchgov_custom3: nil,
+        tags: 'tag1, tag2',
+        title: 'Test Page Title'
+      }
+    end
+
+    it 'calls client.index with the correct index, id, and serialized body' do
+      expect(client).to receive(:index) do |args|
+        expect(args[:index]).to eq(index_name)
+        expect(args[:id]).to eq('abc123')
+        expect(args[:body][:language]).to eq('en')
+        expect(args[:body]['title_en']).to eq('Test Page Title')
+        expect(args[:body]['content_en']).to eq('Full page content here')
+        expect(args[:body]['description_en']).to eq('A test document')
+        expect(args[:body]['audience']).to eq('everyone')
+        expect(args[:body]['content_type']).to eq('article')
+        expect(args[:body][:basename]).to eq('page')
+        expect(args[:body][:extension]).to eq('html')
+        expect(args[:body][:domain_name]).to eq('www.example.gov')
+        expect(args[:body][:url_path]).to eq('/page.html')
+        expect(args[:body]['tags']).to eq(%w[tag1 tag2])
+        expect(args[:body]['searchgov_custom1']).to eq(%w[custom values])
+      end
+
+      described_class.index(params)
+    end
+
+    it 'strips handle from the indexed body' do
+      expect(client).to receive(:index) do |args|
+        expect(args[:body]).not_to have_key(:handle)
+        expect(args[:body]).not_to have_key('handle')
+      end
+
+      described_class.index(params)
+    end
+
+    it 'strips document_id from the indexed body' do
+      expect(client).to receive(:index) do |args|
+        expect(args[:body]).not_to have_key(:document_id)
+        expect(args[:body]).not_to have_key('document_id')
+      end
+
+      described_class.index(params)
+    end
+
+    it 'preserves language in the indexed body' do
+      expect(client).to receive(:index) do |args|
+        expect(args[:body][:language]).to eq('en')
+      end
+
+      described_class.index(params)
+    end
+
+    it 'sets created_at when not present in params' do
+      freeze_time do
+        expect(client).to receive(:index) do |args|
+          expect(args[:body][:updated_at]).to be_within(1.second).of(Time.now.utc)
+        end
+
+        described_class.index(params)
+      end
+    end
+
+    it 'preserves created_at when already present in params' do
+      existing_time = Time.utc(2023, 6, 15, 10, 0, 0)
+      params[:created_at] = existing_time
+
+      expect(client).to receive(:index) do |args|
+        expect(args[:body][:created_at]).to eq(existing_time)
+      end
+
+      described_class.index(params)
+    end
+
+    it 'does not mutate the original params hash' do
+      original_params = params.dup
+      allow(client).to receive(:index)
+
+      described_class.index(params)
+
+      expect(params).to eq(original_params)
+    end
+
+    context 'with Spanish language' do
+      before { params[:language] = 'es' }
+
+      it 'creates language-suffixed fields with es' do
+        expect(client).to receive(:index) do |args|
+          expect(args[:body]['title_es']).to eq('Test Page Title')
+          expect(args[:body][:language]).to eq('es')
+          expect(args[:body]).not_to have_key('title_en')
+        end
+
+        described_class.index(params)
+      end
+    end
+
+    context 'with nil language' do
+      before { params[:language] = nil }
+
+      it 'defaults to en' do
+        expect(client).to receive(:index) do |args|
+          expect(args[:body]['title_en']).to eq('Test Page Title')
+          expect(args[:body][:language]).to eq('en')
+        end
+
+        described_class.index(params)
+      end
+    end
+
+    context 'with missing optional fields' do
+      let(:sparse_params) do
+        {
+          document_id: 'sparse123',
+          language: 'en',
+          title: 'Minimal Document',
+          path: 'https://www.example.gov/minimal'
+        }
+      end
+
+      it 'indexes successfully without optional fields' do
+        expect(client).to receive(:index) do |args|
+          expect(args[:id]).to eq('sparse123')
+          expect(args[:body]['title_en']).to eq('Minimal Document')
+          expect(args[:body][:basename]).to eq('minimal')
+        end
+
+        described_class.index(sparse_params)
+      end
+    end
+
+    context 'with pre-existing array fields' do
+      before do
+        params[:tags] = %w[already an array]
+        params[:searchgov_custom1] = %w[pre split]
+      end
+
+      it 'passes arrays through unchanged' do
+        expect(client).to receive(:index) do |args|
+          expect(args[:body]['tags']).to eq(%w[already an array])
+          expect(args[:body]['searchgov_custom1']).to eq(%w[pre split])
+        end
+
+        described_class.index(params)
+      end
+    end
+
+    context 'with string-keyed params' do
+      let(:string_params) do
+        {
+          'document_id' => 'string_keys',
+          'language' => 'en',
+          'title' => 'String Keys',
+          'path' => 'https://example.gov/string',
+          'handle' => 'searchgov'
+        }
+      end
+
+      it 'handles string keys correctly' do
+        expect(client).to receive(:index) do |args|
+          expect(args[:id]).to eq('string_keys')
+          expect(args[:body]['title_en']).to eq('String Keys')
+        end
+
+        described_class.index(string_params)
+      end
+    end
+
+    context 'when document_id is blank' do
+      before { params[:document_id] = nil }
+
+      it 'raises DocumentIndexerError' do
+        expect { described_class.index(params) }.to raise_error(
+          described_class::DocumentIndexerError, 'document_id is required'
+        )
+      end
+
+      it 'does not call the client' do
+        expect(client).not_to receive(:index)
+        described_class.index(params) rescue nil
+      end
+    end
+
+    context 'when OpenSearch returns a conflict' do
+      before do
+        allow(client).to receive(:index).and_raise(
+          Elasticsearch::Transport::Transport::Errors::Conflict.new('[409] conflict')
+        )
+      end
+
+      it 'raises DuplicateID' do
+        expect { described_class.index(params) }.to raise_error(
+          described_class::DuplicateID
+        )
+      end
+    end
+
+    context 'when OpenSearch returns a transport error' do
+      before do
+        allow(client).to receive(:index).and_raise(
+          Elasticsearch::Transport::Transport::Errors::ServiceUnavailable.new('[503] unavailable')
+        )
+      end
+
+      it 'raises DocumentIndexerError' do
+        expect { described_class.index(params) }.to raise_error(
+          described_class::DocumentIndexerError
+        )
+      end
+
+      it 'logs the error' do
+        expect(Rails.logger).to receive(:error).with(/Failed to index document abc123/)
+        described_class.index(params) rescue nil
+      end
+    end
+  end
+
+  describe '.delete' do
+    it 'calls client.delete with the correct index and id' do
+      expect(client).to receive(:delete).with(
+        index: index_name,
+        id: 'doc_to_delete'
+      )
+
+      described_class.delete(document_id: 'doc_to_delete')
+    end
+
+    it 'accepts and ignores extra keyword arguments like handle' do
+      expect(client).to receive(:delete).with(
+        index: index_name,
+        id: 'doc123'
+      )
+
+      described_class.delete(handle: 'searchgov', document_id: 'doc123')
+    end
+
+    context 'when the document is not found' do
+      before do
+        allow(client).to receive(:delete).and_raise(
+          Elasticsearch::Transport::Transport::Errors::NotFound.new('[404] not found')
+        )
+      end
+
+      it 'does not raise an error' do
+        expect { described_class.delete(document_id: 'missing') }.not_to raise_error
+      end
+
+      it 'logs a warning' do
+        expect(Rails.logger).to receive(:warn).with(/Document not found for deletion: missing/)
+        described_class.delete(document_id: 'missing')
+      end
+    end
+
+    context 'when OpenSearch returns a transport error' do
+      before do
+        allow(client).to receive(:delete).and_raise(
+          Elasticsearch::Transport::Transport::Errors::ServiceUnavailable.new('[503] unavailable')
+        )
+      end
+
+      it 'raises DocumentIndexerError' do
+        expect { described_class.delete(document_id: 'doc123') }.to raise_error(
+          described_class::DocumentIndexerError
+        )
+      end
+
+      it 'logs the error' do
+        expect(Rails.logger).to receive(:error).with(/Failed to delete document doc123/)
+        described_class.delete(document_id: 'doc123') rescue nil
+      end
+    end
+  end
+end

--- a/spec/models/string_spec.rb
+++ b/spec/models/string_spec.rb
@@ -22,12 +22,12 @@ describe String do
       expect('  foo ,  bar  , baz '.extract_array).to eq(%w[foo bar baz])
     end
 
-    it 'returns an array with one empty string for an empty string' do
-      expect(''.extract_array).to eq([''])
+    it 'returns an empty array for an empty string' do
+      expect(''.extract_array).to eq([])
     end
 
-    it 'handles trailing commas' do
-      expect('one, two,'.extract_array).to eq(['one', 'two', ''])
+    it 'handles trailing commas by dropping empty trailing elements' do
+      expect('one, two,'.extract_array).to eq(['one', 'two'])
     end
   end
 end

--- a/spec/models/string_spec.rb
+++ b/spec/models/string_spec.rb
@@ -8,4 +8,26 @@ describe String do
       expect('Muammar al-Gaddafi'.sentence_case).to eq('Muammar al-Gaddafi')
     end
   end
+
+  describe '#extract_array' do
+    it 'splits on commas, strips whitespace, and downcases' do
+      expect('This, That, OTHER'.extract_array).to eq(%w[this that other])
+    end
+
+    it 'handles a single value with no comma' do
+      expect('single value'.extract_array).to eq(['single value'])
+    end
+
+    it 'handles extra whitespace around values' do
+      expect('  foo ,  bar  , baz '.extract_array).to eq(%w[foo bar baz])
+    end
+
+    it 'returns an array with one empty string for an empty string' do
+      expect(''.extract_array).to eq([''])
+    end
+
+    it 'handles trailing commas' do
+      expect('one, two,'.extract_array).to eq(['one', 'two', ''])
+    end
+  end
 end


### PR DESCRIPTION
## What this does

Adds a new `LegacyOpenSearch::DocumentIndexer` service class that can index and delete documents directly in OpenSearch, bypassing the i14y HTTP API entirely. This is the next piece of the Elasticsearch-to-OpenSearch migration (SRCH-6423).

The indexer accepts the same params shape that `SearchgovUrl` already builds for `I14yDocument`, runs the fields through `Serde.serialize_hash` for all the usual transformations (language-suffix renaming, HTML sanitization, array splitting, URI extraction), then writes straight to the OpenSearch cluster via `OPENSEARCH_CLIENT`.

Depends on #1993 (SRCH-6448) for `Serde` and `String#extract_array`.

## Key decisions

- Uses `client.index()` as an upsert instead of separate create/update calls -- this is simpler and matches what `SearchgovUrl` actually needs (re-crawls should overwrite)
- Wraps incoming params in `HashWithIndifferentAccess` to match how i14y's `DocumentRepository` feeds data to `Serde`
- Injects a `created_at` default when not provided, replicating i14y's `Document` model behavior
- Maps `Elasticsearch::Transport` errors to custom exception classes (`DuplicateID`, `DocumentIndexerError`) for clean caller handling
- `delete` accepts a `handle:` kwarg it ignores, for backward compatibility with existing call sites

## Files changed

- `app/models/legacy_opensearch/document_indexer.rb` -- new service class
- `spec/models/legacy_opensearch/document_indexer_spec.rb` -- full spec coverage

## Testing

1. Check out the branch and make sure the SRCH-6448 changes are present (`String#extract_array` and `Serde` specs)
2. Run the new specs:
   ```
   bundle exec rspec spec/models/legacy_opensearch/document_indexer_spec.rb
   ```
3. Verify specs cover:
   - Happy path indexing (correct body shape, language handling, Serde integration)
   - Happy path deletion
   - Error cases: blank document_id, duplicate ID conflict, transport errors, not-found on delete
   - Edge cases: nil language defaults to 'en', missing optional fields, string-keyed params, created_at preservation vs injection, original params not mutated