### PR TITLE
Production Release - Move Crawler to Opensearch

### DIFF
--- a/app/models/legacy_opensearch/document_indexer.rb
+++ b/app/models/legacy_opensearch/document_indexer.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+class LegacyOpenSearch::DocumentIndexer
+  class DocumentIndexerError < StandardError; end
+  class DuplicateID < DocumentIndexerError; end
+
+  INDEX_NAME = ENV.fetch('LEGACY_OPENSEARCH_INDEX')
+
+  # Indexes a document into OpenSearch. Accepts the same params shape as
+  # SearchgovUrl#i14y_params. Uses Serde.serialize_hash to transform fields
+  # (language-suffix renaming, HTML sanitization, array conversion, etc.)
+  # before writing.
+  #
+  # This is an upsert: it creates the document if it doesn't exist, or
+  # replaces it if it does. The i14y create/update distinction is unnecessary
+  # here because SearchgovUrl#i14y_params always sends the full field set.
+  def self.index(params)
+    params = ActiveSupport::HashWithIndifferentAccess.new(params.deep_dup)
+    document_id = params.delete(:document_id)
+    language = params.delete(:language) || 'en'
+    params.delete(:handle)
+
+    raise DocumentIndexerError, 'document_id is required' if document_id.blank?
+
+    params[:created_at] ||= Time.now.utc
+
+    body = Serde.serialize_hash(params, language)
+    body[:language] = language
+
+    client.index(
+      index: INDEX_NAME,
+      id: document_id,
+      body: body
+    )
+  rescue Elasticsearch::Transport::Transport::Errors::Conflict => e
+    raise DuplicateID, e.message
+  rescue Elasticsearch::Transport::Transport::Error => e
+    Rails.logger.error "[LegacyOpenSearch::DocumentIndexer] Failed to index document #{document_id}: #{e.message}"
+    raise DocumentIndexerError, e.message
+  end
+
+  def self.delete(document_id:, **_)
+    client.delete(
+      index: INDEX_NAME,
+      id: document_id
+    )
+  rescue Elasticsearch::Transport::Transport::Errors::NotFound
+    Rails.logger.warn "[LegacyOpenSearch::DocumentIndexer] Document not found for deletion: #{document_id}"
+  rescue Elasticsearch::Transport::Transport::Error => e
+    Rails.logger.error "[LegacyOpenSearch::DocumentIndexer] Failed to delete document #{document_id}: #{e.message}"
+    raise DocumentIndexerError, e.message
+  end
+
+  def self.client
+    OpenSearchConfig.search_client
+  end
+  private_class_method :client
+end

--- a/app/models/searchgov_url.rb
+++ b/app/models/searchgov_url.rb
@@ -209,8 +209,8 @@ class SearchgovUrl < ApplicationRecord
 
   def index_document
     Rails.logger.info "[Index SearchgovUrl] #{log_data}"
-    indexed? ? I14yDocument.update(i14y_params) : I14yDocument.create(i14y_params)
-  rescue I14yDocument::DuplicateID => e
+    LegacyOpenSearch::DocumentIndexer.index(i14y_params)
+  rescue LegacyOpenSearch::DocumentIndexer::DuplicateID => e
     Rails.logger.warn("#{e}: #{hashed_url}")
   end
 
@@ -283,8 +283,8 @@ class SearchgovUrl < ApplicationRecord
   end
 
   def delete_document
-    I14yDocument.delete(handle: 'searchgov', document_id: document_id)
+    LegacyOpenSearch::DocumentIndexer.delete(handle: 'searchgov', document_id: document_id)
   rescue => e
-    Rails.logger.error "[SearchgovUrl] Unable to delete Searchgov i14y document #{document_id}:", e
+    Rails.logger.error "[SearchgovUrl] Unable to delete document #{document_id}: #{e.message}"
   end
 end

--- a/config/initializers/extensions/string.rb
+++ b/config/initializers/extensions/string.rb
@@ -8,4 +8,7 @@ class String
     gsub(/(\b|')[a-z]+/) { |w| NON_CAPITALIZED.include?(w) ? w : w.capitalize }.sub(/^[a-z]/) { |l| l.upcase }
   end
 
+  def extract_array
+    split(',').map(&:strip).map(&:downcase)
+  end
 end

--- a/db/migrate/20260317205709_change_default_search_engine_on_affiliates.rb
+++ b/db/migrate/20260317205709_change_default_search_engine_on_affiliates.rb
@@ -1,0 +1,5 @@
+class ChangeDefaultSearchEngineOnAffiliates < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :affiliates, :search_engine, from: 'SearchElastic', to: 'OpenSearch'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_01_15_163528) do
+ActiveRecord::Schema[7.1].define(version: 2026_03_17_205709) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -69,7 +69,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_01_15_163528) do
     t.boolean "jobs_enabled", default: false, null: false
     t.integer "agency_id"
     t.boolean "raw_log_access_enabled", default: false, null: false
-    t.string "search_engine", default: "SearchElastic", null: false
+    t.string "search_engine", default: "OpenSearch", null: false
     t.boolean "is_rss_govbox_enabled", default: false, null: false
     t.string "rss_govbox_label", null: false
     t.boolean "is_video_govbox_enabled", default: true, null: false

--- a/features/admin.feature
+++ b/features/admin.feature
@@ -37,7 +37,7 @@ Feature:  Administration
     And I should see "agency site"
     And I should see "agency.gov"
     And I should see "www1.agency-site.gov"
-    And I should see "Search elastic"
+    And I should see "OpenSearch"
     And I should see a link to "beta.agency.gov" with url for "http://beta.agency.gov"
     When I follow "www1.agency-site.gov"
     Then I should see "Agency Website"

--- a/spec/lib/serde_spec.rb
+++ b/spec/lib/serde_spec.rb
@@ -1,0 +1,335 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Serde do
+  describe '.serialize_hash' do
+    subject(:serialize_hash) do
+      described_class.serialize_hash(original_hash, 'en')
+    end
+
+    let(:original_hash) do
+      ActiveSupport::HashWithIndifferentAccess.new(
+        { 'title' => 'my title',
+          'description' => 'my description',
+          'content' => 'my content',
+          'path' => 'http://www.foo.gov/bar.html',
+          'promote' => false,
+          'audience' => 'Everyone',
+          'content_type' => 'EVENT',
+          'tags' => 'this that',
+          'searchgov_custom1' => 'this, Custom, CONTENT',
+          'searchgov_custom2' => 'That custom, Content',
+          'searchgov_custom3' => '123',
+          'created' => '2018-01-01T12:00:00Z',
+          'changed' => '2018-02-01T12:00:00Z',
+          'created_at' => '2018-01-01T12:00:00Z',
+          'updated_at' => '2018-02-01T12:00:00Z' }
+      )
+    end
+
+    it 'stores the language fields with the language suffix' do
+      expect(serialize_hash).to match(hash_including(
+                                        { 'title_en' => 'my title',
+                                          'description_en' => 'my description',
+                                          'content_en' => 'my content' }
+                                      ))
+    end
+
+    it 'removes the original language field keys' do
+      expect(serialize_hash).not_to have_key('title')
+      expect(serialize_hash).not_to have_key('description')
+      expect(serialize_hash).not_to have_key('content')
+    end
+
+    it 'stores downcased audience' do
+      expect(serialize_hash).to match(hash_including({ 'audience' => 'everyone' }))
+    end
+
+    it 'stores downcased content_type' do
+      expect(serialize_hash).to match(hash_including({ 'content_type' => 'event' }))
+    end
+
+    it 'stores tags as a downcased array' do
+      expect(serialize_hash).to match(hash_including({ 'tags' => ['this that'] }))
+    end
+
+    it 'stores searchgov_custom fields as downcased arrays' do
+      expect(serialize_hash).to match(hash_including(
+                                        { 'searchgov_custom1' => %w[this custom content],
+                                          'searchgov_custom2' => ['that custom', 'content'],
+                                          'searchgov_custom3' => ['123'] }
+                                      ))
+    end
+
+    it 'updates the updated_at value' do
+      expect(serialize_hash[:updated_at]).to be > 1.second.ago
+    end
+
+    it 'extracts URI params from the path' do
+      expect(serialize_hash).to match(hash_including(
+                                        basename: 'bar',
+                                        extension: 'html',
+                                        url_path: '/bar.html',
+                                        domain_name: 'www.foo.gov'
+                                      ))
+    end
+
+    context 'when language fields contain HTML/CSS' do
+      let(:html) do
+        <<~HTML
+          <div style="height: 100px; width: 100px;"></div>
+          <p>hello & goodbye!</p>
+        HTML
+      end
+
+      let(:original_hash) do
+        ActiveSupport::HashWithIndifferentAccess.new(
+          title: '<b><a href="http://foo.com/">foo</a></b><img src="bar.jpg">',
+          description: html,
+          content: "this <b>is</b> <a href='http://gov.gov/url.html'>html</a>"
+        )
+      end
+
+      it 'sanitizes the language fields' do
+        expect(serialize_hash).to match(hash_including(
+                                          title_en: 'foo',
+                                          description_en: 'hello & goodbye!',
+                                          content_en: 'this is html'
+                                        ))
+      end
+    end
+
+    context 'with Spanish language' do
+      subject(:serialize_hash) do
+        described_class.serialize_hash(original_hash, 'es')
+      end
+
+      let(:original_hash) do
+        ActiveSupport::HashWithIndifferentAccess.new(
+          title: 'Título de la página',
+          description: 'Descripción en español',
+          content: 'Contenido principal'
+        )
+      end
+
+      it 'stores fields with the es suffix' do
+        expect(serialize_hash).to match(hash_including(
+                                          'title_es' => 'Título de la página',
+                                          'description_es' => 'Descripción en español',
+                                          'content_es' => 'Contenido principal'
+                                        ))
+      end
+
+      it 'does not create en-suffixed fields' do
+        expect(serialize_hash).not_to have_key('title_en')
+      end
+    end
+
+    context 'when language fields contain special characters' do
+      let(:original_hash) do
+        ActiveSupport::HashWithIndifferentAccess.new(
+          title: 'Quotes "double" & \'single\' + ampersands',
+          description: 'Unicode: café résumé naïve',
+          content: 'Symbols: <em>©</em> ® ™ — –'
+        )
+      end
+
+      it 'sanitizes HTML and preserves non-HTML special characters' do
+        expect(serialize_hash).to match(hash_including(
+                                          'title_en' => 'Quotes "double" & \'single\' + ampersands',
+                                          'description_en' => 'Unicode: café résumé naïve',
+                                          'content_en' => 'Symbols: © ® ™ — –'
+                                        ))
+      end
+    end
+
+    context 'when the tags are a comma-delimited list' do
+      let(:original_hash) do
+        { tags: 'this, that' }
+      end
+
+      it 'converts the tags to an array' do
+        expect(serialize_hash).to match(hash_including(tags: %w[this that]))
+      end
+    end
+
+    context 'when array fields are already arrays' do
+      let(:original_hash) do
+        { tags: %w[already an array],
+          searchgov_custom1: %w[pre split] }
+      end
+
+      it 'leaves them unchanged' do
+        expect(serialize_hash).to match(hash_including(
+                                          tags: %w[already an array],
+                                          searchgov_custom1: %w[pre split]
+                                        ))
+      end
+    end
+
+    context 'when optional fields are missing' do
+      let(:original_hash) do
+        ActiveSupport::HashWithIndifferentAccess.new(
+          title: 'Just a title',
+          path: 'http://www.example.gov/page.html'
+        )
+      end
+
+      it 'does not add nil audience or content_type' do
+        expect(serialize_hash).not_to have_key(:audience)
+        expect(serialize_hash).not_to have_key(:content_type)
+      end
+
+      it 'does not add nil tags or custom fields' do
+        expect(serialize_hash[:tags]).to be_nil
+        expect(serialize_hash[:searchgov_custom1]).to be_nil
+      end
+
+      it 'still processes language fields and URI params' do
+        expect(serialize_hash).to match(hash_including(
+                                          'title_en' => 'Just a title',
+                                          basename: 'page',
+                                          extension: 'html'
+                                        ))
+      end
+    end
+
+    context 'when path is missing' do
+      let(:original_hash) do
+        { title: 'No path document' }
+      end
+
+      it 'does not add URI params' do
+        expect(serialize_hash).not_to have_key(:basename)
+        expect(serialize_hash).not_to have_key(:extension)
+        expect(serialize_hash).not_to have_key(:url_path)
+        expect(serialize_hash).not_to have_key(:domain_name)
+      end
+    end
+  end
+
+  describe '.deserialize_hash' do
+    subject(:deserialize_hash) do
+      described_class.deserialize_hash(original_hash, :en)
+    end
+
+    let(:original_hash) do
+      ActiveSupport::HashWithIndifferentAccess.new(
+        { 'created_at' => '2018-08-09T21:36:50.087Z',
+          'updated_at' => '2018-08-09T21:36:50.087Z',
+          'path' => 'http://www.foo.gov/bar.html',
+          'language' => 'en',
+          'created' => '2018-08-09T19:36:50.087Z',
+          'updated' => '2018-08-09T14:36:50.087-07:00',
+          'changed' => '2018-08-09T14:36:50.087-07:00',
+          'promote' => true,
+          'tags' => 'this that',
+          'title_en' => 'my title',
+          'description_en' => 'my description',
+          'content_en' => 'my content',
+          'basename' => 'bar',
+          'extension' => 'html',
+          'url_path' => '/bar.html',
+          'domain_name' => 'www.foo.gov' }
+      )
+    end
+
+    it 'removes the language suffix from the text fields' do
+      expect(deserialize_hash).to include(
+        'title' => 'my title',
+        'description' => 'my description',
+        'content' => 'my content'
+      )
+    end
+
+    it 'removes derivative fields' do
+      expect(deserialize_hash).not_to have_key('basename')
+      expect(deserialize_hash).not_to have_key('extension')
+      expect(deserialize_hash).not_to have_key('url_path')
+      expect(deserialize_hash).not_to have_key('domain_name')
+      expect(deserialize_hash).not_to have_key('bigrams')
+    end
+
+    it 'removes language-suffixed keys' do
+      expect(deserialize_hash).not_to have_key('title_en')
+      expect(deserialize_hash).not_to have_key('description_en')
+      expect(deserialize_hash).not_to have_key('content_en')
+    end
+
+    it 'preserves non-language, non-derivative fields' do
+      expect(deserialize_hash).to include(
+        'path' => 'http://www.foo.gov/bar.html',
+        'language' => 'en',
+        'promote' => true,
+        'tags' => 'this that'
+      )
+    end
+  end
+
+  describe '.uri_params_hash' do
+    subject(:result) { described_class.uri_params_hash(path) }
+
+    let(:path) { 'https://www.agency.gov/directory/page1.html' }
+
+    it 'computes basename' do
+      expect(result[:basename]).to eq('page1')
+    end
+
+    it 'computes filename extension' do
+      expect(result[:extension]).to eq('html')
+    end
+
+    it 'computes url_path' do
+      expect(result[:url_path]).to eq('/directory/page1.html')
+    end
+
+    it 'computes domain_name' do
+      expect(result[:domain_name]).to eq('www.agency.gov')
+    end
+
+    context 'when the extension has uppercase characters' do
+      let(:path) { 'https://www.agency.gov/directory/PAGE1.PDF' }
+
+      it 'computes a downcased version of filename extension' do
+        expect(result[:extension]).to eq('pdf')
+      end
+    end
+
+    context 'when there is no filename extension' do
+      let(:path) { 'https://www.agency.gov/directory/page1' }
+
+      it 'computes an empty filename extension' do
+        expect(result[:extension]).to eq('')
+      end
+    end
+
+    context 'when the URL has query parameters' do
+      let(:path) { 'https://www.agency.gov/search?q=test&page=2' }
+
+      it 'extracts the path without query string' do
+        expect(result[:url_path]).to eq('/search')
+      end
+
+      it 'extracts basename from the path portion' do
+        expect(result[:basename]).to eq('search')
+      end
+    end
+
+    context 'when the URL has a fragment' do
+      let(:path) { 'https://www.agency.gov/page.html#section-2' }
+
+      it 'extracts the path without fragment' do
+        expect(result[:url_path]).to eq('/page.html')
+      end
+    end
+
+    context 'when the URL is a root path' do
+      let(:path) { 'https://www.agency.gov/' }
+
+      it 'extracts the root path' do
+        expect(result[:url_path]).to eq('/')
+      end
+    end
+  end
+end

--- a/spec/lib/tasks/searchgov_spec.rb
+++ b/spec/lib/tasks/searchgov_spec.rb
@@ -53,7 +53,7 @@ describe 'Search.gov tasks' do
     end
 
     it 'creates new urls' do
-      expect(I14yDocument).to receive(:create)
+      expect(LegacyOpenSearch::DocumentIndexer).to receive(:index)
       allow(I14yDocument).to receive(:promote).
         with(handle: 'searchgov', document_id: doc_id, bool: 'true').at_least(:once)
       promote_urls

--- a/spec/models/affiliate_spec.rb
+++ b/spec/models/affiliate_spec.rb
@@ -23,7 +23,7 @@ describe Affiliate do
 
       it do
         is_expected.to have_db_column(:search_engine).of_type(:string).
-          with_options(default: 'search_elastic', null: false)
+          with_options(default: 'opensearch', null: false)
       end
 
       it do

--- a/spec/models/legacy_opensearch/document_indexer_spec.rb
+++ b/spec/models/legacy_opensearch/document_indexer_spec.rb
@@ -1,0 +1,302 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe LegacyOpenSearch::DocumentIndexer do
+  let(:client) { double('opensearch_client') }
+  let(:index_name) { ENV.fetch('LEGACY_OPENSEARCH_INDEX') }
+
+  before do
+    allow(OpenSearchConfig).to receive(:search_client).and_return(client)
+  end
+
+  describe '.index' do
+    let(:params) do
+      {
+        audience: 'Everyone',
+        changed: '2024-01-15T12:00:00Z',
+        content: 'Full page content here',
+        content_type: 'article',
+        created: '2024-01-01T00:00:00Z',
+        description: 'A test document',
+        document_id: 'abc123',
+        handle: 'searchgov',
+        thumbnail_url: 'https://example.gov/thumb.png',
+        language: 'en',
+        mime_type: 'text/html',
+        path: 'https://www.example.gov/page.html',
+        searchgov_custom1: 'custom, values',
+        searchgov_custom2: nil,
+        searchgov_custom3: nil,
+        tags: 'tag1, tag2',
+        title: 'Test Page Title'
+      }
+    end
+
+    it 'calls client.index with the correct index, id, and serialized body' do
+      expect(client).to receive(:index) do |args|
+        expect(args[:index]).to eq(index_name)
+        expect(args[:id]).to eq('abc123')
+        expect(args[:body][:language]).to eq('en')
+        expect(args[:body]['title_en']).to eq('Test Page Title')
+        expect(args[:body]['content_en']).to eq('Full page content here')
+        expect(args[:body]['description_en']).to eq('A test document')
+        expect(args[:body]['audience']).to eq('everyone')
+        expect(args[:body]['content_type']).to eq('article')
+        expect(args[:body][:basename]).to eq('page')
+        expect(args[:body][:extension]).to eq('html')
+        expect(args[:body][:domain_name]).to eq('www.example.gov')
+        expect(args[:body][:url_path]).to eq('/page.html')
+        expect(args[:body]['tags']).to eq(%w[tag1 tag2])
+        expect(args[:body]['searchgov_custom1']).to eq(%w[custom values])
+      end
+
+      described_class.index(params)
+    end
+
+    it 'strips handle from the indexed body' do
+      expect(client).to receive(:index) do |args|
+        expect(args[:body]).not_to have_key(:handle)
+        expect(args[:body]).not_to have_key('handle')
+      end
+
+      described_class.index(params)
+    end
+
+    it 'strips document_id from the indexed body' do
+      expect(client).to receive(:index) do |args|
+        expect(args[:body]).not_to have_key(:document_id)
+        expect(args[:body]).not_to have_key('document_id')
+      end
+
+      described_class.index(params)
+    end
+
+    it 'preserves language in the indexed body' do
+      expect(client).to receive(:index) do |args|
+        expect(args[:body][:language]).to eq('en')
+      end
+
+      described_class.index(params)
+    end
+
+    it 'sets created_at when not present in params' do
+      freeze_time do
+        expect(client).to receive(:index) do |args|
+          expect(args[:body][:updated_at]).to be_within(1.second).of(Time.now.utc)
+        end
+
+        described_class.index(params)
+      end
+    end
+
+    it 'preserves created_at when already present in params' do
+      existing_time = Time.utc(2023, 6, 15, 10, 0, 0)
+      params[:created_at] = existing_time
+
+      expect(client).to receive(:index) do |args|
+        expect(args[:body][:created_at]).to eq(existing_time)
+      end
+
+      described_class.index(params)
+    end
+
+    it 'does not mutate the original params hash' do
+      original_params = params.dup
+      allow(client).to receive(:index)
+
+      described_class.index(params)
+
+      expect(params).to eq(original_params)
+    end
+
+    context 'with Spanish language' do
+      before { params[:language] = 'es' }
+
+      it 'creates language-suffixed fields with es' do
+        expect(client).to receive(:index) do |args|
+          expect(args[:body]['title_es']).to eq('Test Page Title')
+          expect(args[:body][:language]).to eq('es')
+          expect(args[:body]).not_to have_key('title_en')
+        end
+
+        described_class.index(params)
+      end
+    end
+
+    context 'with nil language' do
+      before { params[:language] = nil }
+
+      it 'defaults to en' do
+        expect(client).to receive(:index) do |args|
+          expect(args[:body]['title_en']).to eq('Test Page Title')
+          expect(args[:body][:language]).to eq('en')
+        end
+
+        described_class.index(params)
+      end
+    end
+
+    context 'with missing optional fields' do
+      let(:sparse_params) do
+        {
+          document_id: 'sparse123',
+          language: 'en',
+          title: 'Minimal Document',
+          path: 'https://www.example.gov/minimal'
+        }
+      end
+
+      it 'indexes successfully without optional fields' do
+        expect(client).to receive(:index) do |args|
+          expect(args[:id]).to eq('sparse123')
+          expect(args[:body]['title_en']).to eq('Minimal Document')
+          expect(args[:body][:basename]).to eq('minimal')
+        end
+
+        described_class.index(sparse_params)
+      end
+    end
+
+    context 'with pre-existing array fields' do
+      before do
+        params[:tags] = %w[already an array]
+        params[:searchgov_custom1] = %w[pre split]
+      end
+
+      it 'passes arrays through unchanged' do
+        expect(client).to receive(:index) do |args|
+          expect(args[:body]['tags']).to eq(%w[already an array])
+          expect(args[:body]['searchgov_custom1']).to eq(%w[pre split])
+        end
+
+        described_class.index(params)
+      end
+    end
+
+    context 'with string-keyed params' do
+      let(:string_params) do
+        {
+          'document_id' => 'string_keys',
+          'language' => 'en',
+          'title' => 'String Keys',
+          'path' => 'https://example.gov/string',
+          'handle' => 'searchgov'
+        }
+      end
+
+      it 'handles string keys correctly' do
+        expect(client).to receive(:index) do |args|
+          expect(args[:id]).to eq('string_keys')
+          expect(args[:body]['title_en']).to eq('String Keys')
+        end
+
+        described_class.index(string_params)
+      end
+    end
+
+    context 'when document_id is blank' do
+      before { params[:document_id] = nil }
+
+      it 'raises DocumentIndexerError' do
+        expect { described_class.index(params) }.to raise_error(
+          described_class::DocumentIndexerError, 'document_id is required'
+        )
+      end
+
+      it 'does not call the client' do
+        expect(client).not_to receive(:index)
+        described_class.index(params) rescue nil
+      end
+    end
+
+    context 'when OpenSearch returns a conflict' do
+      before do
+        allow(client).to receive(:index).and_raise(
+          Elasticsearch::Transport::Transport::Errors::Conflict.new('[409] conflict')
+        )
+      end
+
+      it 'raises DuplicateID' do
+        expect { described_class.index(params) }.to raise_error(
+          described_class::DuplicateID
+        )
+      end
+    end
+
+    context 'when OpenSearch returns a transport error' do
+      before do
+        allow(client).to receive(:index).and_raise(
+          Elasticsearch::Transport::Transport::Errors::ServiceUnavailable.new('[503] unavailable')
+        )
+      end
+
+      it 'raises DocumentIndexerError' do
+        expect { described_class.index(params) }.to raise_error(
+          described_class::DocumentIndexerError
+        )
+      end
+
+      it 'logs the error' do
+        expect(Rails.logger).to receive(:error).with(/Failed to index document abc123/)
+        described_class.index(params) rescue nil
+      end
+    end
+  end
+
+  describe '.delete' do
+    it 'calls client.delete with the correct index and id' do
+      expect(client).to receive(:delete).with(
+        index: index_name,
+        id: 'doc_to_delete'
+      )
+
+      described_class.delete(document_id: 'doc_to_delete')
+    end
+
+    it 'accepts and ignores extra keyword arguments like handle' do
+      expect(client).to receive(:delete).with(
+        index: index_name,
+        id: 'doc123'
+      )
+
+      described_class.delete(handle: 'searchgov', document_id: 'doc123')
+    end
+
+    context 'when the document is not found' do
+      before do
+        allow(client).to receive(:delete).and_raise(
+          Elasticsearch::Transport::Transport::Errors::NotFound.new('[404] not found')
+        )
+      end
+
+      it 'does not raise an error' do
+        expect { described_class.delete(document_id: 'missing') }.not_to raise_error
+      end
+
+      it 'logs a warning' do
+        expect(Rails.logger).to receive(:warn).with(/Document not found for deletion: missing/)
+        described_class.delete(document_id: 'missing')
+      end
+    end
+
+    context 'when OpenSearch returns a transport error' do
+      before do
+        allow(client).to receive(:delete).and_raise(
+          Elasticsearch::Transport::Transport::Errors::ServiceUnavailable.new('[503] unavailable')
+        )
+      end
+
+      it 'raises DocumentIndexerError' do
+        expect { described_class.delete(document_id: 'doc123') }.to raise_error(
+          described_class::DocumentIndexerError
+        )
+      end
+
+      it 'logs the error' do
+        expect(Rails.logger).to receive(:error).with(/Failed to delete document doc123/)
+        described_class.delete(document_id: 'doc123') rescue nil
+      end
+    end
+  end
+end

--- a/spec/models/searchgov_url_spec.rb
+++ b/spec/models/searchgov_url_spec.rb
@@ -45,17 +45,13 @@ describe SearchgovUrl do
         allow(searchgov_url).to receive(:searchgov_domain).and_return(searchgov_domain)
         allow(searchgov_domain).to receive(:marked_for_destruction?).and_return(false)
 
-        stub_request(:put, %r{http://localhost:8081/api/v1/documents/.*}).to_return(status: 200, body: '', headers: {})
-
-        allow(I14yDocument).to receive(:create).and_call_original
+        allow(LegacyOpenSearch::DocumentIndexer).to receive(:index)
 
         searchgov_url.fetch
-
-        allow(I14yDocument).to receive(:create).and_return(true)
       end
 
       it 'sets the language attribute correctly when indexing the document' do
-        expect(I14yDocument).to receive(:create).with(hash_including(language: 'en'))
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).with(hash_including(language: 'en'))
         searchgov_url.index_and_update_status
       end
     end
@@ -172,7 +168,7 @@ describe SearchgovUrl do
 
     context 'when destroying' do
       it 'deletes the document' do
-        expect(I14yDocument).to receive(:delete).
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:delete).
           with(handle: 'searchgov', document_id: searchgov_url.document_id)
         searchgov_url.destroy
       end
@@ -181,13 +177,26 @@ describe SearchgovUrl do
         let!(:searchgov_url) { described_class.create!(valid_attributes) }
 
         before do
-          allow(I14yDocument).to receive(:delete).
+          allow(LegacyOpenSearch::DocumentIndexer).to receive(:delete).
             with(handle: 'searchgov', document_id: searchgov_url.document_id).
-            and_raise(I14yDocument::I14yDocumentError.new('not found'))
+            and_raise(LegacyOpenSearch::DocumentIndexer::DocumentIndexerError.new('not found'))
         end
 
         it 'deletes the Searchgov Url' do
           expect { searchgov_url.destroy }.to change { described_class.count }.by(-1)
+        end
+      end
+
+      context 'when the document does not exist in OpenSearch' do
+        let!(:searchgov_url) { described_class.create!(valid_attributes) }
+
+        before do
+          allow(LegacyOpenSearch::DocumentIndexer).to receive(:delete).
+            with(handle: 'searchgov', document_id: searchgov_url.document_id)
+        end
+
+        it 'succeeds without error' do
+          expect { searchgov_url.destroy }.not_to raise_error
         end
       end
     end
@@ -210,7 +219,7 @@ describe SearchgovUrl do
 
     before do
       allow(searchgov_url).to receive(:searchgov_domain).and_return(searchgov_domain)
-      allow(I14yDocument).to receive(:create)
+      allow(LegacyOpenSearch::DocumentIndexer).to receive(:index)
     end
 
     context 'when the fetch is successful' do
@@ -223,7 +232,7 @@ describe SearchgovUrl do
       end
 
       it 'fetches and indexes the document' do
-        expect(I14yDocument).to receive(:create).
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
           with(hash_including(
                  document_id: '1ff7dfd3cf763d08bee3546e2538cf0315578fbd7b1d3f28f014915983d4d7ef',
                  handle: 'searchgov',
@@ -239,6 +248,16 @@ describe SearchgovUrl do
                  changed: '2017-03-30T13:18:28-04:00',
                  mime_type: 'text/html'
                ))
+        fetch
+      end
+
+      it 'passes all expected i14y_params fields to the indexer' do
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:index) do |params|
+          %i[document_id handle language title path description content
+             content_type mime_type tags created changed].each do |key|
+            expect(params).to have_key(key), "expected params to include :#{key}"
+          end
+        end
         fetch
       end
 
@@ -320,7 +339,7 @@ describe SearchgovUrl do
           let(:valid_attributes) { { url: url, lastmod: '2018-01-01' } }
 
           it 'passes that as the changed value' do
-            expect(I14yDocument).to receive(:create).
+            expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
               with(hash_including(changed: '2018-01-01T00:00:00Z'))
             fetch
           end
@@ -334,7 +353,7 @@ describe SearchgovUrl do
             let(:valid_attributes) { { url: url, lastmod: '2018-01-01' } }
 
             it 'passes whichever value is more recent' do
-              expect(I14yDocument).to receive(:create).
+              expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
                 with(hash_including(changed: '2018-01-01T00:00:00Z'))
               fetch
             end
@@ -344,8 +363,8 @@ describe SearchgovUrl do
         context 'when the document has already been indexed' do
           before { allow(searchgov_url).to receive(:indexed?).and_return(true) }
 
-          it 'updates the document' do
-            expect(I14yDocument).to receive(:update).
+          it 'upserts the document via index' do
+            expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
               with(hash_including(
                      document_id: '1ff7dfd3cf763d08bee3546e2538cf0315578fbd7b1d3f28f014915983d4d7ef',
                      handle: 'searchgov',
@@ -364,7 +383,7 @@ describe SearchgovUrl do
 
         context 'when the document is successfully indexed' do
           before do
-            allow(I14yDocument).to receive(:create).with(anything).and_return(I14yDocument.new)
+            allow(LegacyOpenSearch::DocumentIndexer).to receive(:index).and_return({ '_id' => 'abc' })
           end
 
           it 'records the load time' do
@@ -387,11 +406,24 @@ describe SearchgovUrl do
         end
 
         context 'when the indexing fails' do
-          before { allow(I14yDocument).to receive(:create).and_raise(StandardError.new('Kaboom')) }
+          before { allow(LegacyOpenSearch::DocumentIndexer).to receive(:index).and_raise(StandardError.new('Kaboom')) }
 
           it 'records the error' do
             expect { fetch }.not_to raise_error
             expect(searchgov_url.last_crawl_status).to match(/Kaboom/)
+          end
+        end
+
+        context 'when the indexing fails with a DocumentIndexerError' do
+          before do
+            allow(LegacyOpenSearch::DocumentIndexer).to receive(:index).and_raise(
+              LegacyOpenSearch::DocumentIndexer::DocumentIndexerError.new('[503] unavailable')
+            )
+          end
+
+          it 'records the error gracefully' do
+            expect { fetch }.not_to raise_error
+            expect(searchgov_url.last_crawl_status).to match(/503/)
           end
         end
 
@@ -412,7 +444,7 @@ describe SearchgovUrl do
 
         context 'when the page should not be indexed' do
           before do
-            expect(I14yDocument).not_to receive(:create)
+            expect(LegacyOpenSearch::DocumentIndexer).not_to receive(:index)
           end
 
           context 'when noindex is specified in the page' do
@@ -471,8 +503,8 @@ describe SearchgovUrl do
       # In those cases, we log it, consider the #fetch to have been successful, and move on.
       context 'when the URL was indexed by a parallel process' do
         before do
-          allow(I14yDocument).to receive(:create).
-            and_raise(I14yDocument::DuplicateID, 'Document already exists with that ID')
+          allow(LegacyOpenSearch::DocumentIndexer).to receive(:index).
+            and_raise(LegacyOpenSearch::DocumentIndexer::DuplicateID, 'Document already exists with that ID')
           allow(Rails.logger).to receive(:warn)
         end
 
@@ -535,7 +567,7 @@ describe SearchgovUrl do
       end
 
       it 'fetches and indexes the document' do
-        expect(I14yDocument).to receive(:create).
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
           with(hash_including(
                  handle: 'searchgov',
                  path: url,
@@ -622,7 +654,7 @@ describe SearchgovUrl do
       end
 
       it 'fetches and indexes the document' do
-        expect(I14yDocument).to receive(:create).
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
           with(hash_including(
                  handle: 'searchgov',
                  path: url,
@@ -665,7 +697,7 @@ describe SearchgovUrl do
       end
 
       it 'fetches and indexes the document' do
-        expect(I14yDocument).to receive(:create).
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
           with(hash_including(
                  handle: 'searchgov',
                  path: url,
@@ -708,7 +740,7 @@ describe SearchgovUrl do
       end
 
       it 'fetches and indexes the document' do
-        expect(I14yDocument).to receive(:create).
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
           with(hash_including(
                  handle: 'searchgov',
                  path: url,
@@ -751,7 +783,7 @@ describe SearchgovUrl do
       end
 
       it 'fetches and indexes the document' do
-        expect(I14yDocument).to receive(:create).
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
           with(hash_including(
                  handle: 'searchgov',
                  path: url,
@@ -794,7 +826,7 @@ describe SearchgovUrl do
       end
 
       it 'fetches and indexes the document' do
-        expect(I14yDocument).to receive(:create).
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
           with(hash_including(
                  handle: 'searchgov',
                  path: 'https://agency.gov/test.txt',
@@ -839,19 +871,19 @@ describe SearchgovUrl do
         before { allow(searchgov_url).to receive(:indexed?).and_return(true) }
 
         it 'deletes the document' do
-          expect(I14yDocument).to receive(:delete).with(handle: 'searchgov', document_id: searchgov_url.document_id)
+          expect(LegacyOpenSearch::DocumentIndexer).to receive(:delete).with(handle: 'searchgov', document_id: searchgov_url.document_id)
           fetch
         end
 
         context 'when the document cannot be deleted' do
           before do
-            allow(I14yDocument).to receive(:delete).and_raise('something went wrong')
+            allow(LegacyOpenSearch::DocumentIndexer).to receive(:delete).and_raise('something went wrong')
             allow(Rails.logger).to receive(:error)
           end
 
           it 'logs the error' do
             fetch
-            expect(Rails.logger).to have_received(:error).with("[SearchgovUrl] Unable to delete Searchgov i14y document #{searchgov_url.document_id}:", instance_of(RuntimeError))
+            expect(Rails.logger).to have_received(:error).with(/Unable to delete document #{searchgov_url.document_id}/)
           end
         end
       end
@@ -866,7 +898,7 @@ describe SearchgovUrl do
       let(:new_url) { 'https://www.agency.gov/new.html' }
 
       before do
-        expect(I14yDocument).not_to receive(:create).
+        expect(LegacyOpenSearch::DocumentIndexer).not_to receive(:index).
           with(hash_including(title: 'My Title', description: 'My description'))
         stub_request(:get, url).
           to_return(status: 301,
@@ -897,7 +929,7 @@ describe SearchgovUrl do
         end
 
         it 'does not index the content' do
-          expect(I14yDocument).not_to receive(:create)
+          expect(LegacyOpenSearch::DocumentIndexer).not_to receive(:index)
           fetch
         end
 
@@ -931,7 +963,7 @@ describe SearchgovUrl do
       let(:url) { 'https://www.medicare.gov/find-a-plan/questions/home.aspx' }
 
       it 'can index the content' do
-        expect(I14yDocument).to receive(:create).
+        expect(LegacyOpenSearch::DocumentIndexer).to receive(:index).
           with(hash_including(title: 'Medicare Plan Finder for Health, Prescription Drug and Medigap plans'))
         fetch
       end

--- a/spec/models/string_spec.rb
+++ b/spec/models/string_spec.rb
@@ -8,4 +8,26 @@ describe String do
       expect('Muammar al-Gaddafi'.sentence_case).to eq('Muammar al-Gaddafi')
     end
   end
+
+  describe '#extract_array' do
+    it 'splits on commas, strips whitespace, and downcases' do
+      expect('This, That, OTHER'.extract_array).to eq(%w[this that other])
+    end
+
+    it 'handles a single value with no comma' do
+      expect('single value'.extract_array).to eq(['single value'])
+    end
+
+    it 'handles extra whitespace around values' do
+      expect('  foo ,  bar  , baz '.extract_array).to eq(%w[foo bar baz])
+    end
+
+    it 'returns an empty array for an empty string' do
+      expect(''.extract_array).to eq([])
+    end
+
+    it 'handles trailing commas by dropping empty trailing elements' do
+      expect('one, two,'.extract_array).to eq(['one', 'two'])
+    end
+  end
 end


### PR DESCRIPTION
SRCH-6450: Update SearchgovUrl to index directly to OpenSearch (#1995) 
SRCH-6449: Build OpenSearch document indexing service (#1994) 
SRCH-6448: Port i14y Serde serialize_hash into search-gov (#1993) 
SRCH-6442 Change the default search engine to OpenSearch (#1991) 