### PR TITLE
SRCH-6433 Fix the innactive affiliate banner icon

### DIFF
--- a/app/assets/stylesheets/sites/_site_header.less
+++ b/app/assets/stylesheets/sites/_site_header.less
@@ -122,7 +122,7 @@
       width: 24px;
       height: 24px;
       margin-right: 5px;
-      background-image: url("/assets/uswds/usa-icons/warning.svg");
+      background-image: image-url('uswds/usa-icons/warning.svg');
     }
 
   }


### PR DESCRIPTION
## Summary
Replace static url() references with Rails asset pipeline helper image-url() for better asset management and deployment consistency.

- Updated CSS background image references from url("/assets/uswds/usa-icons/warning.svg") to image-url('uswds/usa-icons/warning.svg'). This leverages the Rails asset pipeline for proper asset path generation.

## Testing

1. Run `yarn build:css`
2. Check if the warning icon in the inactive banner is visible.
<img width="596" height="60" alt="Screenshot 2026-03-26 at 12 27 37 PM" src="https://github.com/user-attachments/assets/3b5e9c9e-6989-45dd-8720-806c823586ab" />
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
