### PR TITLE
SRCH-5747: Pin rexml to satisfy ISSO minimum (≥3.4.2)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'googlecharts', '~> 1.6.12'
 gem 'flickraw', '~> 0.9.9'
 gem 'mutex_m', '~> 0.2.0'
 gem 'bigdecimal', '~> 3.1', '>= 3.1.8'
+gem 'rexml', '>= 3.4.2'
 gem 'csv', '~> 3.3'
 gem 'active_scaffold', '~> 3.7', '>= 3.7.6'
 # # SRCH-3837: We need this change: https://github.com/activescaffold/active_scaffold/pull/666

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -720,7 +720,7 @@ GEM
       rspec-expectations (>= 3.0.0)
       rspec-mocks (>= 3.0.0)
     retriable (3.1.2)
-    rexml (3.4.1)
+    rexml (3.4.4)
     robots_tag_parser (0.1.1)
     rspec-activemodel-mocks (1.2.1)
       activemodel (>= 3.0)
@@ -1014,6 +1014,7 @@ DEPENDENCIES
   resque-scheduler (~> 4.10.2)
   resque_spec (~> 0.18.0)
   retriable (~> 3.1)
+  rexml (>= 3.4.2)
   robotex!
   robots_tag_parser (~> 0.1.0)
   rspec-activemodel-mocks (~> 1.1)


### PR DESCRIPTION
**Merge target:** `staging` (not `main`). This branch is rebased onto current `staging` so the PR only contains the SRCH-5747 dependency change—no unrelated work.

## Why this change

We need to stay on a supported **rexml** version for compliance (SRCH-5747). Scanning had called out older releases; the ISSO vulnerability report from Feb 2026 says we should be on **at least 3.4.2**.

We were already close—the lockfile had **3.4.1**—so this is a small bump, not a big refactor.

## What we did

- Added an explicit **`rexml` ≥ 3.4.2** entry in the Gemfile so we don’t accidentally drift back below what ISSO expects if another gem’s requirements change.
- Updated **Gemfile.lock** so the resolved version is **3.4.4** (still in the 3.4 line, includes the 3.4.2 fixes and later patches).

No application code changes; we still use REXML the same way as before (e.g. bulk XML parsing).

## How to verify (optional but quick)

1. `bundle install`
2. Confirm version: `bundle info rexml` — should show **3.4.4** (or newer if you intentionally update again, as long as it’s ≥ 3.4.2).
3. If you want extra confidence: run the usual Ruby test suite you’d run for a dependency-only change (e.g. `bundle exec rspec`).

---

**Jira:** [SRCH-5747](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-5747)