### PR TITLE
Srch 6471 serp pagination should not show pages above 10

### DIFF
--- a/app/assets/stylesheets/sites/_site_header.less
+++ b/app/assets/stylesheets/sites/_site_header.less
@@ -122,7 +122,7 @@
       width: 24px;
       height: 24px;
       margin-right: 5px;
-      background-image: image-url('uswds/usa-icons/warning.svg');
+      background-image: url("/assets/uswds/usa-icons/warning.svg");
     }
 
   }

--- a/app/assets/stylesheets/sites/_site_header.less
+++ b/app/assets/stylesheets/sites/_site_header.less
@@ -122,7 +122,7 @@
       width: 24px;
       height: 24px;
       margin-right: 5px;
-      background-image: url("/assets/uswds/usa-icons/warning.svg");
+      background-image: image-url('uswds/usa-icons/warning.svg');
     }
 
   }

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,11 +1,14 @@
 # frozen_string_literal: true
 
 class SearchesController < ApplicationController
+  MAX_PAGES = 10
+
   layout :set_layout
 
   skip_before_action :verify_authenticity_token, :set_default_locale
 
   before_action :set_affiliate, :set_locale_based_on_affiliate_locale
+  before_action :validate_page_number
   #eventually all the searches should be redirected, but currently we're doing it as-needed
   #to ensure that the correct params are being passed, etc.
   before_action :set_web_search_options, :only => [:advanced, :index]
@@ -21,14 +24,20 @@ class SearchesController < ApplicationController
       template = :index_redesign if redesign?
       @search = search_klass.new(@search_options.merge(geoip_info: GeoipLookup.lookup(request.remote_ip)))
       @search.run
+
       @form_path = search_path
       @page_title = @search.query
       set_search_page_title
       set_search_params
+
+      # If the requested page number exceeds the total number of pages, redirect to the last available page.
+      redirect_if_invalid_page_number and return
+
       respond_to do |format|
         format.html { render template }
         format.json { render :json => @search }
       end
+
     else
       @page_title = "Search Temporarily Unavailable - #{@affiliate.display_name}"
       respond_to do |format|
@@ -75,6 +84,31 @@ class SearchesController < ApplicationController
   end
 
   private
+
+  # Ensures that the page number is within the valid range (1 to MAX_PAGES). If it's not, redirects to the appropriate page.
+  def validate_page_number
+    page = permitted_params[:page].to_i
+    # Redirect to the last page if the page number is greater than the maximum allowed.
+    if page > MAX_PAGES
+      redirect_to search_path(permitted_params.except(:page).merge(page: MAX_PAGES))
+
+    # Redirect to the first page if the page number is less than 1.
+    elsif page < 1
+      redirect_to search_path(permitted_params.except(:page).merge(page: 1))
+    end
+  end
+
+  # Redirects to the last available page if the requested page number exceeds the total number of pages.
+  def redirect_if_invalid_page_number
+    return unless @search&.total.present?
+
+    requested_page = params[:page].to_i
+    total_pages = (@search.total.to_f / @search.per_page).ceil
+
+    if requested_page > total_pages && total_pages > 0
+      redirect_to search_path(permitted_params.except(:page).merge(page: total_pages))
+    end
+  end
 
   def pick_klass_vertical_template
     if get_commercial_results?

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -8,7 +8,6 @@ class SearchesController < ApplicationController
   skip_before_action :verify_authenticity_token, :set_default_locale
 
   before_action :set_affiliate, :set_locale_based_on_affiliate_locale
-  before_action :validate_page_number
   #eventually all the searches should be redirected, but currently we're doing it as-needed
   #to ensure that the correct params are being passed, etc.
   before_action :set_web_search_options, :only => [:advanced, :index]
@@ -84,19 +83,6 @@ class SearchesController < ApplicationController
   end
 
   private
-
-  # Ensures that the page number is within the valid range (1 to MAX_PAGES). If it's not, redirects to the appropriate page.
-  def validate_page_number
-    page = permitted_params[:page].to_i
-    # Redirect to the last page if the page number is greater than the maximum allowed.
-    if page > MAX_PAGES
-      redirect_to search_path(permitted_params.except(:page).merge(page: MAX_PAGES))
-
-    # Redirect to the first page if the page number is less than 1.
-    elsif page < 1
-      redirect_to search_path(permitted_params.except(:page).merge(page: 1))
-    end
-  end
 
   # Redirects to the last available page if the requested page number exceeds the total number of pages.
   def redirect_if_invalid_page_number

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -86,7 +86,10 @@ class SearchesController < ApplicationController
 
   # Redirects to the last available page if the requested page number exceeds the total number of pages.
   def redirect_if_invalid_page_number
-    return unless @search&.total.present?
+    # I14ySearch handles page numbers differently, so we skip this check for it. Also, we are going to delete this code soon, so we don't want to spend time refactoring it for I14ySearch.
+    return if gets_i14y_results?
+
+    return unless @search.total.present?
 
     requested_page = params[:page].to_i
     total_pages = (@search.total.to_f / @search.per_page).ceil

--- a/app/controllers/searches_controller.rb
+++ b/app/controllers/searches_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class SearchesController < ApplicationController
-  MAX_PAGES = 10
-
   layout :set_layout
 
   skip_before_action :verify_authenticity_token, :set_default_locale

--- a/app/javascript/components/Pagination/Pagination.tsx
+++ b/app/javascript/components/Pagination/Pagination.tsx
@@ -33,7 +33,7 @@ export const Pagination = ({ pathname, totalPages = null, unboundedResults }: Pa
           <Grid tablet={{ col: true }}>
             <UswdsPagination 
               pathname={pathname} 
-              totalPages={totalPages} 
+              totalPages={cappedTotalPages} 
               currentPage={getCurrentPage()}
               unboundedResults={unboundedResults}
             />

--- a/app/javascript/components/Pagination/Pagination.tsx
+++ b/app/javascript/components/Pagination/Pagination.tsx
@@ -12,6 +12,9 @@ interface PaginationProps {
 }
 
 export const Pagination = ({ pathname, totalPages = null, unboundedResults }: PaginationProps) => {
+  const MAX_PAGES = 10;
+  const cappedTotalPages = totalPages ? Math.min(totalPages, MAX_PAGES) : null;
+
   useEffect(() => {
     // SRCH-4102: added the  aria label to fix the accessibility violation
     Array.from(document.getElementsByClassName('usa-icon')).forEach((el) => { 
@@ -19,7 +22,7 @@ export const Pagination = ({ pathname, totalPages = null, unboundedResults }: Pa
     });
   });
   
-  if ((!totalPages || totalPages < 2 || getCurrentPage() > totalPages)) {
+  if((!cappedTotalPages || cappedTotalPages < 2 || getCurrentPage() > cappedTotalPages)) {
     return (<></>);
   }
 

--- a/app/javascript/test/Pagination.test.tsx
+++ b/app/javascript/test/Pagination.test.tsx
@@ -8,7 +8,7 @@ jest.mock('i18n-js', () => {
 });
 
 describe('Pagination component', () => {
-  const testPages = 24;
+  const testPages = 10;
   const testThreePages = 3;
   const testSevenPages = 7;
   const testPathname = '/test-pathname';
@@ -17,7 +17,7 @@ describe('Pagination component', () => {
     render(
       <UswdsPagination
         totalPages={testPages}
-        currentPage={10}
+        currentPage={4}
         pathname={testPathname}
         unboundedResults={true}
       />
@@ -28,7 +28,7 @@ describe('Pagination component', () => {
     render(
       <UswdsPagination
         totalPages={testPages}
-        currentPage={10}
+        currentPage={5}
         pathname={testPathname}
         unboundedResults={false}
       />
@@ -51,7 +51,7 @@ describe('Pagination component', () => {
     render(
       <UswdsPagination
         totalPages={testPages}
-        currentPage={24}
+        currentPage={10}
         pathname={testPathname}
         unboundedResults={false}
       />
@@ -62,7 +62,7 @@ describe('Pagination component', () => {
     render(
       <UswdsPagination
         totalPages={testPages}
-        currentPage={24}
+        currentPage={10}
         pathname={testPathname}
         unboundedResults={true}
       />
@@ -73,7 +73,7 @@ describe('Pagination component', () => {
     render(
       <UswdsPagination
         totalPages={testPages}
-        currentPage={10}
+        currentPage={5}
         pathname={testPathname}
         unboundedResults={false}
       />
@@ -96,7 +96,7 @@ describe('Pagination component', () => {
     render(
       <UswdsPagination
         totalPages={testPages}
-        currentPage={21}
+        currentPage={9}
         pathname={testPathname}
         unboundedResults={false}
       />
@@ -112,7 +112,7 @@ describe('Pagination component', () => {
     const { getByTestId, getAllByTestId } = render(
       <UswdsPagination
         totalPages={testPages}
-        currentPage={21}
+        currentPage={9}
         pathname={testPathname}
         onClickPrevious={mockOnClickPrevious}
         onClickNext={mockOnClickNext}

--- a/app/javascript/test/Pagination.test.tsx
+++ b/app/javascript/test/Pagination.test.tsx
@@ -165,13 +165,13 @@ describe('Pagination component', () => {
       render(
         <UswdsPagination
           totalPages={testPages}
-          currentPage={10}
+          currentPage={5}
           pathname={testPathname}
-          maxSlots={10}
+          maxSlots={5}
           unboundedResults={false}
         />
       );
-      expect(screen.getAllByRole('listitem')).toHaveLength(10);
+      expect(screen.getAllByRole('listitem')).toHaveLength(5);
     });
   });
 });

--- a/app/models/results_post_processor.rb
+++ b/app/models/results_post_processor.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class ResultsPostProcessor
-  MAX_PAGES = 500
+  MAX_PAGES = 10
   DEFAULT_TRUNCATED_HTML_LENGTH = 280
   DEFAULT_TRUNCATE_OPTIONS = { length_in_chars: true, ellipsis: ' ...' }.freeze
 

--- a/features/redesigned_searches.feature
+++ b/features/redesigned_searches.feature
@@ -55,11 +55,11 @@ Feature: Search - redesign
     And I should be on page "1" of results
     And I should see a link to the "Next" page
     And I should not see a link to the "Previous" page
-    And I should see a link to the last page ("14")
+    And I should see a link to the last page ("10")
     And I should see "270 results"
-    When I click on the last page ("14")
+    When I click on the last page ("10")
     Then I should see exactly "20" web search results
-    And I should be on page "14" of results
+    And I should be on page "10" of results
     And I should not see a link to the "Next" page
     And I should see a link to the "Previous" page
     And I should see Powered by SearchGov

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -334,7 +334,8 @@ describe SearchesController do
   context "when a page number exceeds available pages" do
     before do
       # Mock a search with only 3 pages of results.
-      allow_any_instance_of(WebSearch).to receive(:total_pages).and_return(3)
+      allow_any_instance_of(WebSearch).to receive(:total).and_return(30)
+      allow_any_instance_of(WebSearch).to receive(:per_page).and_return(10)
     end
 
     it "redirects to the last available page" do

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -331,6 +331,37 @@ describe SearchesController do
     end
   end
 
+  context "when page number is less than 1" do
+    it "redirects to page 1" do
+      get :index, params: { query: 'weather', page: 0, affiliate: 'usagov' }
+      expect(response).to redirect_to search_path(query: 'weather', page: 1, affiliate: 'usagov')
+    end
+  end
+
+  context "when a page number exceeds availale pages" do
+    before do
+      # Mock a search with only 3 pages of results.
+      allow_any_instance_of(WebSearch).to receive(:total_pages).and_return(3)
+    end
+
+    it "redirects to the last available page" do
+      get :index, params: { query: 'test', page: 4, affiliate: 'usagov' }
+      expect(response).to redirect_to search_path(query: 'test', page: 3, affiliate: 'usagov')
+    end
+  end
+  
+  context "when page number exceeds maximum allowed (10)" do
+    before do
+      # Mock a search with more than 10 pages of results.
+      allow_any_instance_of(WebSearch).to receive(:total_pages).and_return(15)
+    end
+
+    it "redirects to page 10" do
+      get :index, params: { query: 'test', page: 11, affiliate: 'usagov' }
+      expect(response).to redirect_to search_path(query: 'test', page: 10, affiliate: 'usagov')
+    end
+  end
+  
   context 'highlighting' do
     context 'when a client requests results without highlighting' do
       before do

--- a/spec/controllers/searches_controller_spec.rb
+++ b/spec/controllers/searches_controller_spec.rb
@@ -331,14 +331,7 @@ describe SearchesController do
     end
   end
 
-  context "when page number is less than 1" do
-    it "redirects to page 1" do
-      get :index, params: { query: 'weather', page: 0, affiliate: 'usagov' }
-      expect(response).to redirect_to search_path(query: 'weather', page: 1, affiliate: 'usagov')
-    end
-  end
-
-  context "when a page number exceeds availale pages" do
+  context "when a page number exceeds available pages" do
     before do
       # Mock a search with only 3 pages of results.
       allow_any_instance_of(WebSearch).to receive(:total_pages).and_return(3)
@@ -347,18 +340,6 @@ describe SearchesController do
     it "redirects to the last available page" do
       get :index, params: { query: 'test', page: 4, affiliate: 'usagov' }
       expect(response).to redirect_to search_path(query: 'test', page: 3, affiliate: 'usagov')
-    end
-  end
-  
-  context "when page number exceeds maximum allowed (10)" do
-    before do
-      # Mock a search with more than 10 pages of results.
-      allow_any_instance_of(WebSearch).to receive(:total_pages).and_return(15)
-    end
-
-    it "redirects to page 10" do
-      get :index, params: { query: 'test', page: 11, affiliate: 'usagov' }
-      expect(response).to redirect_to search_path(query: 'test', page: 10, affiliate: 'usagov')
     end
   end
   

--- a/spec/models/results_post_processor_spec.rb
+++ b/spec/models/results_post_processor_spec.rb
@@ -68,10 +68,10 @@ describe ResultsPostProcessor do
       end
     end
 
-    context 'when there are more than 500 pages of results' do
-      let(:total_results) { 15_000 }
+    context 'when there are more than 10 pages of results' do
+      let(:total_results) { 300 }
 
-      it { is_expected.to eq(500) }
+      it { is_expected.to eq(10) }
     end
 
     context 'when an invalid value is passed in' do

--- a/spec/vcr_cassettes/searches_controller/when_a_page_number_exceeds_available_pages.yml
+++ b/spec/vcr_cassettes/searches_controller/when_a_page_number_exceeds_available_pages.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.bing.microsoft.com/v7.0/search?count=20&mkt=en-US&offset=60&q=test%20(site:gov%20OR%20site:mil)&responseFilter=WebPages&safeSearch=moderate&textDecorations=<DATADOG_API_ENABLED>&traffictype=test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - USASearch
+      Ocp-Apim-Subscription-Key:
+      - "<BING_V7_WEB_SUBSCRIPTION_ID>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 401
+      message: PermissionDenied
+    headers:
+      Content-Length:
+      - '224'
+      Date:
+      - Thu, 02 Apr 2026 17:39:35 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"401","message":"Access denied due to invalid subscription
+        key or wrong API endpoint. Make sure to provide a valid key for an active
+        subscription and use a correct regional API endpoint for your resource."}}'
+  recorded_at: Thu, 02 Apr 2026 17:39:35 GMT
+recorded_with: VCR 6.3.1

--- a/spec/vcr_cassettes/searches_controller/when_a_page_number_exceeds_availale_pages.yml
+++ b/spec/vcr_cassettes/searches_controller/when_a_page_number_exceeds_availale_pages.yml
@@ -1,0 +1,37 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.bing.microsoft.com/v7.0/search?count=20&mkt=en-US&offset=60&q=test%20(site:gov%20OR%20site:mil)&responseFilter=WebPages&safeSearch=moderate&textDecorations=<DATADOG_API_ENABLED>&traffictype=test
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - USASearch
+      Ocp-Apim-Subscription-Key:
+      - "<BING_V7_WEB_SUBSCRIPTION_ID>"
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+      Connection:
+      - keep-alive
+      Keep-Alive:
+      - '30'
+  response:
+    status:
+      code: 401
+      message: PermissionDenied
+    headers:
+      Content-Length:
+      - '224'
+      Date:
+      - Thu, 02 Apr 2026 15:46:25 GMT
+    body:
+      encoding: UTF-8
+      string: '{"error":{"code":"401","message":"Access denied due to invalid subscription
+        key or wrong API endpoint. Make sure to provide a valid key for an active
+        subscription and use a correct regional API endpoint for your resource."}}'
+  recorded_at: Thu, 02 Apr 2026 15:46:25 GMT
+recorded_with: VCR 6.3.1


### PR DESCRIPTION
## Summary
This PR updates the pagination behavior in the ReactJS component used in the SERP to limit the number of visible pages.

### **Changes**

* Updated the pagination logic to **cap the maximum number of displayed pages at 10**
* Adjusted related React component logic to handle page limits correctly
* Updated tests accordingly.

### **Testing**
* Verified pagination renders a maximum of 10 pages
* Confirmed correct behavior across:
  * First page
  * Middle pages
  * Last page
* Ensured navigation still works as expected

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
  
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
 
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
