### PR TITLE
SRCH-6484: Stop ElasticSearch-related error logging

### DIFF
--- a/app/models/api_video_search.rb
+++ b/app/models/api_video_search.rb
@@ -24,6 +24,7 @@ class ApiVideoSearch < Search
 
   def search
     return unless @video_rss_feeds.present?
+    return unless Es.custom_indices_enabled?
 
     search_options = {
       language: @affiliate.indexing_locale,

--- a/app/models/news_search.rb
+++ b/app/models/news_search.rb
@@ -49,6 +49,7 @@ class NewsSearch < FilterableSearch
 
   def search
     return if @rss_feeds.blank?
+    return unless Es.custom_indices_enabled?
 
     ElasticNewsItem.search_for(q: @query, rss_feeds: @rss_feeds, excluded_urls: @affiliate.excluded_urls,
                                since: @since, until: @until,

--- a/app/models/sayt_suggestion.rb
+++ b/app/models/sayt_suggestion.rb
@@ -19,6 +19,7 @@ class SaytSuggestion < ApplicationRecord
   class << self
     def related_search(query, affiliate, options = {})
       return [] unless affiliate.is_related_searches_enabled?
+      return [] unless Es.custom_indices_enabled?
 
       search_options = { affiliate_id: affiliate.id,
                          language: affiliate.indexing_locale,

--- a/lib/es.rb
+++ b/lib/es.rb
@@ -10,6 +10,10 @@ module Es
     :elasticsearch_client
   ).deep_symbolize_keys.freeze
 
+  def self.custom_indices_enabled?
+    ENV['ES_HOSTS'].present?
+  end
+
   private
 
   def initialize_client(config = {})

--- a/lib/indexable.rb
+++ b/lib/indexable.rb
@@ -133,10 +133,14 @@ module Indexable
   end
 
   def search_for(options)
+    return "#{name}Results".constantize.new(NO_HITS) unless use_opensearch? || Es.custom_indices_enabled?
+
     query = "#{name}Query".constantize.new(options)
     ActiveSupport::Notifications.instrument('elastic_search.usasearch', query: query.body, index: name) do
       search(query)
     end
+  rescue Faraday::Error::ConnectionFailed, Faraday::ConnectionFailed
+    "#{name}Results".constantize.new(NO_HITS)
   rescue StandardError => e
     Rails.logger.error "Problem in #{name}#search_for():", e
     "#{name}Results".constantize.new(NO_HITS)


### PR DESCRIPTION
## Summary

- ES is turned off but `ElasticSaytSuggestion` and `ElasticNewsItem` were still being called on every search request, generating **~766k error logs/day** (`Faraday::Error::ConnectionFailed: Couldn't resolve host name`)
- Adds `Es.custom_indices_enabled?` (keyed off `ES_HOSTS` env var) as a feature flag to detect when ES custom indices are intentionally disabled
- Guards `Indexable#search_for`, `SaytSuggestion.related_search`, `NewsSearch#search`, and `ApiVideoSearch#search` to short-circuit when ES is disabled
- Adds a silent rescue for `Faraday::ConnectionFailed` in `Indexable#search_for` as a belt-and-suspenders fallback until `ES_HOSTS` is cleared from the production environment

## Log evidence (last 24h, production)

| Class | Errors |
|---|---|
| `ElasticSaytSuggestion` | ~510,846 |
| `ElasticNewsItem` | ~254,802 |
| **Total** | **~765,648** |

## Required ops action

Unset `ES_HOSTS` in the production environment. Once cleared, `Es.custom_indices_enabled?` returns `false` and all callers skip ES entirely with no error logging.

## Jira

[SRCH-6484](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6484)