### PR TITLE
SRCH-6443: CodeDeploy hooks for crawler Resque (systemd alignment)

### DIFF
--- a/cicd-scripts/application_start.sh
+++ b/cicd-scripts/application_start.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ -f /home/search/.config/searchgov-codedeploy.env ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source /home/search/.config/searchgov-codedeploy.env
+  set +a
+fi
+
 log() {
   echo "[CODEDEPLOY][APPLICATION_START] $*"
 }

--- a/cicd-scripts/application_stop.sh
+++ b/cicd-scripts/application_stop.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ -f /home/search/.config/searchgov-codedeploy.env ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source /home/search/.config/searchgov-codedeploy.env
+  set +a
+fi
+
 log() {
   echo "[CODEDEPLOY][APPLICATION_STOP] $*"
+}
+
+error() {
+  echo "[CODEDEPLOY][APPLICATION_STOP][ERROR] $*" >&2
 }
 
 service_exists() {
@@ -50,8 +61,24 @@ RESQUE_SCHEDULER_SERVICE="${RESQUE_SCHEDULER_SERVICE:-resque-scheduler}"
 log "Starting ApplicationStop hook"
 log "Host: $(hostname) | User: $(whoami)"
 
+if [ "${REQUIRE_RESQUE_SERVICES:-false}" = "true" ]; then
+  for required in "$RESQUE_WORKER_SERVICE" "$RESQUE_SCHEDULER_SERVICE"; do
+    if ! service_exists "$required"; then
+      error "REQUIRE_RESQUE_SERVICES is true but unit not installed: $required (run crawl Ansible resque_systemd role)"
+      exit 1
+    fi
+  done
+fi
+
 stop_service_if_present "$PUMA_SERVICE"
 stop_service_if_present "$RESQUE_WORKER_SERVICE"
 stop_service_if_present "$RESQUE_SCHEDULER_SERVICE"
+
+if [ "${REQUIRE_RESQUE_SERVICES:-false}" = "true" ] && [ "${SKIP_ORPHAN_RESQUE_SIGTERM:-false}" != "true" ]; then
+  log "Sending SIGTERM to leftover search-user Resque processes (non-systemd orphans)"
+  pkill -u search -TERM -f '[r]esque-' || true
+  sleep 3
+  pkill -u search -KILL -f '[r]esque-' || true
+fi
 
 log "ApplicationStop hook completed"

--- a/cicd-scripts/validate_service.sh
+++ b/cicd-scripts/validate_service.sh
@@ -1,12 +1,23 @@
 #!/bin/bash
 set -euo pipefail
 
+if [ -f /home/search/.config/searchgov-codedeploy.env ]; then
+  set -a
+  # shellcheck disable=SC1090
+  source /home/search/.config/searchgov-codedeploy.env
+  set +a
+fi
+
 log() {
   echo "[CODEDEPLOY][VALIDATE_SERVICE] $*"
 }
 
 warn() {
   echo "[CODEDEPLOY][VALIDATE_SERVICE][WARN] $*"
+}
+
+error() {
+  echo "[CODEDEPLOY][VALIDATE_SERVICE][ERROR] $*" >&2
 }
 
 service_exists() {
@@ -45,6 +56,21 @@ assert_service_active_if_present() {
   else
     log "Service not found, skipping active check: $service_name"
   fi
+}
+
+assert_service_active_required() {
+  local service_name="$1"
+
+  if ! service_exists "$service_name"; then
+    error "Required service unit missing: $service_name"
+    exit 1
+  fi
+  log "Checking required service is active: $service_name"
+  if ! systemctl is-active --quiet "$service_name"; then
+    error "Required service is not active: $service_name"
+    exit 1
+  fi
+  log "Service is active: $service_name"
 }
 
 wait_for_http_healthy() {
@@ -117,12 +143,24 @@ SEARCHGOV_ROOT="${SEARCHGOV_ROOT:-/home/search/searchgov}"
 log "Starting ValidateService hook"
 log "Host: $(hostname) | User: $(whoami)"
 
+if [ "${REQUIRE_RESQUE_SERVICES:-false}" = "true" ]; then
+  assert_service_active_required "$RESQUE_WORKER_SERVICE"
+  assert_service_active_required "$RESQUE_SCHEDULER_SERVICE"
+else
+  assert_service_active_if_present "$RESQUE_WORKER_SERVICE"
+  assert_service_active_if_present "$RESQUE_SCHEDULER_SERVICE"
+fi
+
 assert_service_active_if_present "$PUMA_SERVICE"
-assert_service_active_if_present "$RESQUE_WORKER_SERVICE"
-assert_service_active_if_present "$RESQUE_SCHEDULER_SERVICE"
 
 log "Validating HTTP endpoint: $APP_HEALTHCHECK_URL"
 wait_for_http_healthy "$APP_HEALTHCHECK_URL" "${HEALTHCHECK_ATTEMPTS:-12}" "${HEALTHCHECK_SLEEP_SECONDS:-5}"
 assert_puma_serving_current_release "$SEARCHGOV_ROOT"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+if [ "${REQUIRE_RESQUE_CWD_CHECK:-false}" = "true" ]; then
+  log "Running Resque cwd verification (REQUIRE_RESQUE_CWD_CHECK)"
+  bash "$SCRIPT_DIR/verify_resque_cwd.sh"
+fi
 
 log "ValidateService hook completed"

--- a/cicd-scripts/verify_resque_cwd.sh
+++ b/cicd-scripts/verify_resque_cwd.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+log() {
+  echo "[CODEDEPLOY][VERIFY_RESQUE_CWD] $*"
+}
+
+err() {
+  echo "[CODEDEPLOY][VERIFY_RESQUE_CWD][ERROR] $*" >&2
+}
+
+ROOT="${SEARCHGOV_ROOT:-/home/search/searchgov}"
+CURRENT=$(readlink -f "$ROOT/current" 2>/dev/null || true)
+if [[ -z "${CURRENT:-}" || ! -d "$CURRENT" ]]; then
+  err "No valid current release at $ROOT/current"
+  exit 1
+fi
+
+log "Expecting Resque processes cwd under: $CURRENT"
+
+bad=0
+while IFS= read -r line; do
+  [[ -z "$line" ]] && continue
+  pid="${line%% *}"
+  args="${line#* }"
+  [[ "$args" == *resque* ]] || continue
+  [[ "$args" == *grep* ]] && continue
+  if ! [[ "$pid" =~ ^[0-9]+$ ]]; then
+    continue
+  fi
+  cwd=$(readlink -f "/proc/$pid/cwd" 2>/dev/null || true)
+  if [[ -z "$cwd" ]]; then
+    continue
+  fi
+  case "$cwd" in
+    "$CURRENT"/*|"$CURRENT")
+      ;;
+    *)
+      err "PID $pid cwd=$cwd not under current release $CURRENT (args=${args:0:120})"
+      bad=1
+      ;;
+  esac
+done < <(ps -u search -ww -o pid=,args= 2>/dev/null || true)
+
+if [[ "$bad" -ne 0 ]]; then
+  err "One or more Resque processes are running from a stale release path"
+  exit 1
+fi
+
+log "Resque process working directories look valid"
+exit 0


### PR DESCRIPTION
## SRCH-6443

Production crawler Resque workers were not managed by systemd, so CodeDeploy `application_stop` / `application_start` skipped `resque-worker` and `resque-scheduler`, leaving processes on pruned release paths.

### Changes

* Source optional `/home/search/.config/searchgov-codedeploy.env` (installed by searchgov-ansible crawl playbook on crawlers) so hooks can enforce stricter checks only on those hosts.
* When `REQUIRE_RESQUE_SERVICES=true`: fail ApplicationStop if units are missing; require active resque services in ValidateService.
* After systemd stop, SIGTERM/SIGKILL leftover `resque` processes (disable with `SKIP_ORPHAN_RESQUE_SIGTERM=true` if needed).
* Add `verify_resque_cwd.sh` invoked when `REQUIRE_RESQUE_CWD_CHECK=true`.

### Rollout

1. Merge this PR.
2. Run crawl Ansible (`resque_systemd` role) on production crawlers.
3. Deploy via CodeDeploy as usual.

### Related

* Supersedes #2002 (retargeted from staging to main, resolved conflicts with latest main improvements).
* searchgov-ansible: systemd units + env file (companion PR).
* searchgov-tf: optional CloudWatch alarm on `LoadError` in resque.log (companion PR).