### PR TITLE
SRCH-6443: Fix service_exists() to support systemd targets

### DIFF
--- a/cicd-scripts/application_start.sh
+++ b/cicd-scripts/application_start.sh
@@ -21,9 +21,9 @@ error() {
 }
 
 service_exists() {
-  local service_name="$1"
-  systemctl list-unit-files --type=service --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "${service_name}.service" || \
-    systemctl list-unit-files --type=service --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "$service_name"
+  local unit_name="$1"
+  systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "${unit_name}.service" || \
+    systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "$unit_name"
 }
 
 resolve_puma_service() {

--- a/cicd-scripts/application_stop.sh
+++ b/cicd-scripts/application_stop.sh
@@ -17,9 +17,9 @@ error() {
 }
 
 service_exists() {
-  local service_name="$1"
-  systemctl list-unit-files --type=service --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "${service_name}.service" || \
-    systemctl list-unit-files --type=service --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "$service_name"
+  local unit_name="$1"
+  systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "${unit_name}.service" || \
+    systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "$unit_name"
 }
 
 resolve_puma_service() {

--- a/cicd-scripts/validate_service.sh
+++ b/cicd-scripts/validate_service.sh
@@ -21,9 +21,9 @@ error() {
 }
 
 service_exists() {
-  local service_name="$1"
-  systemctl list-unit-files --type=service --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "${service_name}.service" || \
-    systemctl list-unit-files --type=service --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "$service_name"
+  local unit_name="$1"
+  systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "${unit_name}.service" || \
+    systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "$unit_name"
 }
 
 resolve_puma_service() {


### PR DESCRIPTION
## Summary

Fixes CodeDeploy deployment failures on crawlers where `ValidateService` reports `Required service unit missing: resque-worker`.

### Root cause

The `resque_systemd` ansible role installs:
- `resque-worker@.service` (systemd template unit with instances `@1`, `@2`, etc.)
- `resque-worker.target` (aggregates all worker instances)
- `resque-scheduler.service`

The `service_exists()` function in all three CodeDeploy hooks (`application_stop.sh`, `application_start.sh`, `validate_service.sh`) filtered with `--type=service`, which excludes targets and template units from the lookup. When checking for `resque-worker.target` (set via companion ansible PR), the function couldn't find it.

### Fix

Remove the `--type=service` filter from `systemctl list-unit-files` so the function can discover any unit type (services, targets, template units).

### Companion PR

- searchgov-ansible: Sets `RESQUE_WORKER_SERVICE=resque-worker.target` in the CodeDeploy env file so hooks reference the correct unit name

### Testing

- After both PRs merge and ansible runs on crawlers, CodeDeploy will correctly find `resque-worker.target` and `resque-scheduler.service`
- App servers (without resque env file) are unaffected -- they skip resque checks as before