### PR TITLE
SRCH-6443: Use sudo for systemctl stop/restart in CodeDeploy hooks

### DIFF
--- a/cicd-scripts/application_start.sh
+++ b/cicd-scripts/application_start.sh
@@ -51,7 +51,7 @@ restart_or_start_service() {
 
   if service_exists "$service_name"; then
     log "Restarting service: $service_name"
-    systemctl restart "$service_name"
+    sudo systemctl restart "$service_name"
   else
     log "Service not found, skipping: $service_name"
   fi

--- a/cicd-scripts/application_stop.sh
+++ b/cicd-scripts/application_stop.sh
@@ -47,7 +47,7 @@ stop_service_if_present() {
 
   if service_exists "$service_name"; then
     log "Stopping service: $service_name"
-    systemctl stop "$service_name"
+    sudo systemctl stop "$service_name"
   else
     log "Service not found, skipping: $service_name"
   fi


### PR DESCRIPTION
## Summary

CodeDeploy hooks run as user `search` which lacks privileges to stop/restart system services. Adds `sudo` prefix to `systemctl stop` and `systemctl restart` calls in `application_stop.sh` and `application_start.sh`.

Without this, deployments fail on crawlers with:
```
Failed to restart resque-worker.target: Interactive authentication required.
```

### Companion PR

- searchgov-ansible: Adds a sudoers drop-in allowing the `search` user to manage resque services without a password

### Deployment order

1. Merge **ansible PR** first and run crawl pipeline (installs sudoers rule)
2. Merge **this PR** and trigger app deployment (hooks now use sudo)