### PR TITLE
SRCH-6443: Fix service_exists() to query specific unit

### DIFF
--- a/cicd-scripts/application_start.sh
+++ b/cicd-scripts/application_start.sh
@@ -22,8 +22,8 @@ error() {
 
 service_exists() {
   local unit_name="$1"
-  systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "${unit_name}.service" || \
-    systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "$unit_name"
+  systemctl list-unit-files "${unit_name}.service" --no-legend 2>/dev/null | grep -q . || \
+    systemctl list-unit-files "${unit_name}" --no-legend 2>/dev/null | grep -q .
 }
 
 resolve_puma_service() {

--- a/cicd-scripts/application_stop.sh
+++ b/cicd-scripts/application_stop.sh
@@ -18,8 +18,8 @@ error() {
 
 service_exists() {
   local unit_name="$1"
-  systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "${unit_name}.service" || \
-    systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "$unit_name"
+  systemctl list-unit-files "${unit_name}.service" --no-legend 2>/dev/null | grep -q . || \
+    systemctl list-unit-files "${unit_name}" --no-legend 2>/dev/null | grep -q .
 }
 
 resolve_puma_service() {

--- a/cicd-scripts/validate_service.sh
+++ b/cicd-scripts/validate_service.sh
@@ -22,8 +22,8 @@ error() {
 
 service_exists() {
   local unit_name="$1"
-  systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "${unit_name}.service" || \
-    systemctl list-unit-files --no-legend 2>/dev/null | awk '{print $1}' | grep -Fxq "$unit_name"
+  systemctl list-unit-files "${unit_name}.service" --no-legend 2>/dev/null | grep -q . || \
+    systemctl list-unit-files "${unit_name}" --no-legend 2>/dev/null | grep -q .
 }
 
 resolve_puma_service() {


### PR DESCRIPTION
## Summary
- Fix `service_exists()` in all three CodeDeploy hooks (`application_stop.sh`, `application_start.sh`, `validate_service.sh`)
- Previous approach piped `systemctl list-unit-files` (full list) through `awk` + `grep -Fxq`, which silently failed to match installed units like `resque-scheduler.service`
- New approach passes the unit name directly to `systemctl list-unit-files <unit>` for a targeted, reliable lookup

## Context
Deployment `d-AZ18EF7SI` proved that the `sudo` fix (PR #2034) works — `ApplicationStart` succeeded and `resque-worker.target` was restarted. However `ValidateService` still failed because `service_exists "resque-scheduler"` returns false despite the unit file being present at `/etc/systemd/system/resque-scheduler.service` (confirmed via ansible logs).

## Test plan
- [ ] Deploy to dev with `--ignore-application-stop-failures` (bootstrapping)
- [ ] Verify `ValidateService` passes for both `resque-worker.target` and `resque-scheduler`
- [ ] Re-deploy without the ignore flag to confirm clean deployment cycle