### PR TITLE
SRCH-6443: Add retry logic to assert_service_active_if_present

### DIFF
--- a/cicd-scripts/validate_service.sh
+++ b/cicd-scripts/validate_service.sh
@@ -48,14 +48,28 @@ resolve_puma_service() {
 
 assert_service_active_if_present() {
   local service_name="$1"
+  local retries="${SERVICE_ACTIVE_RETRIES:-6}"
+  local wait_sec="${SERVICE_ACTIVE_WAIT:-5}"
 
-  if service_exists "$service_name"; then
-    log "Checking service is active: $service_name"
-    systemctl is-active --quiet "$service_name"
-    log "Service is active: $service_name"
-  else
+  if ! service_exists "$service_name"; then
     log "Service not found, skipping active check: $service_name"
+    return 0
   fi
+  log "Checking service is active: $service_name"
+  local try=1
+  while [ "$try" -le "$retries" ]; do
+    if systemctl is-active --quiet "$service_name"; then
+      log "Service is active: $service_name"
+      return 0
+    fi
+    if [ "$try" -lt "$retries" ]; then
+      warn "Service not yet active (attempt ${try}/${retries}): $service_name -- retrying in ${wait_sec}s"
+      sleep "$wait_sec"
+    fi
+    try=$((try + 1))
+  done
+  error "Service is present but not active after $retries attempts: $service_name"
+  return 1
 }
 
 assert_service_active_required() {


### PR DESCRIPTION
## Summary
- The `assert_service_active_if_present` function in `validate_service.sh` used a bare `systemctl is-active --quiet` call
- With `set -e`, this crashes the script with exit code 3 when a service exists but hasn't finished starting
- Add retry logic (same pattern as `assert_service_active_required`) to wait for services like puma to become active after restart
- Configurable via `SERVICE_ACTIVE_RETRIES` (default 6) and `SERVICE_ACTIVE_WAIT` (default 5s)

## Context
Deployment `d-5754E7ASI` succeeded on 2 of 5 instances (crawler + cron). Failed on app1 because puma service wasn't active yet when ValidateService checked -- same timing class as the resque issue fixed in PR #2037.

## Test plan
- [ ] Deploy and verify all 5 instances pass ValidateService