### PR TITLE
SRCH-6443: Increase puma active check retry window to 60s

### DIFF
--- a/cicd-scripts/validate_service.sh
+++ b/cicd-scripts/validate_service.sh
@@ -48,7 +48,7 @@ resolve_puma_service() {
 
 assert_service_active_if_present() {
   local service_name="$1"
-  local retries="${SERVICE_ACTIVE_RETRIES:-6}"
+  local retries="${SERVICE_ACTIVE_RETRIES:-12}"
   local wait_sec="${SERVICE_ACTIVE_WAIT:-5}"
 
   if ! service_exists "$service_name"; then


### PR DESCRIPTION
## Summary
- Puma loads the full Rails environment on cold start, which can take 30-60s on busier instances
- The default 30s window (6 retries x 5s) from PR #2038 was insufficient -- app2 (i-0f49358c4ea018864) failed after all 6 retries
- Increase default to 60s (12 retries x 5s), still overridable via `SERVICE_ACTIVE_RETRIES` env var

## Context
Deployment `d-XUU708RSI` succeeded on 3 of 5 instances (crawl2, cron1, app1) but app2's puma wasn't active within 30s.

## Test plan
- [ ] Deploy and verify all 5 instances pass ValidateService