### PR TITLE
SRCH-6443: Add systemctl/journalctl diagnostics on service active failure

### DIFF
--- a/cicd-scripts/validate_service.sh
+++ b/cicd-scripts/validate_service.sh
@@ -48,7 +48,7 @@ resolve_puma_service() {
 
 assert_service_active_if_present() {
   local service_name="$1"
-  local retries="${SERVICE_ACTIVE_RETRIES:-6}"
+  local retries="${SERVICE_ACTIVE_RETRIES:-12}"
   local wait_sec="${SERVICE_ACTIVE_WAIT:-5}"
 
   if ! service_exists "$service_name"; then

--- a/cicd-scripts/validate_service.sh
+++ b/cicd-scripts/validate_service.sh
@@ -69,6 +69,10 @@ assert_service_active_if_present() {
     try=$((try + 1))
   done
   error "Service is present but not active after $retries attempts: $service_name"
+  log "--- systemctl status $service_name ---"
+  systemctl status "$service_name" --no-pager 2>&1 || true
+  log "--- journalctl -u $service_name (last 30 lines) ---"
+  journalctl -u "$service_name" -n 30 --no-pager 2>&1 || true
   return 1
 }
 


### PR DESCRIPTION
## Summary
- When a service fails to become active after all retry attempts, dump `systemctl status` and `journalctl` (last 30 lines) so the root cause appears in CodeDeploy logs
- App2 (`i-0f49358c4ea018864`) puma consistently fails to start even after 60s (12 retries x 5s). We need visibility into the actual error.

## Context
Deployments `d-XUU708RSI` and `d-MIXDZ4SSI` both succeeded on 3/5 instances but failed on app2 with puma not becoming active. Without journal output in the CodeDeploy logs, we're blind to the root cause.

## Test plan
- [ ] Deploy and check CodeDeploy logs for app2 -- should now show why puma isn't starting