### PR TITLE
SRCH-6443: Symlink .bundle config so systemd can find gems

### DIFF
--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -86,11 +86,18 @@ export BUNDLE_FROZEN="false"
 
 log "Bundler config: without=$BUNDLE_WITHOUT, path=$BUNDLE_PATH"
 
-# Create shared bundle directories
+# Create shared bundle directories and persist config for systemd
 mkdir -p "$SHARED_DIR/bundle" "$SHARED_DIR/.bundle"
+cat > "$SHARED_DIR/.bundle/config" <<BUNDLECONF
+---
+BUNDLE_PATH: "$SHARED_DIR/bundle"
+BUNDLE_WITHOUT: "development:test"
+BUNDLECONF
 
-# Remove per-release bundle config
+# Symlink per-release .bundle to shared config so systemd's bundler
+# can find BUNDLE_PATH without needing env vars at runtime
 rm -rf "$RELEASE_DIR/.bundle"
+ln -sfn "$SHARED_DIR/.bundle" "$RELEASE_DIR/.bundle"
 
 # Optionally clean git gem cache
 if [ "${CLEAN_BUNDLER_GIT_CACHE:-false}" = "true" ]; then


### PR DESCRIPTION
## Summary
- `after_install.sh` uses env vars (`BUNDLE_PATH`, `BUNDLE_APP_CONFIG`) to configure bundler during deployment, then deletes `.bundle/config` from the release directory
- When systemd starts puma, it has none of these env vars, so bundler can't locate gems at the shared path -- exit code 127 ("command not found")
- App1 worked by luck: puma was in the global gem dir from a legacy install. App2 only had puma in the shared bundle path

### Changes
- Write `BUNDLE_PATH` and `BUNDLE_WITHOUT` to `shared/.bundle/config` explicitly
- Symlink `release/.bundle -> shared/.bundle` instead of removing it
- Now systemd's bundler reads the symlinked config and finds gems without needing env vars

### Root cause investigation
SSM diagnostics on app2 showed:
- `omniauth_login_dot_gov` git gem wasn't checked out (from `bundle info` output)
- `bundle exec puma` returned "command not found" because without `.bundle/config`, bundler looked in the default Ruby gem dir where puma wasn't installed
- app1's `bundle info puma` showed path at global gem dir, app2's showed shared bundle path

## Test plan
- [ ] Deploy and verify app2 puma starts successfully
- [ ] Verify all 5 instances pass ValidateService