### PR TITLE
SRCH-6443: Always run db:migrate during deployment

### DIFF
--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -129,11 +129,9 @@ fi
 log "Precompiling assets"
 SECRET_KEY_BASE=placeholder RAILS_ENV=production ./bin/rails assets:precompile
 
-# Optional migrations
-if [ "${RUN_DB_MIGRATIONS:-false}" = "true" ]; then
-  log "Running database migrations"
-  RAILS_ENV=production bundle exec rails db:migrate
-fi
+# Run pending migrations (idempotent -- no-op if none pending)
+log "Running database migrations"
+RAILS_ENV=production bundle exec rails db:migrate
 
 # Atomically promote release
 log "Promoting release to current"


### PR DESCRIPTION
## Summary
- Remove the `RUN_DB_MIGRATIONS` feature flag gate and run `db:migrate` unconditionally during `AfterInstall`
- `db:migrate` is idempotent -- if there are no pending migrations, it's a no-op
- This ensures schema changes are always applied as part of the deployment, matching the behavior developers expect from the old Capistrano-based deploys

## Test plan
- [ ] Deploy to dev and verify `db:migrate` runs in AfterInstall logs
- [ ] Confirm no-op when there are no pending migrations