### PR TITLE
fix(deploy): remove --acl public-read from S3 asset upload script

### DIFF
--- a/cicd-scripts/upload_assets_to_s3.sh
+++ b/cicd-scripts/upload_assets_to_s3.sh
@@ -89,7 +89,6 @@ sync_to_s3() {
     --exclude ".sprockets-manifest-*.json" \
     --exclude "manifest.json.br" \
     --cache-control "public, max-age=31536000, immutable" \
-    --acl public-read \
     --size-only \
     --delete; then
     log "Successfully synced all assets from $source_dir"
@@ -115,7 +114,6 @@ sync_to_s3() {
       aws s3 cp "$source_dir/$file" "s3://${S3_BUCKET}${s3_path}/$file" \
         --region "$AWS_REGION" \
         --cache-control "public, max-age=3600" \
-        --acl public-read \
         --metadata-directive REPLACE 2>/dev/null || true
     fi
   done


### PR DESCRIPTION
## Problem

The staging deployment pipeline (`staging_app_searchgov_pipeline`) was failing during asset upload with:

```
AccessDenied: User: arn:aws:iam::xxxxxxxxxx:user/dgsearch-images-manager
is not authorized to perform: s3:PutObjectAcl on resource:
"arn:aws:s3:::dgsearch-images-staging/assets/..."
because no identity-based policy allows the s3:PutObjectAcl action
```

`cicd-scripts/upload_assets_to_s3.sh` passes `--acl public-read` on both the `aws s3 sync` and `aws s3 cp` calls. The AWS CLI translates `--acl public-read` into a `PutObjectAcl` API call after each `PutObject`. The `dgsearch-images-manager` IAM user's bucket policy grants `s3:PutObject` but not `s3:PutObjectAcl`, causing every upload to fail.

## Why Dev Was Unaffected

`dgsearch-images-dev` is a legacy S3 bucket with no `OwnershipControls` or `BlockPublicAcls` configuration — ACLs work implicitly on old buckets. `dgsearch-images-staging` is a new bucket created in SRCH-6472 Terraform work with `BucketOwnerPreferred` ownership controls, which enforces IAM-based access rather than ACL-based access.

## Fix

Remove `--acl public-read` from:
- Line 92: `aws s3 sync` (fingerprinted assets batch upload)
- Line 118: `aws s3 cp` (non-fingerprinted cache header override)

Assets on `dgsearch-images-staging` are served exclusively via CloudFront with Origin Access Control (OAC) — public access is controlled by the bucket policy, not object ACLs. No ACL flag is needed.

## Testing

Re-run `staging_app_searchgov_pipeline` after merging. Asset upload step should complete without `AccessDenied` errors.

## Related

- SRCH-6472: S3/CloudFront bucket separation Terraform work (searchgov-tf PR #316)
- Root cause confirmed via SSM diagnostics on `app4.staging` 