### PR TITLE
fix(deploy): remove --acl public-read from upload_assets_to_s3.sh

### DIFF
--- a/cicd-scripts/upload_assets_to_s3.sh
+++ b/cicd-scripts/upload_assets_to_s3.sh
@@ -89,7 +89,6 @@ sync_to_s3() {
     --exclude ".sprockets-manifest-*.json" \
     --exclude "manifest.json.br" \
     --cache-control "public, max-age=31536000, immutable" \
-    --acl public-read \
     --size-only \
     --delete; then
     log "Successfully synced all assets from $source_dir"
@@ -115,7 +114,6 @@ sync_to_s3() {
       aws s3 cp "$source_dir/$file" "s3://${S3_BUCKET}${s3_path}/$file" \
         --region "$AWS_REGION" \
         --cache-control "public, max-age=3600" \
-        --acl public-read \
         --metadata-directive REPLACE 2>/dev/null || true
     fi
   done


### PR DESCRIPTION
When aws s3 sync or aws s3 cp is called with --acl public-read, the AWS CLI issues a separate PutObjectAcl API call after each PutObject. On S3 buckets configured with BucketOwnerPreferred ownership controls (the AWS default since April 2023 for new buckets), the dgsearch-images-manager IAM user's bucket policy only grants s3:PutObject — not s3:PutObjectAcl — causing every upload to fail with AccessDenied.

This was discovered during staging deployments after a dedicated dgsearch-images-staging bucket was created as part of SRCH-6472 infrastructure work. The legacy dgsearch-images-dev bucket was not affected because it predates the AWS ownership controls default change.

Fix
Remove --acl public-read from both call sites:

aws s3 sync (line 92) — bulk fingerprinted asset upload
aws s3 cp (line 118) — non-fingerprinted cache header override
Assets are served via CloudFront with Origin Access Control (OAC). Public access is controlled by the S3 bucket policy — no object-level ACL is needed.

Impact
Fixes staging deployment pipeline asset upload failures
No functional change to how assets are served (CloudFront OAC unchanged)
Safe for dev environment (dgsearch-images-dev) — removing the flag is a no-op on legacy buckets that already allowed ACLs

