### PR TITLE
SRCH-6598: Reap orphaned geckodriver when Firefox fails to launch

### DIFF
--- a/lib/js_fetcher.rb
+++ b/lib/js_fetcher.rb
@@ -10,7 +10,15 @@ module JsFetcher
     options.add_preference('browser.tabs.warnOnClose', false)
     options.add_preference('general.useragent.override', DEFAULT_USER_AGENT)
 
-    driver = Selenium::WebDriver.for(:firefox, options:)
+    begin
+      driver = Selenium::WebDriver.for(:firefox, options:)
+    rescue StandardError
+      # If Firefox fails to launch, Selenium raises before `driver` is
+      # assigned, leaving the already-spawned geckodriver running with
+      # inherited file descriptors (e.g. MySQL connections). Reap it.
+      kill_stray_geckodrivers
+      raise
+    end
 
     driver.manage.timeouts.implicit_wait = 5
     driver.manage.timeouts.page_load = 30
@@ -23,4 +31,14 @@ module JsFetcher
       driver.quit
     end
   end
+
+  def self.kill_stray_geckodrivers
+    pids = `pgrep -P #{Process.pid} -f geckodriver`.split.map(&:to_i)
+    pids.each do |pid|
+      Process.kill('TERM', pid)
+    rescue Errno::ESRCH, Errno::EPERM
+      next
+    end
+  end
+  private_class_method :kill_stray_geckodrivers
 end

--- a/spec/lib/js_fetcher_spec.rb
+++ b/spec/lib/js_fetcher_spec.rb
@@ -5,10 +5,10 @@ require 'spec_helper'
 describe JsFetcher do
   describe '.fetch' do
     let(:url) { 'https://digital.gov/guides/search/' }
-    let(:options) { instance_double('Selenium::WebDriver::Firefox::Options') }
-    let(:driver)  { instance_double('Selenium::WebDriver::Driver') }
-    let(:manage)  { instance_double('Selenium::WebDriver::Driver::Manage') }
-    let(:timeouts) { instance_double('Selenium::WebDriver::Timeouts') }
+    let(:options) { instance_double(Selenium::WebDriver::Firefox::Options) }
+    let(:driver)  { instance_double(Selenium::WebDriver::Driver) }
+    let(:manage)  { instance_double(Selenium::WebDriver::Manager) }
+    let(:timeouts) { instance_double(Selenium::WebDriver::Timeouts) }
 
     before do
       # Stub Firefox options creation and configuration
@@ -22,17 +22,16 @@ describe JsFetcher do
       allow(Selenium::WebDriver).to receive(:for).with(:firefox, options: options).and_return(driver)
 
       # Stub timeouts chain
-      allow(driver).to receive(:manage).and_return(manage)
       allow(manage).to receive(:timeouts).and_return(timeouts)
       allow(timeouts).to receive(:implicit_wait=).with(5)
       allow(timeouts).to receive(:page_load=).with(30)
 
       # Avoid real sleeps in specs
-      allow(JsFetcher).to receive(:sleep)
+      allow(described_class).to receive(:sleep)
 
       # Normal driver interactions
       allow(driver).to receive(:get).with(url)
-      allow(driver).to receive(:page_source).and_return('<html>fake content</html>')
+      allow(driver).to receive_messages(manage: manage, page_source: '<html>fake content</html>')
       allow(driver).to receive(:quit)
     end
 
@@ -50,6 +49,24 @@ describe JsFetcher do
 
       # Verify it quit the driver
       expect(driver).to have_received(:quit)
+    end
+
+    context 'when the driver fails to launch' do
+      before do
+        allow(Selenium::WebDriver).to receive(:for).
+          and_raise(Selenium::WebDriver::Error::UnknownError, 'Process unexpectedly closed with status 1')
+        allow(described_class).to receive(:`).
+          with("pgrep -P #{Process.pid} -f geckodriver").and_return("123\n456\n")
+        allow(Process).to receive(:kill)
+      end
+
+      it 'kills stray geckodriver children and re-raises' do
+        expect { described_class.fetch(url) }.
+          to raise_error(Selenium::WebDriver::Error::UnknownError)
+
+        expect(Process).to have_received(:kill).with('TERM', 123)
+        expect(Process).to have_received(:kill).with('TERM', 456)
+      end
     end
   end
 end


### PR DESCRIPTION
## What this fixes

The other half of SRCH-6598 (dev's geckodriver/MySQL connection leak). When Firefox fails to launch, Selenium raises before `driver` is ever assigned in JsFetcher, so the `ensure driver.quit` never runs. The geckodriver that was already spawned just lives on forever with inherited file descriptors, including MySQL connections. That's how dev ended up with 875 leaked connections on crawl2 and 401 on crawl1.

## What it does now

Wraps driver creation in a rescue that TERMs any geckodriver children of the current process before re-raising. So even if Firefox is broken, we can't accumulate orphans anymore.

Also fixed a latent spec bug while adding the failure path test: the old spec referenced `Selenium::WebDriver::Driver::Manage`, which doesn't exist (the real class is `Selenium::WebDriver::Manager`). It never failed before because it was passed as a string.

## Test plan
- [x] `bundle exec rspec spec/lib/js_fetcher_spec.rb` (2 examples, 0 failures)
- [x] `bundle exec rubocop` clean on changed files
- [ ] On dev (after the ansible fix lands), fetch a js_renderer URL and confirm `pgrep -c geckodriver` stays at 0

Companion infra fix: GSA/searchgov-ansible#362 (installs the real Mozilla deb instead of the snap wrapper)