### PR TITLE
SRCH-6581 Decode percent-encoded PDF filename result titles

### DIFF
--- a/lib/search_elastic/document_search_results.rb
+++ b/lib/search_elastic/document_search_results.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'cgi'
+
 class SearchElastic::DocumentSearchResults
   attr_reader :total, :offset, :results, :suggestion, :aggregations
 
@@ -37,11 +39,25 @@ class SearchElastic::DocumentSearchResults
         end
       end
 
+      source['title'] = decode_filename_title(source['title'])
+
       %w[created_at created changed updated_at updated].each do |date|
         source[date] = Time.parse(source[date]).utc.to_s if source[date].present?
       end
       source
     end
+  end
+
+  # Titles that fall back to a raw filename (e.g. for PDFs without metadata)
+  # arrive percent-encoded and may carry a query string. Such filename titles
+  # have no whitespace, unlike genuine metadata titles, so decode only those to
+  # avoid altering legitimate titles. See SRCH-6581.
+  def decode_filename_title(title)
+    return title if title.blank?
+    return title if title.match?(/\s/)
+    return title unless title.match?(/%[0-9A-Fa-f]{2}/) || title.include?('?')
+
+    CGI.unescape(title.sub(/\?.*\z/, ''))
   end
 
   def extract_aggregations(aggregations)

--- a/spec/lib/search_elastic/document_search_results_spec.rb
+++ b/spec/lib/search_elastic/document_search_results_spec.rb
@@ -51,6 +51,115 @@ describe SearchElastic::DocumentSearchResults do
                                                'content' => 'Some highlighted content' }))
       }
     end
+
+    context 'when the title is a percent-encoded filename' do
+      let(:result) do
+        { 'hits' => { 'total' => 1, 'hits' => [hits] },
+          'aggregations' => {},
+          'suggest' => [] }
+      end
+      let(:hits) do
+        { '_type' => '_doc',
+          '_source' => { 'path' => 'https://www.va.gov/files/2022-10/BA%20degree%20nurse%20scholarship_0.pdf',
+                         'language' => 'en',
+                         'title_en' => 'BA%20degree%20nurse%20scholarship_0.pdf' } }
+      end
+
+      it 'decodes the percent-encoding' do
+        expect(results.first['title']).to eq('BA degree nurse scholarship_0.pdf')
+      end
+    end
+
+    context 'when the filename title carries a query string' do
+      let(:result) do
+        { 'hits' => { 'total' => 1, 'hits' => [hits] },
+          'aggregations' => {},
+          'suggest' => [] }
+      end
+      let(:hits) do
+        { '_type' => '_doc',
+          '_source' => { 'path' => 'https://www.asbca.mil/Portals/143/Decisions/2015/foo.pdf',
+                         'language' => 'en',
+                         'title_en' => '59702%20Waterman%20Steamship%20Corporation%203.12.15.pdf?ver=kx-UXd05JFKrQzcV6QQKoQ==' } }
+      end
+
+      it 'discards the query string and decodes the filename' do
+        expect(results.first['title']).to eq('59702 Waterman Steamship Corporation 3.12.15.pdf')
+      end
+    end
+
+    context 'when the filename title has no extension' do
+      let(:result) do
+        { 'hits' => { 'total' => 1, 'hits' => [hits] },
+          'aggregations' => {},
+          'suggest' => [] }
+      end
+      let(:hits) do
+        { '_type' => '_doc',
+          '_source' => { 'path' => 'https://www.oig.dol.gov/public/Press%20Releases/foo.pdf',
+                         'language' => 'en',
+                         'title_en' => 'AZ*AG*Attorney%20General%20Kris%20Mayes%20Announces%20Sentencing%20in%20Pandemic%20Unemployment%20Assistance%20Fraud' } }
+      end
+
+      it 'still decodes the percent-encoding' do
+        expect(results.first['title']).to eq('AZ*AG*Attorney General Kris Mayes Announces Sentencing in Pandemic Unemployment Assistance Fraud')
+      end
+    end
+
+    context 'when the title is a normal metadata title' do
+      let(:result) do
+        { 'hits' => { 'total' => 1, 'hits' => [hits] },
+          'aggregations' => {},
+          'suggest' => [] }
+      end
+      let(:hits) do
+        { '_type' => '_doc',
+          '_source' => { 'path' => 'https://search.gov/about/',
+                         'language' => 'en',
+                         'title_en' => 'About Search.gov | Search.gov' } }
+      end
+
+      it 'leaves the title unchanged' do
+        expect(results.first['title']).to eq('About Search.gov | Search.gov')
+      end
+    end
+
+    context 'when a normal title contains a percent sign with spaces' do
+      let(:result) do
+        { 'hits' => { 'total' => 1, 'hits' => [hits] },
+          'aggregations' => {},
+          'suggest' => [] }
+      end
+      let(:hits) do
+        { '_type' => '_doc',
+          '_source' => { 'path' => 'https://search.gov/report/',
+                         'language' => 'en',
+                         'title_en' => 'Save 20%20 on the report' } }
+      end
+
+      it 'does not decode titles that contain whitespace' do
+        expect(results.first['title']).to eq('Save 20%20 on the report')
+      end
+    end
+
+    context 'when the title is highlighted' do
+      let(:result) do
+        { 'hits' => { 'total' => 1, 'hits' => [hits] },
+          'aggregations' => {},
+          'suggest' => [] }
+      end
+      let(:hits) do
+        { '_type' => '_doc',
+          '_source' => { 'path' => 'https://search.gov/about/',
+                         'language' => 'en',
+                         'title_en' => 'About Search.gov | Search.gov' },
+          'highlight' => { 'title_en' => ["About \uE000Search\uE001.gov | Search.gov"] } }
+      end
+
+      it 'preserves highlight markers' do
+        expect(results.first['title']).to eq("About \uE000Search\uE001.gov | Search.gov")
+      end
+    end
   end
 
   describe '#aggregations' do

--- a/spec/models/open_search/document_search_spec.rb
+++ b/spec/models/open_search/document_search_spec.rb
@@ -42,5 +42,24 @@ describe OpenSearch::DocumentSearch do
         rest_total_hits_as_int: true
       )
     end
+
+    context 'when a result title is a percent-encoded filename' do
+      let(:search_results) do
+        {
+          'hits' => {
+            'total' => 1,
+            'hits' => [
+              { '_source' => { 'path' => 'https://www.va.gov/files/2022-10/BA%20degree%20nurse%20scholarship_0.pdf',
+                               'language' => 'en',
+                               'title_en' => 'BA%20degree%20nurse%20scholarship_0.pdf' } }
+            ]
+          }
+        }
+      end
+
+      it 'decodes the title for downstream SERP and API consumers' do
+        expect(search.search.results.first['title']).to eq('BA degree nurse scholarship_0.pdf')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary
- When a document (e.g. a PDF) has no metadata title, the result title falls back to the raw filename derived from the URL, surfacing percent-encoding (`%20`) and trailing query strings in both the SERP and the API (per [SRCH-6581](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6581)).
- Decodes such filename-derived titles at the shared read-time chokepoint `SearchElastic::DocumentSearchResults#extract_hits` (inherited by `OpenSearch::DocumentSearchResults`), so all consumers (redesign React SERP, legacy HAML SERP, browser JSON, and API v2) are corrected for already-indexed documents across the OpenSearch/Legacy OpenSearch/SearchElastic indexes with no reindex.
- Conservative heuristic: only titles that look like raw filenames (no whitespace, containing percent-encoding or a query string) are transformed; genuine metadata titles are left untouched. The query string is dropped and the value is `CGI.unescape`d.

Acceptance criteria examples verified:
- `BA%20degree%20nurse%20scholarship_0.pdf` -> `BA degree nurse scholarship_0.pdf`
- `59702%20Waterman%20Steamship%20Corporation%203.12.15.pdf?ver=...==` -> `59702 Waterman Steamship Corporation 3.12.15.pdf`
- `AZ*AG*Attorney%20General%20...%20Fraud` -> `AZ*AG*Attorney General ... Fraud`

## Test plan
- [x] Unit specs in `spec/lib/search_elastic/document_search_results_spec.rb` covering the three ticket examples plus untouched cases (normal title, spaced title containing `%`, highlighted title).
- [x] Integration spec in `spec/models/open_search/document_search_spec.rb` decoding through the real `DocumentSearchResults`.
- [x] Local e2e via docker compose (search-services): seeded an OpenSearch-engine affiliate + an encoded-filename PDF doc and confirmed the decoded title in both the SERP (`/search`) HTML and the API (`/api/v2/search/i14y`) JSON, while the result link URL remains correctly encoded.

### Checklist
#### Functionality Checks
- [x] You have merged the latest changes from the target branch (`main`) into your branch. (Branch was created off latest `upstream/main`.)
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [x] PR title is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [ ] Automated checks pass.
#### Process Checks
- [ ] You have specified at least one "Reviewer".

[SRCH-6581]: https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6581