### PR TITLE
SRCH-6581 Strip file extension from decoded PDF filename titles

### DIFF
--- a/lib/search_elastic/document_search_results.rb
+++ b/lib/search_elastic/document_search_results.rb
@@ -51,13 +51,16 @@ class SearchElastic::DocumentSearchResults
   # Titles that fall back to a raw filename (e.g. for PDFs without metadata)
   # arrive percent-encoded and may carry a query string. Such filename titles
   # have no whitespace, unlike genuine metadata titles, so decode only those to
-  # avoid altering legitimate titles. See SRCH-6581.
+  # avoid altering legitimate titles. We drop the query string, decode the
+  # percent-encoding, and strip the file extension so these titles match what
+  # the spider now writes at index time (SRCH-6609). See SRCH-6581.
   def decode_filename_title(title)
     return title if title.blank?
     return title if title.match?(/\s/)
     return title unless title.match?(/%[0-9A-Fa-f]{2}/) || title.include?('?')
 
-    CGI.unescape(title.sub(/\?.*\z/, ''))
+    decoded = CGI.unescape(title.sub(/\?.*\z/, ''))
+    decoded.chomp(File.extname(decoded))
   end
 
   def extract_aggregations(aggregations)

--- a/spec/lib/search_elastic/document_search_results_spec.rb
+++ b/spec/lib/search_elastic/document_search_results_spec.rb
@@ -65,8 +65,8 @@ describe SearchElastic::DocumentSearchResults do
                          'title_en' => 'BA%20degree%20nurse%20scholarship_0.pdf' } }
       end
 
-      it 'decodes the percent-encoding' do
-        expect(results.first['title']).to eq('BA degree nurse scholarship_0.pdf')
+      it 'decodes the percent-encoding and strips the extension' do
+        expect(results.first['title']).to eq('BA degree nurse scholarship_0')
       end
     end
 
@@ -83,8 +83,8 @@ describe SearchElastic::DocumentSearchResults do
                          'title_en' => '59702%20Waterman%20Steamship%20Corporation%203.12.15.pdf?ver=kx-UXd05JFKrQzcV6QQKoQ==' } }
       end
 
-      it 'discards the query string and decodes the filename' do
-        expect(results.first['title']).to eq('59702 Waterman Steamship Corporation 3.12.15.pdf')
+      it 'discards the query string, decodes the filename, and strips the extension' do
+        expect(results.first['title']).to eq('59702 Waterman Steamship Corporation 3.12.15')
       end
     end
 

--- a/spec/models/open_search/document_search_spec.rb
+++ b/spec/models/open_search/document_search_spec.rb
@@ -57,8 +57,8 @@ describe OpenSearch::DocumentSearch do
         }
       end
 
-      it 'decodes the title for downstream SERP and API consumers' do
-        expect(search.search.results.first['title']).to eq('BA degree nurse scholarship_0.pdf')
+      it 'decodes the title and strips the extension for downstream SERP and API consumers' do
+        expect(search.search.results.first['title']).to eq('BA degree nurse scholarship_0')
       end
     end
   end


### PR DESCRIPTION
## Summary
Follow-up to #2073 (SRCH-6581). The read-time filename-title decode now also **strips the file extension**, so Legacy OpenSearch titles line up with what the spider writes at index time (SRCH-6609 / searchgov-spider#480).

Requested by David on SRCH-6581: keep the legacy crawler and spider aligned since the titles are customer/public-facing (usability + SEO), even though the legacy path is slated for eventual retirement.

## Behavior
`decode_filename_title` still only touches whitespace-free, filename-style titles (percent-encoded or carrying a query string) and leaves genuine metadata titles alone. For those it now:
- drops the query string,
- decodes the percent-encoding,
- strips the trailing file extension.

Examples:
- `BA%20degree%20nurse%20scholarship_0.pdf` -> `BA degree nurse scholarship_0`
- `59702%20Waterman%20Steamship%20Corporation%203.12.15.pdf?ver=...` -> `59702 Waterman Steamship Corporation 3.12.15`
- `Vinson%20Voice%20Quarterly%20Stakeholders%27%20Newsletter%20Jan.-March%202025.pdf` -> `Vinson Voice Quarterly Stakeholders' Newsletter Jan.-March 2025` (matches the spider output)

## Note / known boundary
Non-encoded filename titles with no query string (e.g. a stored `report.pdf` that has no `%` or `?`) are still left untouched by the whitespace guard, so they keep their extension. Broadening this would risk altering legitimate single-token metadata titles. Happy to expand if we want exact parity with the spider for that case too.

## Testing
- Updated `spec/lib/search_elastic/document_search_results_spec.rb` and `spec/models/open_search/document_search_spec.rb` to expect extension-stripped titles.
- Verified the decode logic against the ticket examples and David's staging example in isolation; CI runs the full suite.