### PR TITLE
feat(SRCH-6631): gate db:migrate on environment + terraform_module + Fleet

### DIFF
--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -199,7 +199,7 @@ TERRAFORM_MODULE="$(get_terraform_module_tag)"
 # troubleshooting/verification once app/crawler/cron share one deployment
 # group and are no longer distinguishable by deployment group name alone.
 case "$TERRAFORM_MODULE" in
-  app)
+  app | app-green)
     log "Running database migrations (terraform_module=$TERRAFORM_MODULE)"
     RAILS_ENV=production bundle exec rails db:migrate
     ;;
@@ -210,6 +210,7 @@ esac
 
 # Atomically promote release
 log "Promoting release to current"
+
 TMP_LINK="${APP_ROOT}/.current_tmp"
 ln -sfn "$RELEASE_DIR" "$TMP_LINK"
 mv -Tf "$TMP_LINK" "$CURRENT_LINK"

--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -134,35 +134,48 @@ fi
 log "Precompiling assets"
 SECRET_KEY_BASE=placeholder RAILS_ENV=production ./bin/rails assets:precompile
 
-# SRCH-6631: Only run database migrations on the main "app" tier. All other
-# tiers (crawler, cron, spider, api, proxy, letsencrypt, and their -green
-# counterparts) share the same production RDS instance but must NOT run
-# migrations independently, since deploying to those tiers could otherwise
-# apply schema changes the main app fleet's currently-running release does
-# not expect. See: prod_outage_20260710_shared_db_migration_incident.md for
-# the incident this guards against.
+# SRCH-6631: Only run database migrations on the currently-active "app" tier
+# instance for this environment. All other tiers (crawler, cron, spider, api,
+# proxy, letsencrypt, and their -green counterparts) share the same
+# production RDS instance but must NOT run migrations independently, since
+# deploying to those tiers could otherwise apply schema changes the main app
+# fleet's currently-running release does not expect. See:
+# prod_outage_20260710_shared_db_migration_incident.md for the incident this
+# guards against.
 #
-# NOTE: an earlier version of this gate checked $DEPLOYMENT_GROUP_NAME
-# (set directly by the CodeDeploy agent, no IMDS/AWS API calls needed).
-# That approach breaks once app/crawler/cron are consolidated behind a
-# single shared deployment group (dg_searchgov) -- at that point
-# DEPLOYMENT_GROUP_NAME is identical for all three tiers and can no longer
-# distinguish them. This version instead reads the instance's own
-# terraform_module EC2 tag, which is set independently per-instance by
-# Terraform at provisioning time and is unaffected by which deployment
-# group happens to trigger a given deployment.
+# NOTE: an earlier version of this gate checked only the terraform_module
+# tag for an exact match on "app". That is correct for dev and production
+# today (both have a plain "app" instance with no Fleet tag at all, and no
+# coexisting green fleet), but it is NOT correct for an environment mid
+# Ubuntu-24.04 green-fleet upgrade: staging's app tier currently only exists
+# as "app-green" (Fleet=green) -- exact-matching "app" alone means staging
+# never runs migrations automatically, forcing manual db:migrate on every
+# staging deploy.
 #
-# Fail-safe: if the tag cannot be resolved for any reason, migrations are
+# This version reads three EC2 tags together -- terraform_module, Fleet, and
+# environment -- in a single describe-tags call, and gates on the
+# combination of all three. This correctly distinguishes "the tier that owns
+# migrations in this environment right now" without reintroducing the
+# shared-DB race condition the original incident was caused by: if/when
+# production ever has its own coexisting "app" + "app-green" pair during its
+# own cutover, the same tag combination that currently matches production's
+# plain "app" tier will need to be revisited then, based on the real tag
+# state at that time -- not decided preemptively here.
+#
+# Confirmed live (2026-07-14): dev's "app" and production's "app" both have
+# no Fleet tag at all; only staging currently has an "app-green" instance,
+# tagged Fleet=green.
+#
+# Fail-safe: if any tag cannot be resolved for any reason, migrations are
 # SKIPPED (never default to running them).
-get_terraform_module_tag() {
-  local imds_token instance_id tag_value
+get_instance_tags() {
+  local imds_token instance_id
 
   imds_token=$(curl -sS --fail --max-time 2 -X PUT \
     "http://169.254.169.254/latest/api/token" \
     -H "X-aws-ec2-metadata-token-ttl-seconds: 300" 2>/dev/null || true)
   if [ -z "$imds_token" ]; then
-    warn "Could not retrieve IMDSv2 token; terraform_module tag unknown"
-    echo "unknown"
+    warn "Could not retrieve IMDSv2 token; instance tags unknown"
     return
   fi
 
@@ -171,40 +184,65 @@ get_terraform_module_tag() {
     "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null || true)
 
   if [ -z "$instance_id" ]; then
-    warn "Could not determine instance-id; terraform_module tag unknown"
-    echo "unknown"
+    warn "Could not determine instance-id; instance tags unknown"
     return
   fi
 
-  # Deliberately omit --region: AWS CLI v2 automatically resolves the region
-  # via IMDS when no region is set via env var/profile/flag.
-  tag_value=$(aws ec2 describe-tags \
-    --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=terraform_module" \
-    --query "Tags[0].Value" --output text 2>/dev/null || true)
-
-  if [ -z "$tag_value" ] || [ "$tag_value" = "None" ]; then
-    warn "terraform_module tag not found on this instance; defaulting to unknown"
-    echo "unknown"
-    return
-  fi
-
-  echo "$tag_value"
+  # Single describe-tags call for all three keys at once -- same AWS API
+  # call cost as the previous single-tag lookup. Deliberately omit --region:
+  # AWS CLI v2 automatically resolves the region via IMDS when no region is
+  # set via env var/profile/flag. Requested as JSON and parsed with jq (both
+  # confirmed present on all app-tier instances in dev/staging/prod) rather
+  # than tab/newline-delimited text -- this avoids relying on whitespace
+  # characters as field separators and lets jq return each tag's actual
+  # value, or a clean explicit empty result if the tag key is absent, with
+  # no special-casing needed to tell "absent" apart from a delimiter quirk.
+  aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=$instance_id" \
+      "Name=key,Values=terraform_module,Fleet,environment" \
+    --output json 2>/dev/null || true
 }
 
-TERRAFORM_MODULE="$(get_terraform_module_tag)"
+TAGS_JSON="$(get_instance_tags)"
 
-# Every branch of this case logs the resolved terraform_module value and
-# whether migrations ran, so every pipeline run's log clearly shows which
-# tier it deployed to and whether db:migrate executed -- needed for
-# troubleshooting/verification once app/crawler/cron share one deployment
-# group and are no longer distinguishable by deployment group name alone.
-case "$TERRAFORM_MODULE" in
-  app)
-    log "Running database migrations (terraform_module=$TERRAFORM_MODULE)"
+lookup_tag() {
+  local key="$1"
+  if [ -z "$TAGS_JSON" ]; then
+    echo ""
+    return
+  fi
+  echo "$TAGS_JSON" | jq -r --arg key "$key" \
+    '.Tags[] | select(.Key == $key) | .Value' 2>/dev/null || true
+}
+
+TERRAFORM_MODULE="$(lookup_tag terraform_module)"
+FLEET="$(lookup_tag Fleet)"
+ENVIRONMENT="$(lookup_tag environment)"
+
+[ -z "$TERRAFORM_MODULE" ] && TERRAFORM_MODULE="unknown"
+[ -z "$ENVIRONMENT" ] && ENVIRONMENT="unknown"
+
+if [ "$TERRAFORM_MODULE" = "unknown" ]; then
+  warn "terraform_module tag not found on this instance; defaulting to unknown"
+fi
+if [ "$ENVIRONMENT" = "unknown" ]; then
+  warn "environment tag not found on this instance; defaulting to unknown"
+fi
+
+# Every branch of this case logs the resolved tag values and whether
+# migrations ran, so every pipeline run's log clearly shows which
+# environment/tier/fleet it deployed to and whether db:migrate executed --
+# needed for troubleshooting/verification since app/crawler/cron share one
+# deployment group and are no longer distinguishable by deployment group
+# name alone, and since the migration-owning tag combination now differs by
+# environment.
+case "$ENVIRONMENT:$TERRAFORM_MODULE:$FLEET" in
+  dev:app:|staging:app-green:green|production:app:)
+    log "Running database migrations (environment=$ENVIRONMENT, terraform_module=$TERRAFORM_MODULE, Fleet=${FLEET:-<absent>})"
     RAILS_ENV=production bundle exec rails db:migrate
     ;;
   *)
-    log "Skipping database migrations (terraform_module=$TERRAFORM_MODULE) -- not the migration-owning tier"
+    log "Skipping database migrations (environment=$ENVIRONMENT, terraform_module=$TERRAFORM_MODULE, Fleet=${FLEET:-<absent>}) -- not the migration-owning tier for this environment"
     ;;
 esac
 

--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -146,7 +146,7 @@ SECRET_KEY_BASE=placeholder RAILS_ENV=production ./bin/rails assets:precompile
 # Fail-safe: if the tier tag, RUN_MIGRATIONS value, or jq cannot be resolved
 # for any reason, migrations are SKIPPED (never default to running them).
 get_terraform_module_tag() {
-  local imds_token region instance_id tag_value
+  local imds_token instance_id tag_value
 
   imds_token=$(curl -sS --fail --max-time 2 -X PUT \
     "http://169.254.169.254/latest/api/token" \
@@ -157,21 +157,23 @@ get_terraform_module_tag() {
     return
   fi
 
-  region=$(curl -sS --fail --max-time 2 \
-    -H "X-aws-ec2-metadata-token: $imds_token" \
-    "http://169.254.169.254/latest/dynamic/instance-identity/document" 2>/dev/null \
-    | sed -n 's/.*"region"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
   instance_id=$(curl -sS --fail --max-time 2 \
     -H "X-aws-ec2-metadata-token: $imds_token" \
     "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null || true)
 
-  if [ -z "$region" ] || [ -z "$instance_id" ]; then
-    warn "Could not determine region/instance-id; terraform_module tag unknown"
+  if [ -z "$instance_id" ]; then
+    warn "Could not determine instance-id; terraform_module tag unknown"
     echo "unknown"
     return
   fi
 
-  tag_value=$(aws ec2 describe-tags --region "$region" \
+  # Deliberately omit --region: AWS CLI v2 automatically resolves the region
+  # via IMDS when no region is set via env var/profile/flag (confirmed via
+  # `aws configure list` -> "region : <value> : imds" on these instances).
+  # CodeDeploy does not inject a region env var into hook scripts, so this
+  # relies on the CLI's own IMDS fallback rather than duplicating that lookup
+  # with a manual instance-identity-document parse.
+  tag_value=$(aws ec2 describe-tags \
     --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=terraform_module" \
     --query "Tags[0].Value" --output text 2>/dev/null || true)
 
@@ -183,6 +185,7 @@ get_terraform_module_tag() {
 
   echo "$tag_value"
 }
+
 
 # Extract only the RUN_MIGRATIONS line from the shared .env file. Deliberately
 # avoids sourcing .env wholesale in bash, since it may contain multiline

--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -134,89 +134,32 @@ fi
 log "Precompiling assets"
 SECRET_KEY_BASE=placeholder RAILS_ENV=production ./bin/rails assets:precompile
 
-# SRCH-6631: Only run database migrations on the tier(s) designated as the
-# migration owner (RUN_MIGRATIONS SSM parameter, managed in searchgov-tf).
-# This prevents a deploy to crawler/cron/spider/api/proxy/letsencrypt (which
-# share the same production RDS instance as the main app fleet) from running
-# `db:migrate` independently and applying schema changes the main app
-# fleet's currently-running release does not expect. See:
-# prod_outage_20260710_shared_db_migration_incident.md for the incident this
-# guards against.
+# SRCH-6631: Only run database migrations when this deployment targets the
+# main app CodeDeploy deployment group. All other deployment groups
+# (crawler, cron, spider, api, proxy, letsencrypt, and their -green
+# counterparts) share the same production RDS instance but must NOT run
+# migrations independently, since deploying to those groups could otherwise
+# apply schema changes the main app fleet's currently-running release does
+# not expect. See: prod_outage_20260710_shared_db_migration_incident.md for
+# the incident this guards against.
 #
-# Fail-safe: if the tier tag, RUN_MIGRATIONS value, or jq cannot be resolved
-# for any reason, migrations are SKIPPED (never default to running them).
-get_terraform_module_tag() {
-  local imds_token instance_id tag_value
-
-  imds_token=$(curl -sS --fail --max-time 2 -X PUT \
-    "http://169.254.169.254/latest/api/token" \
-    -H "X-aws-ec2-metadata-token-ttl-seconds: 300" 2>/dev/null || true)
-  if [ -z "$imds_token" ]; then
-    warn "Could not retrieve IMDSv2 token; terraform_module tag unknown"
-    echo "unknown"
-    return
-  fi
-
-  instance_id=$(curl -sS --fail --max-time 2 \
-    -H "X-aws-ec2-metadata-token: $imds_token" \
-    "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null || true)
-
-  if [ -z "$instance_id" ]; then
-    warn "Could not determine instance-id; terraform_module tag unknown"
-    echo "unknown"
-    return
-  fi
-
-  # Deliberately omit --region: AWS CLI v2 automatically resolves the region
-  # via IMDS when no region is set via env var/profile/flag (confirmed via
-  # `aws configure list` -> "region : <value> : imds" on these instances).
-  # CodeDeploy does not inject a region env var into hook scripts, so this
-  # relies on the CLI's own IMDS fallback rather than duplicating that lookup
-  # with a manual instance-identity-document parse.
-  tag_value=$(aws ec2 describe-tags \
-    --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=terraform_module" \
-    --query "Tags[0].Value" --output text 2>/dev/null || true)
-
-  if [ -z "$tag_value" ] || [ "$tag_value" = "None" ]; then
-    warn "terraform_module tag not found on this instance; defaulting to unknown"
-    echo "unknown"
-    return
-  fi
-
-  echo "$tag_value"
-}
-
-
-# Extract only the RUN_MIGRATIONS line from the shared .env file. Deliberately
-# avoids sourcing .env wholesale in bash, since it may contain multiline
-# PEM/certificate-style values that are unsafe to source directly.
-read_run_migrations_json() {
-  local env_file="$SHARED_DIR/.env"
-  if [ ! -f "$env_file" ]; then
-    echo "{}"
-    return
-  fi
-  grep -m1 '^RUN_MIGRATIONS=' "$env_file" | sed 's/^RUN_MIGRATIONS=//' || echo "{}"
-}
-
-TERRAFORM_MODULE="$(get_terraform_module_tag)"
-RUN_MIGRATIONS_JSON="$(read_run_migrations_json)"
-SHOULD_RUN_MIGRATIONS="false"
-
-if [ -n "$RUN_MIGRATIONS_JSON" ] && command -v jq >/dev/null 2>&1; then
-  SHOULD_RUN_MIGRATIONS="$(echo "$RUN_MIGRATIONS_JSON" | jq -r --arg tier "$TERRAFORM_MODULE" '.[$tier] // "false"' 2>/dev/null || echo "false")"
-fi
-
-log "terraform_module tag: $TERRAFORM_MODULE"
-log "RUN_MIGRATIONS policy value for this tier: $SHOULD_RUN_MIGRATIONS"
-
-if [ "$SHOULD_RUN_MIGRATIONS" = "true" ]; then
-  log "Running database migrations (tier=$TERRAFORM_MODULE, RUN_MIGRATIONS=true)"
-  RAILS_ENV=production bundle exec rails db:migrate
-else
-  log "Skipping database migrations (tier=$TERRAFORM_MODULE, RUN_MIGRATIONS=$SHOULD_RUN_MIGRATIONS)"
-fi
-
+# DEPLOYMENT_GROUP_NAME is set directly by the CodeDeploy agent for every
+# hook script (see hook_executor.rb's @child_envs / Open3.popen3 call) --
+# no IMDS calls, no AWS API calls, and no dependency on IMDS response
+# formats ever changing. This intentionally replaces an earlier
+# implementation that queried IMDS for an EC2 tag and cross-referenced it
+# against an SSM parameter; that approach was reviewed as unnecessarily
+# complex (multiple curl calls + an AWS API call + sed/jq parsing) for a
+# fact CodeDeploy already hands the script for free.
+case "${DEPLOYMENT_GROUP_NAME:-}" in
+  dev_searchgov_dg | staging_searchgov_dg | prod_searchgov_dg)
+    log "Running database migrations (deployment_group=$DEPLOYMENT_GROUP_NAME)"
+    RAILS_ENV=production bundle exec rails db:migrate
+    ;;
+  *)
+    log "Skipping database migrations (deployment_group=${DEPLOYMENT_GROUP_NAME:-unset})"
+    ;;
+esac
 
 # Atomically promote release
 log "Promoting release to current"

--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -134,30 +134,77 @@ fi
 log "Precompiling assets"
 SECRET_KEY_BASE=placeholder RAILS_ENV=production ./bin/rails assets:precompile
 
-# SRCH-6631: Only run database migrations when this deployment targets the
-# main app CodeDeploy deployment group. All other deployment groups
-# (crawler, cron, spider, api, proxy, letsencrypt, and their -green
+# SRCH-6631: Only run database migrations on the main "app" tier. All other
+# tiers (crawler, cron, spider, api, proxy, letsencrypt, and their -green
 # counterparts) share the same production RDS instance but must NOT run
-# migrations independently, since deploying to those groups could otherwise
+# migrations independently, since deploying to those tiers could otherwise
 # apply schema changes the main app fleet's currently-running release does
 # not expect. See: prod_outage_20260710_shared_db_migration_incident.md for
 # the incident this guards against.
 #
-# DEPLOYMENT_GROUP_NAME is set directly by the CodeDeploy agent for every
-# hook script (see hook_executor.rb's @child_envs / Open3.popen3 call) --
-# no IMDS calls, no AWS API calls, and no dependency on IMDS response
-# formats ever changing. This intentionally replaces an earlier
-# implementation that queried IMDS for an EC2 tag and cross-referenced it
-# against an SSM parameter; that approach was reviewed as unnecessarily
-# complex (multiple curl calls + an AWS API call + sed/jq parsing) for a
-# fact CodeDeploy already hands the script for free.
-case "${DEPLOYMENT_GROUP_NAME:-}" in
-  dev_searchgov_dg | staging_searchgov_dg | prod_searchgov_dg)
-    log "Running database migrations (deployment_group=$DEPLOYMENT_GROUP_NAME)"
+# NOTE: an earlier version of this gate checked $DEPLOYMENT_GROUP_NAME
+# (set directly by the CodeDeploy agent, no IMDS/AWS API calls needed).
+# That approach breaks once app/crawler/cron are consolidated behind a
+# single shared deployment group (dg_searchgov) -- at that point
+# DEPLOYMENT_GROUP_NAME is identical for all three tiers and can no longer
+# distinguish them. This version instead reads the instance's own
+# terraform_module EC2 tag, which is set independently per-instance by
+# Terraform at provisioning time and is unaffected by which deployment
+# group happens to trigger a given deployment.
+#
+# Fail-safe: if the tag cannot be resolved for any reason, migrations are
+# SKIPPED (never default to running them).
+get_terraform_module_tag() {
+  local imds_token instance_id tag_value
+
+  imds_token=$(curl -sS --fail --max-time 2 -X PUT \
+    "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 300" 2>/dev/null || true)
+  if [ -z "$imds_token" ]; then
+    warn "Could not retrieve IMDSv2 token; terraform_module tag unknown"
+    echo "unknown"
+    return
+  fi
+
+  instance_id=$(curl -sS --fail --max-time 2 \
+    -H "X-aws-ec2-metadata-token: $imds_token" \
+    "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null || true)
+
+  if [ -z "$instance_id" ]; then
+    warn "Could not determine instance-id; terraform_module tag unknown"
+    echo "unknown"
+    return
+  fi
+
+  # Deliberately omit --region: AWS CLI v2 automatically resolves the region
+  # via IMDS when no region is set via env var/profile/flag.
+  tag_value=$(aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=terraform_module" \
+    --query "Tags[0].Value" --output text 2>/dev/null || true)
+
+  if [ -z "$tag_value" ] || [ "$tag_value" = "None" ]; then
+    warn "terraform_module tag not found on this instance; defaulting to unknown"
+    echo "unknown"
+    return
+  fi
+
+  echo "$tag_value"
+}
+
+TERRAFORM_MODULE="$(get_terraform_module_tag)"
+
+# Every branch of this case logs the resolved terraform_module value and
+# whether migrations ran, so every pipeline run's log clearly shows which
+# tier it deployed to and whether db:migrate executed -- needed for
+# troubleshooting/verification once app/crawler/cron share one deployment
+# group and are no longer distinguishable by deployment group name alone.
+case "$TERRAFORM_MODULE" in
+  app)
+    log "Running database migrations (terraform_module=$TERRAFORM_MODULE)"
     RAILS_ENV=production bundle exec rails db:migrate
     ;;
   *)
-    log "Skipping database migrations (deployment_group=${DEPLOYMENT_GROUP_NAME:-unset})"
+    log "Skipping database migrations (terraform_module=$TERRAFORM_MODULE) -- not the migration-owning tier"
     ;;
 esac
 

--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -134,9 +134,86 @@ fi
 log "Precompiling assets"
 SECRET_KEY_BASE=placeholder RAILS_ENV=production ./bin/rails assets:precompile
 
-# Run pending migrations (idempotent -- no-op if none pending)
-log "Running database migrations"
-RAILS_ENV=production bundle exec rails db:migrate
+# SRCH-6631: Only run database migrations on the tier(s) designated as the
+# migration owner (RUN_MIGRATIONS SSM parameter, managed in searchgov-tf).
+# This prevents a deploy to crawler/cron/spider/api/proxy/letsencrypt (which
+# share the same production RDS instance as the main app fleet) from running
+# `db:migrate` independently and applying schema changes the main app
+# fleet's currently-running release does not expect. See:
+# prod_outage_20260710_shared_db_migration_incident.md for the incident this
+# guards against.
+#
+# Fail-safe: if the tier tag, RUN_MIGRATIONS value, or jq cannot be resolved
+# for any reason, migrations are SKIPPED (never default to running them).
+get_terraform_module_tag() {
+  local imds_token region instance_id tag_value
+
+  imds_token=$(curl -sS --fail --max-time 2 -X PUT \
+    "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 300" 2>/dev/null || true)
+  if [ -z "$imds_token" ]; then
+    warn "Could not retrieve IMDSv2 token; terraform_module tag unknown"
+    echo "unknown"
+    return
+  fi
+
+  region=$(curl -sS --fail --max-time 2 \
+    -H "X-aws-ec2-metadata-token: $imds_token" \
+    "http://169.254.169.254/latest/dynamic/instance-identity/document" 2>/dev/null \
+    | sed -n 's/.*"region"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')
+  instance_id=$(curl -sS --fail --max-time 2 \
+    -H "X-aws-ec2-metadata-token: $imds_token" \
+    "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null || true)
+
+  if [ -z "$region" ] || [ -z "$instance_id" ]; then
+    warn "Could not determine region/instance-id; terraform_module tag unknown"
+    echo "unknown"
+    return
+  fi
+
+  tag_value=$(aws ec2 describe-tags --region "$region" \
+    --filters "Name=resource-id,Values=$instance_id" "Name=key,Values=terraform_module" \
+    --query "Tags[0].Value" --output text 2>/dev/null || true)
+
+  if [ -z "$tag_value" ] || [ "$tag_value" = "None" ]; then
+    warn "terraform_module tag not found on this instance; defaulting to unknown"
+    echo "unknown"
+    return
+  fi
+
+  echo "$tag_value"
+}
+
+# Extract only the RUN_MIGRATIONS line from the shared .env file. Deliberately
+# avoids sourcing .env wholesale in bash, since it may contain multiline
+# PEM/certificate-style values that are unsafe to source directly.
+read_run_migrations_json() {
+  local env_file="$SHARED_DIR/.env"
+  if [ ! -f "$env_file" ]; then
+    echo "{}"
+    return
+  fi
+  grep -m1 '^RUN_MIGRATIONS=' "$env_file" | sed 's/^RUN_MIGRATIONS=//' || echo "{}"
+}
+
+TERRAFORM_MODULE="$(get_terraform_module_tag)"
+RUN_MIGRATIONS_JSON="$(read_run_migrations_json)"
+SHOULD_RUN_MIGRATIONS="false"
+
+if [ -n "$RUN_MIGRATIONS_JSON" ] && command -v jq >/dev/null 2>&1; then
+  SHOULD_RUN_MIGRATIONS="$(echo "$RUN_MIGRATIONS_JSON" | jq -r --arg tier "$TERRAFORM_MODULE" '.[$tier] // "false"' 2>/dev/null || echo "false")"
+fi
+
+log "terraform_module tag: $TERRAFORM_MODULE"
+log "RUN_MIGRATIONS policy value for this tier: $SHOULD_RUN_MIGRATIONS"
+
+if [ "$SHOULD_RUN_MIGRATIONS" = "true" ]; then
+  log "Running database migrations (tier=$TERRAFORM_MODULE, RUN_MIGRATIONS=true)"
+  RAILS_ENV=production bundle exec rails db:migrate
+else
+  log "Skipping database migrations (tier=$TERRAFORM_MODULE, RUN_MIGRATIONS=$SHOULD_RUN_MIGRATIONS)"
+fi
+
 
 # Atomically promote release
 log "Promoting release to current"

--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -199,7 +199,7 @@ TERRAFORM_MODULE="$(get_terraform_module_tag)"
 # troubleshooting/verification once app/crawler/cron share one deployment
 # group and are no longer distinguishable by deployment group name alone.
 case "$TERRAFORM_MODULE" in
-  app | app-green)
+  app)
     log "Running database migrations (terraform_module=$TERRAFORM_MODULE)"
     RAILS_ENV=production bundle exec rails db:migrate
     ;;
@@ -210,7 +210,6 @@ esac
 
 # Atomically promote release
 log "Promoting release to current"
-
 TMP_LINK="${APP_ROOT}/.current_tmp"
 ln -sfn "$RELEASE_DIR" "$TMP_LINK"
 mv -Tf "$TMP_LINK" "$CURRENT_LINK"


### PR DESCRIPTION
## Summary
Extends the SRCH-6631 migration-safety gate to be environment-aware, using a single combined EC2 `describe-tags` lookup (`terraform_module`, `Fleet`, `environment`) instead of `terraform_module` alone.

## Problem
Exact-matching `terraform_module=app` alone is correct for dev and production today (both have a plain `app` instance with no `Fleet` tag, no coexisting green fleet), but incorrect for staging, which is mid Ubuntu-24.04 green-fleet upgrade — staging's app tier currently only exists as `app-green` (`Fleet=green`). The old exact-match logic meant staging never auto-ran migrations, forcing manual `db:migrate` on every staging deploy.

## Fix
Case-match on `$ENVIRONMENT:$TERRAFORM_MODULE:$FLEET` together, covering only the 3 real, confirmed-live combinations:
- `dev:app:` (no Fleet tag)
- `staging:app-green:green`
- `production:app:` (no Fleet tag)

No other combination (including hypothetical future coexistence scenarios, e.g. production's own eventual `app-green`) is matched — those will be designed later based on real tag state at that time, per `app_fixes_tracking.md` item #10.

Tag lookup uses a single `aws ec2 describe-tags --output json` call (same API cost as before) parsed with `jq` (confirmed already installed on all app-tier instances in dev/staging/prod) rather than delimiter-split text, avoiding any reliance on whitespace/tab characters to distinguish an absent tag from a parsing artifact.

Fail-safe unchanged: any unresolved tag defaults to `unknown`, which always skips migrations.

## Verification
- `bash -n` syntax check passed
- **Live-tested via SSM on real instances**, running as the actual `search` user:
  - staging `app-green` (`Fleet=green`) → now runs migrations (the fix)
  - dev `app` (no Fleet tag) → still runs migrations (unchanged)
  - production `app` (no Fleet tag) → still runs migrations (unchanged)

## Related
- Staging-targeted PR: #2088 (same commit, cherry-picked)
- Design/decision history: `app_fixes_tracking.md` item #10

## Note
Branch renamed from `feature/SRCH-6631-db-migration-flag-azhar` to `feature/SRCH-6631-db-migration-flag-azhar-main` for naming consistency with the `-staging` companion branch. No open PR previously referenced the old name.