### PR TITLE
SRCH-6631: Gate release/service hooks against legacy Capistrano tiers

### DIFF
--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=lib/tier_gate.sh
+source "$SCRIPT_DIR/lib/tier_gate.sh"
+
 log() {
   echo "[CODEDEPLOY][AFTER_INSTALL] $*"
 }
@@ -16,6 +20,21 @@ SHARED_DIR="${APP_ROOT}/shared"
 CURRENT_LINK="${APP_ROOT}/current"
 TIMESTAMP="$(date +%Y%m%d%H%M%S)"
 RELEASE_DIR="${RELEASES_DIR}/${TIMESTAMP}"
+
+log "Starting AfterInstall hook"
+
+# Resolve terraform_module/Fleet/environment tags once, up front, before any
+# filesystem changes. See cicd-scripts/lib/tier_gate.sh for why: production's
+# "app"/"cron" tiers are still deployed via Capistrano today, and running
+# this hook's release-management logic there would race with it.
+resolve_deployment_tags
+if is_legacy_capistrano_tier; then
+  log "Skipping AfterInstall release management (environment=$ENVIRONMENT, terraform_module=$TERRAFORM_MODULE) -- legacy Capistrano-managed tier"
+  log "AfterInstall hook completed (no-op)"
+  exit 0
+fi
+
+log "Release dir: $RELEASE_DIR"
 
 # ERR trap to clean up failed releases
 cleanup_on_error() {
@@ -33,8 +52,6 @@ cleanup_on_error() {
 
 trap cleanup_on_error ERR
 
-log "Starting AfterInstall hook"
-log "Release dir: $RELEASE_DIR"
 
 # Log current symlink state
 if [ -L "$CURRENT_LINK" ]; then
@@ -168,68 +185,13 @@ SECRET_KEY_BASE=placeholder RAILS_ENV=production ./bin/rails assets:precompile
 #
 # Fail-safe: if any tag cannot be resolved for any reason, migrations are
 # SKIPPED (never default to running them).
-get_instance_tags() {
-  local imds_token instance_id
-
-  imds_token=$(curl -sS --fail --max-time 2 -X PUT \
-    "http://169.254.169.254/latest/api/token" \
-    -H "X-aws-ec2-metadata-token-ttl-seconds: 300" 2>/dev/null || true)
-  if [ -z "$imds_token" ]; then
-    warn "Could not retrieve IMDSv2 token; instance tags unknown"
-    return
-  fi
-
-  instance_id=$(curl -sS --fail --max-time 2 \
-    -H "X-aws-ec2-metadata-token: $imds_token" \
-    "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null || true)
-
-  if [ -z "$instance_id" ]; then
-    warn "Could not determine instance-id; instance tags unknown"
-    return
-  fi
-
-  # Single describe-tags call for all three keys at once -- same AWS API
-  # call cost as the previous single-tag lookup. Deliberately omit --region:
-  # AWS CLI v2 automatically resolves the region via IMDS when no region is
-  # set via env var/profile/flag. Requested as JSON and parsed with jq (both
-  # confirmed present on all app-tier instances in dev/staging/prod) rather
-  # than tab/newline-delimited text -- this avoids relying on whitespace
-  # characters as field separators and lets jq return each tag's actual
-  # value, or a clean explicit empty result if the tag key is absent, with
-  # no special-casing needed to tell "absent" apart from a delimiter quirk.
-  aws ec2 describe-tags \
-    --filters "Name=resource-id,Values=$instance_id" \
-      "Name=key,Values=terraform_module,Fleet,environment" \
-    --output json 2>/dev/null || true
-}
-
-TAGS_JSON="$(get_instance_tags)"
-
-lookup_tag() {
-  local key="$1"
-  if [ -z "$TAGS_JSON" ]; then
-    echo ""
-    return
-  fi
-  echo "$TAGS_JSON" | jq -r --arg key "$key" \
-    '.Tags[] | select(.Key == $key) | .Value' 2>/dev/null || true
-}
-
-TERRAFORM_MODULE="$(lookup_tag terraform_module)"
-FLEET="$(lookup_tag Fleet)"
-ENVIRONMENT="$(lookup_tag environment)"
-
-[ -z "$TERRAFORM_MODULE" ] && TERRAFORM_MODULE="unknown"
-[ -z "$ENVIRONMENT" ] && ENVIRONMENT="unknown"
-
-if [ "$TERRAFORM_MODULE" = "unknown" ]; then
-  warn "terraform_module tag not found on this instance; defaulting to unknown"
-fi
-if [ "$ENVIRONMENT" = "unknown" ]; then
-  warn "environment tag not found on this instance; defaulting to unknown"
-fi
+#
+# TERRAFORM_MODULE/FLEET/ENVIRONMENT were already resolved once, above, by
+# resolve_deployment_tags (see cicd-scripts/lib/tier_gate.sh) -- reused here
+# rather than making a second describe-tags call for the same instance.
 
 # Every branch of this case logs the resolved tag values and whether
+
 # migrations ran, so every pipeline run's log clearly shows which
 # environment/tier/fleet it deployed to and whether db:migrate executed --
 # needed for troubleshooting/verification since app/crawler/cron share one

--- a/cicd-scripts/application_start.sh
+++ b/cicd-scripts/application_start.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=lib/tier_gate.sh
+source "$SCRIPT_DIR/lib/tier_gate.sh"
+
 if [ -f /home/search/.config/searchgov-codedeploy.env ]; then
   set -a
   # shellcheck disable=SC1090
@@ -11,6 +15,7 @@ fi
 log() {
   echo "[CODEDEPLOY][APPLICATION_START] $*"
 }
+
 
 warn() {
   echo "[CODEDEPLOY][APPLICATION_START][WARN] $*"
@@ -266,7 +271,19 @@ APP_HEALTHCHECK_URL="${APP_HEALTHCHECK_URL:-http://127.0.0.1:3000/}"
 log "Starting ApplicationStart hook"
 log "Host: $(hostname) | User: $(whoami)"
 
+# See cicd-scripts/lib/tier_gate.sh: production's "app"/"cron" tiers are
+# still Capistrano-managed today. Restarting/starting services here using
+# this script's assumptions (systemd unit names, fallback Puma start, etc.)
+# is not validated against that deployment mechanism and must not run there.
+resolve_deployment_tags
+if is_legacy_capistrano_tier; then
+  log "Skipping ApplicationStart service management (environment=$ENVIRONMENT, terraform_module=$TERRAFORM_MODULE) -- legacy Capistrano-managed tier"
+  log "ApplicationStart hook completed (no-op)"
+  exit 0
+fi
+
 restart_or_start_service "$PUMA_SERVICE"
+
 restart_or_start_service "$RESQUE_WORKER_SERVICE"
 restart_or_start_service "$RESQUE_SCHEDULER_SERVICE"
 

--- a/cicd-scripts/lib/tier_gate.sh
+++ b/cicd-scripts/lib/tier_gate.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Shared helper sourced by CodeDeploy lifecycle hook scripts.
+#
+# Determines whether the current instance is a legacy, Capistrano-managed
+# tier that must NOT run the CodeDeploy-hook-driven release/service
+# management introduced by the Ubuntu 24.04 upgrade (PR #1990 and everything
+# built on top of it since, including SRCH-6631's db:migrate gate).
+#
+# Background: `production`'s "app" and "cron" terraform_module tiers have no
+# Fleet tag (they have not been cut over to their "-green" counterparts) and
+# are still deployed today via Capistrano's `cap $SEARCH_ENV deploy`, run as
+# a separate CodeBuild stage (see buildspec_searchgov.yml). CodeDeploy's full
+# lifecycle already runs end-to-end against these hosts today (confirmed
+# live via `aws deploy get-deployment-instance`, 2026-07-15), but only
+# BeforeInstall's fetch_env_vars.sh and AfterInstall's asset-copy step are
+# currently meaningful there. If the newer release-management hooks
+# (creating releases/<timestamp>, promoting `current`, running
+# `bundle install`, running db:migrate) also ran unconditionally on these
+# hosts, they would race with Capistrano's independent deploy on the same
+# release/current state -- e.g. migrations running twice, or two competing
+# release trees fighting over the `current` symlink.
+#
+# This helper isolates exactly that legacy-tier case so all three affected
+# hook scripts (after_install.sh, application_start.sh, validate_service.sh)
+# use one consistent, explicit definition rather than relying on incidental
+# no-op behavior (e.g. unit-name mismatches) to stay safe on those hosts.
+#
+# Fail-safe: if instance tags cannot be resolved for any reason, this treats
+# the host as NOT a legacy tier (i.e. hook logic proceeds). Silently skipping
+# hook logic on a host we can't identify is a bigger risk than proceeding,
+# since dev/staging/other green hosts must not be accidentally skipped just
+# because of a transient IMDS/AWS CLI hiccup.
+#
+# NOTE: when production's "app"/"cron" tiers are cut over to their green
+# counterparts, the case statement in is_legacy_capistrano_tier() below must
+# be updated (or retired) to match the new state, the same way SRCH-6631's
+# db:migrate gate documents a required post-cutover follow-up in
+# app_fixes_tracking.md, section 10.
+
+_tier_gate_log() {
+  echo "[CODEDEPLOY][TIER_GATE] $*"
+}
+
+_tier_gate_warn() {
+  echo "[CODEDEPLOY][TIER_GATE][WARN] $*"
+}
+
+# Single describe-tags call for terraform_module, Fleet, and environment.
+# Deliberately omits --region: AWS CLI v2 resolves the region via IMDS
+# automatically when no region is set via env var/profile/flag.
+get_instance_tags() {
+  local imds_token instance_id
+
+  imds_token=$(curl -sS --fail --max-time 2 -X PUT \
+    "http://169.254.169.254/latest/api/token" \
+    -H "X-aws-ec2-metadata-token-ttl-seconds: 300" 2>/dev/null || true)
+  if [ -z "$imds_token" ]; then
+    _tier_gate_warn "Could not retrieve IMDSv2 token; instance tags unknown"
+    return
+  fi
+
+  instance_id=$(curl -sS --fail --max-time 2 \
+    -H "X-aws-ec2-metadata-token: $imds_token" \
+    "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null || true)
+
+  if [ -z "$instance_id" ]; then
+    _tier_gate_warn "Could not determine instance-id; instance tags unknown"
+    return
+  fi
+
+  aws ec2 describe-tags \
+    --filters "Name=resource-id,Values=$instance_id" \
+      "Name=key,Values=terraform_module,Fleet,environment" \
+    --output json 2>/dev/null || true
+}
+
+lookup_tag() {
+  local tags_json="$1"
+  local key="$2"
+  if [ -z "$tags_json" ]; then
+    echo ""
+    return
+  fi
+  echo "$tags_json" | jq -r --arg key "$key" \
+    '.Tags[] | select(.Key == $key) | .Value' 2>/dev/null || true
+}
+
+# Resolves and exports TERRAFORM_MODULE, FLEET, ENVIRONMENT for the current
+# instance. Callers should invoke this once near the top of their script and
+# reuse the resulting variables rather than re-fetching tags later (e.g. for
+# a db:migrate gate) -- one describe-tags call per deployment is sufficient.
+resolve_deployment_tags() {
+  local tags_json
+  tags_json="$(get_instance_tags)"
+
+  TERRAFORM_MODULE="$(lookup_tag "$tags_json" terraform_module)"
+  FLEET="$(lookup_tag "$tags_json" Fleet)"
+  ENVIRONMENT="$(lookup_tag "$tags_json" environment)"
+
+  [ -z "$TERRAFORM_MODULE" ] && TERRAFORM_MODULE="unknown"
+  [ -z "$ENVIRONMENT" ] && ENVIRONMENT="unknown"
+
+  if [ "$TERRAFORM_MODULE" = "unknown" ]; then
+    _tier_gate_warn "terraform_module tag not found on this instance; defaulting to unknown"
+  fi
+  if [ "$ENVIRONMENT" = "unknown" ]; then
+    _tier_gate_warn "environment tag not found on this instance; defaulting to unknown"
+  fi
+
+  export TERRAFORM_MODULE FLEET ENVIRONMENT
+}
+
+# Returns success (0) if this instance is a legacy, Capistrano-managed tier
+# that the new release-management/service hooks must not act on.
+# Requires resolve_deployment_tags to have been called first.
+is_legacy_capistrano_tier() {
+  case "${ENVIRONMENT:-unknown}:${TERRAFORM_MODULE:-unknown}" in
+    production:app|production:cron)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}

--- a/cicd-scripts/validate_service.sh
+++ b/cicd-scripts/validate_service.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=lib/tier_gate.sh
+source "$SCRIPT_DIR/lib/tier_gate.sh"
+
 if [ -f /home/search/.config/searchgov-codedeploy.env ]; then
   set -a
   # shellcheck disable=SC1090
@@ -11,6 +15,7 @@ fi
 log() {
   echo "[CODEDEPLOY][VALIDATE_SERVICE] $*"
 }
+
 
 warn() {
   echo "[CODEDEPLOY][VALIDATE_SERVICE][WARN] $*"
@@ -213,7 +218,19 @@ SEARCHGOV_ROOT="${SEARCHGOV_ROOT:-/home/search/searchgov}"
 log "Starting ValidateService hook"
 log "Host: $(hostname) | User: $(whoami)"
 
+# See cicd-scripts/lib/tier_gate.sh: production's "app"/"cron" tiers are
+# still Capistrano-managed today. This script's systemd/service-based
+# validation assumptions are not validated against that deployment
+# mechanism and must not run there.
+resolve_deployment_tags
+if is_legacy_capistrano_tier; then
+  log "Skipping ValidateService checks (environment=$ENVIRONMENT, terraform_module=$TERRAFORM_MODULE) -- legacy Capistrano-managed tier"
+  log "ValidateService hook completed (no-op)"
+  exit 0
+fi
+
 if [ "${REQUIRE_RESQUE_SERVICES:-false}" = "true" ]; then
+
   assert_service_active_required "$RESQUE_WORKER_SERVICE"
   assert_worker_instances_active
   assert_service_active_required "$RESQUE_SCHEDULER_SERVICE"


### PR DESCRIPTION
## Problem

Companion PR to #2090 (production) and #2092 (main). Lands the same `tier_gate.sh` gate on `staging` so all three branches converge on identical hook logic.

Production's `app`/`cron` tiers (`terraform_module=app`/`cron`, no `Fleet` tag) are still deployed via Capistrano's `cap deploy`. The CodeDeploy release-management hooks (`after_install.sh`, `application_start.sh`, `validate_service.sh`) must not act on those hosts, since doing so unconditionally would race with Capistrano over release/current/migrate state.

## Changes

Cherry-picked from `b341df203` (search-gov `feature/SRCH-6631-db-migration-flag-azhar-prod`, already in PR #2090):

- Adds `cicd-scripts/lib/tier_gate.sh` — shared helper resolving `environment`/`terraform_module`/`Fleet` tags once and exposing `is_legacy_capistrano_tier()`.
- Wires the gate into `after_install.sh`, `application_start.sh`, `validate_service.sh` — each exits early (no-op) when `environment:terraform_module` is `production:app` or `production:cron`.

## Impact on staging

**None.** `is_legacy_capistrano_tier()` only matches `environment=production`; staging (`environment=staging`) never matches, so the gate is inert here — verified via the same isolated test cases used in #2090 (7 tag combinations, all pass, including `staging:app-green` proceeding unaffected). This PR exercises the sourcing/tag-resolution plumbing on staging's next deploy without ever hitting the skip branch.

## Verified

- `bash -n` syntax check passed on all 4 files.
- Clean cherry-pick onto `staging`, no conflicts.

## Related

- #2090 — same gate, targeting `production`.
- #2092 — same gate, targeting `main`.