### PR TITLE
SRCH-6482 Add a notes field to the affiliates table

### DIFF
--- a/app/controllers/admin/affiliates_controller.rb
+++ b/app/controllers/admin/affiliates_controller.rb
@@ -99,6 +99,7 @@ class Admin::AffiliatesController < Admin::AdminController
       jobs_enabled
       locale
       name
+      notes
       raw_log_access_enabled
       search_engine
       website
@@ -172,6 +173,8 @@ class Admin::AffiliatesController < Admin::AdminController
     config.columns[:locale].options = { options: Language.order(:name).pluck(:code) }
 
     config.columns[:mobile_logo_url].label = 'Logo URL'
+
+    config.columns[:notes].form_ui = :textarea
 
     config.columns[:theme].form_ui = :select
     config.columns[:theme].options = { include_blank: '- select -',

--- a/db/migrate/20260717113000_add_notes_to_affiliates.rb
+++ b/db/migrate/20260717113000_add_notes_to_affiliates.rb
@@ -1,0 +1,5 @@
+class AddNotesToAffiliates < ActiveRecord::Migration[7.1]
+  def change
+    add_column :affiliates, :notes, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2026_05_29_160056) do
+ActiveRecord::Schema[7.1].define(version: 2026_07_17_113000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_unicode_ci", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -100,6 +100,7 @@ ActiveRecord::Schema[7.1].define(version: 2026_05_29_160056) do
     t.boolean "looking_for_government_services", default: true, null: false
     t.boolean "show_search_filter_settings", default: false, null: false
     t.boolean "gets_results_from_all_domains", default: false, null: false
+    t.text "notes"
     t.index ["name"], name: "index_affiliates_on_name", unique: true
   end
 

--- a/spec/controllers/admin/affiliates_controller_spec.rb
+++ b/spec/controllers/admin/affiliates_controller_spec.rb
@@ -54,6 +54,26 @@ describe Admin::AffiliatesController do
     end
   end
 
+  describe '#show' do
+    context 'when logged in as an affiliate admin' do
+      render_views
+      let(:affiliate) { affiliates('basic_affiliate') }
+
+      before do
+        activate_authlogic
+        UserSession.create(users('affiliate_admin'))
+        affiliate.update!(notes: 'Visible note for review')
+        get :show, params: { id: affiliate.id }
+      end
+
+      it { is_expected.to respond_with :success }
+
+      it 'displays the notes value for review' do
+        expect(response.body).to include('Visible note for review')
+      end
+    end
+  end
+
   describe '#update' do
     let(:affiliate) { affiliates(:basic_affiliate) }
 
@@ -74,7 +94,7 @@ describe Admin::AffiliatesController do
       describe 'Settings subgroup' do
         let(:settings_columns) do
           %i[ active agency display_name domain_control_validation_code
-              fetch_concurrency ga_web_property_id locale name
+              fetch_concurrency ga_web_property_id locale name notes
               search_engine website affiliate_feature_addition excluded_domains ]
         end
 
@@ -117,6 +137,25 @@ describe Admin::AffiliatesController do
         it 'contains the specified columns' do
           expect(update_columns.find { |c| c.label == 'Analytics-Tracking Code' }.to_a).to match_array(analytics_columns)
         end
+      end
+
+      describe 'notes column' do
+        it 'renders as a textarea' do
+          expect(config.columns[:notes].form_ui).to eq(:textarea)
+        end
+      end
+    end
+
+    context 'when submitting the update form' do
+      it 'persists the notes value' do
+        put :update, params: { id: affiliate.id, record: { notes: 'Low-traffic site; search box in footer.' } }
+        expect(affiliate.reload.notes).to eq('Low-traffic site; search box in footer.')
+      end
+
+      it 'clears the notes value when submitted blank' do
+        affiliate.update!(notes: 'Existing note')
+        put :update, params: { id: affiliate.id, record: { notes: '' } }
+        expect(affiliate.reload.notes).to be_blank
       end
     end
   end
@@ -165,6 +204,7 @@ describe Admin::AffiliatesController do
             looking_for_government_services
             mobile_logo_url
             name
+            notes
             raw_log_access_enabled
             recent_user_activity
             related_sites_dropdown_label

--- a/spec/models/affiliate_spec.rb
+++ b/spec/models/affiliate_spec.rb
@@ -50,11 +50,38 @@ describe Affiliate do
         is_expected.to have_db_column(:use_extended_header).of_type(:boolean).
           with_options(default: true, null: false)
       end
+
+      it { is_expected.to have_db_column(:notes).of_type(:text) }
     end
 
     describe 'Paperclip attachments' do
       it { is_expected.to have_attached_file :mobile_logo }
       it { is_expected.to have_attached_file :header_tagline_logo }
+    end
+  end
+
+  describe 'notes' do
+    it 'is valid without notes' do
+      affiliate = described_class.new(valid_create_attributes)
+      expect(affiliate).to be_valid
+      expect(affiliate.notes).to be_nil
+    end
+
+    it 'persists a notes value' do
+      affiliate = described_class.create!(valid_create_attributes.merge(notes: 'Uses Bing for internal reasons.'))
+      expect(described_class.find(affiliate.id).notes).to eq('Uses Bing for internal reasons.')
+    end
+
+    it 'can be updated after creation' do
+      affiliate = described_class.create!(valid_create_attributes)
+      affiliate.update!(notes: 'Search box lives on the low-traffic microsite footer.')
+      expect(affiliate.reload.notes).to eq('Search box lives on the low-traffic microsite footer.')
+    end
+
+    it 'stores long multi-line text with special characters' do
+      long_notes = (["Line with \"quotes\", commas, and symbols: <>&"] * 500).join("\n")
+      affiliate = described_class.create!(valid_create_attributes.merge(notes: long_notes))
+      expect(described_class.find(affiliate.id).notes).to eq(long_notes)
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds an open-ended `notes` text column to the `affiliates` table (migration + schema).
- Exposes the field in the Super Admin (ActiveScaffold) "Sites" interface so Super Admins can **add/edit** it (Settings subgroup, rendered as a textarea), **review** it (site show page), and **export** it (included in the affiliates CSV export).
- No end-user/SERP exposure; Super Admin only. No validation (field is intentionally open-ended and optional).

### Implementation notes
- `db/migrate/20260717113000_add_notes_to_affiliates.rb`: `add_column :affiliates, :notes, :text`.
- `app/controllers/admin/affiliates_controller.rb`: `:notes` added to `update_columns` (Settings subgroup) and `config.columns[:notes].form_ui = :textarea`. Review (show) and export inclusion are automatic since `notes` is a non-hidden attribute column that flows into `all_columns`.

### Tests (happy / sad / edge)
- Model (`spec/models/affiliate_spec.rb`): column is `text`; valid without notes; persists a value; updatable; stores long multi-line text with quotes/commas/`<>&`.
- Controller (`spec/controllers/admin/affiliates_controller_spec.rb`): `notes` in Settings subgroup and export columns; renders as a textarea; show page displays the notes value (review); update persists notes and clears it when submitted blank.

### Checklist
#### Functionality Checks
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch. (Branch is based directly on current `main`.)
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [x] PR title is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [x] Automated checks pass. (`spec/models/affiliate_spec.rb` and `spec/controllers/admin/affiliates_controller_spec.rb`: 245 examples, 0 failures locally.)

#### Process Checks
- [x] You have specified at least one "Reviewer".