### PR TITLE
Fix upload_assets_to_s3.sh gating gap and tier_gate.sh fail-open risk

### DIFF
--- a/cicd-scripts/lib/tier_gate.sh
+++ b/cicd-scripts/lib/tier_gate.sh
@@ -25,11 +25,24 @@
 # use one consistent, explicit definition rather than relying on incidental
 # no-op behavior (e.g. unit-name mismatches) to stay safe on those hosts.
 #
-# Fail-safe: if instance tags cannot be resolved for any reason, this treats
-# the host as NOT a legacy tier (i.e. hook logic proceeds). Silently skipping
-# hook logic on a host we can't identify is a bigger risk than proceeding,
-# since dev/staging/other green hosts must not be accidentally skipped just
-# because of a transient IMDS/AWS CLI hiccup.
+# Fail-safe: if instance tags cannot be resolved after retries, this ABORTS
+# the deployment on that instance (hard exit 1) rather than guessing either
+# direction. An earlier version of this fail-safe treated unresolved tags as
+# "not a legacy tier" (i.e. let hook logic proceed), reasoning that silently
+# skipping on a healthy green host was the bigger risk. On reflection that
+# is backwards: proceeding on an actual legacy Capistrano host risks two
+# independent release-management systems racing over the same releases/
+# current state -- creating releases, flipping symlinks, restarting
+# services -- which is exactly the corruption scenario this gate exists to
+# prevent (see Issue 3 in the crawler-cutover appendix). Skipping on a
+# healthy green host, by contrast, is a self-contained, visible failure:
+# CodeDeploy reports it and the next deploy attempt starts clean. Aborting
+# outright is safer than either silent guess, and turns an ambiguous tag
+# resolution into a loud, troubleshootable failure instead of a silent
+# wrong answer in either direction. get_instance_tags() retries transient
+# IMDS/DescribeTags hiccups before giving up, so this should only trigger
+# on a persistent problem (e.g. a missing ec2:DescribeTags permission, or
+# an actual AWS API outage) worth paging on, not routine flakiness.
 #
 # NOTE: when production's "app"/"cron" tiers are cut over to their green
 # counterparts, the case statement in is_legacy_capistrano_tier() below must
@@ -42,20 +55,26 @@ _tier_gate_log() {
 }
 
 _tier_gate_warn() {
-  echo "[CODEDEPLOY][TIER_GATE][WARN] $*"
+  echo "[CODEDEPLOY][TIER_GATE][WARN] $*" >&2
 }
 
-# Single describe-tags call for terraform_module, Fleet, and environment.
-# Deliberately omits --region: AWS CLI v2 resolves the region via IMDS
-# automatically when no region is set via env var/profile/flag.
-get_instance_tags() {
+_tier_gate_error() {
+  echo "[CODEDEPLOY][TIER_GATE][ERROR] $*" >&2
+}
+
+
+# Single attempt: resolve IMDSv2 token, instance-id, then describe-tags for
+# terraform_module, Fleet, and environment. Deliberately omits --region on
+# the describe-tags call: AWS CLI v2 resolves the region via IMDS
+# automatically when no region is set via env var/profile/flag. Returns
+# empty output (not an error) on any failure -- retries live in the caller.
+_get_instance_tags_once() {
   local imds_token instance_id
 
   imds_token=$(curl -sS --fail --max-time 2 -X PUT \
     "http://169.254.169.254/latest/api/token" \
     -H "X-aws-ec2-metadata-token-ttl-seconds: 300" 2>/dev/null || true)
   if [ -z "$imds_token" ]; then
-    _tier_gate_warn "Could not retrieve IMDSv2 token; instance tags unknown"
     return
   fi
 
@@ -64,7 +83,6 @@ get_instance_tags() {
     "http://169.254.169.254/latest/meta-data/instance-id" 2>/dev/null || true)
 
   if [ -z "$instance_id" ]; then
-    _tier_gate_warn "Could not determine instance-id; instance tags unknown"
     return
   fi
 
@@ -72,6 +90,31 @@ get_instance_tags() {
     --filters "Name=resource-id,Values=$instance_id" \
       "Name=key,Values=terraform_module,Fleet,environment" \
     --output json 2>/dev/null || true
+}
+
+# Retries _get_instance_tags_once up to TIER_GATE_TAG_RETRIES times (default
+# 3), with TIER_GATE_TAG_RETRY_DELAY seconds (default 2) between attempts,
+# to absorb a transient IMDS/DescribeTags hiccup rather than treating a
+# single failed call as a persistent problem. Returns empty output if every
+# attempt fails.
+get_instance_tags() {
+  local retries="${TIER_GATE_TAG_RETRIES:-3}"
+  local delay="${TIER_GATE_TAG_RETRY_DELAY:-2}"
+  local attempt=1
+  local tags_json=""
+
+  while [ "$attempt" -le "$retries" ]; do
+    tags_json="$(_get_instance_tags_once)"
+    if [ -n "$tags_json" ]; then
+      echo "$tags_json"
+      return
+    fi
+    _tier_gate_warn "Could not resolve instance tags (attempt ${attempt}/${retries})"
+    if [ "$attempt" -lt "$retries" ]; then
+      sleep "$delay"
+    fi
+    attempt=$((attempt + 1))
+  done
 }
 
 lookup_tag() {
@@ -89,6 +132,14 @@ lookup_tag() {
 # instance. Callers should invoke this once near the top of their script and
 # reuse the resulting variables rather than re-fetching tags later (e.g. for
 # a db:migrate gate) -- one describe-tags call per deployment is sufficient.
+#
+# Hard-fails (exit 1) if terraform_module or environment cannot be resolved
+# after get_instance_tags()'s retries. This is deliberate: proceeding with
+# "unknown" tags means guessing whether this hook logic is safe to run, and
+# neither possible guess is safe -- see the fail-safe rationale at the top
+# of this file. Callers must have `set -e` (all current hook scripts do)
+# for this exit to actually stop the script; this function does not rely on
+# that alone and exits explicitly regardless.
 resolve_deployment_tags() {
   local tags_json
   tags_json="$(get_instance_tags)"
@@ -100,11 +151,11 @@ resolve_deployment_tags() {
   [ -z "$TERRAFORM_MODULE" ] && TERRAFORM_MODULE="unknown"
   [ -z "$ENVIRONMENT" ] && ENVIRONMENT="unknown"
 
-  if [ "$TERRAFORM_MODULE" = "unknown" ]; then
-    _tier_gate_warn "terraform_module tag not found on this instance; defaulting to unknown"
-  fi
-  if [ "$ENVIRONMENT" = "unknown" ]; then
-    _tier_gate_warn "environment tag not found on this instance; defaulting to unknown"
+  if [ "$TERRAFORM_MODULE" = "unknown" ] || [ "$ENVIRONMENT" = "unknown" ]; then
+    _tier_gate_error "Could not resolve terraform_module/environment tags after retries (terraform_module=$TERRAFORM_MODULE, environment=$ENVIRONMENT)."
+    _tier_gate_error "Aborting: cannot safely determine whether this instance is a legacy Capistrano-managed tier."
+    _tier_gate_error "Check IMDSv2 connectivity and the instance profile's ec2:DescribeTags permission, then retry the deployment."
+    exit 1
   fi
 
   export TERRAFORM_MODULE FLEET ENVIRONMENT

--- a/cicd-scripts/upload_assets_to_s3.sh
+++ b/cicd-scripts/upload_assets_to_s3.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=lib/tier_gate.sh
+source "$SCRIPT_DIR/lib/tier_gate.sh"
+
 log() {
   echo "[CODEDEPLOY][UPLOAD_ASSETS] $*"
 }
@@ -9,8 +13,23 @@ error() {
   echo "[CODEDEPLOY][UPLOAD_ASSETS][ERROR] $*" >&2
 }
 
+# Legacy Capistrano-managed tiers (production app/cron) have never run this
+# hook -- it did not exist in prod's pre-reconciliation appspec.yml. Assets
+# on those hosts currently reach S3 via whichever CodeDeploy-hook-driven
+# tier last deployed (today, crawler-green), not via a Capistrano task.
+# Running this hook unconditionally on all legacy app instances would add a
+# new, redundant `aws s3 sync --delete` from every instance on every deploy.
+# See cicd-scripts/lib/tier_gate.sh for the full rationale.
+resolve_deployment_tags
+if is_legacy_capistrano_tier; then
+  log "Skipping asset upload (environment=$ENVIRONMENT, terraform_module=$TERRAFORM_MODULE) -- legacy Capistrano-managed tier"
+  log "Asset upload hook completed (no-op)"
+  exit 0
+fi
+
 # Configuration
 SEARCHGOV_ROOT="${SEARCHGOV_ROOT:-/home/search/searchgov}"
+
 CURRENT_PATH="${SEARCHGOV_ROOT}/current"
 ASSETS_DIR="${CURRENT_PATH}/public"
 SHARED_DIR="${SEARCHGOV_ROOT}/shared"


### PR DESCRIPTION
## Background

Two bug fixes originally found and fixed while reviewing PR #2090 (production's CodeDeploy hook reconciliation), cherry-picked here since both bugs exist identically on `main` — this repo's `cicd-scripts/lib/tier_gate.sh` and `cicd-scripts/upload_assets_to_s3.sh` are byte-identical to production's pre-fix versions.

## Changes

### 1. Gate `upload_assets_to_s3.sh` behind `tier_gate.sh`

This hook was not sourcing `tier_gate.sh`, so it ran unconditionally on every instance — including any legacy Capistrano-managed tier that never had this hook before the Ubuntu 24.04 CodeDeploy migration. Confirmed live: prod app assets currently reach S3 via whichever CodeDeploy-hook-driven tier last deployed, not via any Capistrano task — no S3 sync exists anywhere in `config/deploy.rb`/`Capfile`. Running this hook ungated on a legacy tier would add a new, redundant `aws s3 sync --delete` per instance on every deploy that doesn't happen today.

Gated identically to `after_install.sh`/`application_start.sh`/`validate_service.sh`.

### 2. `tier_gate.sh`: fail closed with retry, instead of fail-open

The previous fail-safe — treating unresolved instance tags as "not a legacy tier" so hook logic proceeds — has an asymmetric risk: proceeding on an actual legacy Capistrano host risks two independent release-management systems racing over the same `releases/`/`current` state (real corruption, the exact scenario this gate exists to prevent). Skipping on a healthy host is a self-contained, visible failure that resolves cleanly on the next deploy attempt.

Changed to fail loudly instead of guessing either direction:
- `get_instance_tags()` now retries the IMDS/describe-tags lookup up to 3 times (2s apart) to absorb a genuinely transient hiccup.
- `resolve_deployment_tags()` now hard-exits (`exit 1`) if tags still can't be resolved after retries, rather than silently defaulting to "unknown" and letting callers proceed.

**Bug caught while writing tests for this change:** `_tier_gate_warn` was writing to stdout, and `get_instance_tags()` is always invoked via command substitution — so warning lines were being captured as part of the JSON return value on any retry, corrupting tag resolution on the very hiccup-recovery path this change was meant to harden. Fixed by moving `_tier_gate_warn` to stderr, matching `_tier_gate_error`. Verified via 4 scenario tests (immediate success x2, retry-then-succeed, persistent-failure → clean exit 1).

## Verification

- `bash -n` syntax check passes on both changed files.
- Verified live via SSM that `ec2:DescribeTags` succeeds on both a dev `app` instance and a staging `app-green` instance, confirming the new fail-closed retry logic has no permission-related risk on either environment.
- 4 scenario tests run locally against `tier_gate.sh`'s retry/fail-closed logic (immediate success, crawler-green not-legacy case, retry-then-succeed, persistent-failure exit code + clean stdout).

## Related

- `search-gov` PR #2090 (original findings, production-scoped fixes)