### PR TITLE
SRCH-6641: remove "is_photo_govbox_enabled" boolean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ yarn-debug.log*
 .DS_Store
 .idea
 .cursor/
+.vscode

--- a/app/controllers/admin/affiliates_controller.rb
+++ b/app/controllers/admin/affiliates_controller.rb
@@ -91,7 +91,6 @@ class Admin::AffiliatesController < Admin::AdminController
       gets_results_from_all_domains
       is_federal_register_document_govbox_enabled
       is_medline_govbox_enabled
-      is_photo_govbox_enabled
       is_related_searches_enabled
       is_rss_govbox_enabled
       is_sayt_enabled

--- a/db/migrate/20260722160615_remove_is_photo_govbox_enabled_from_affiliates.rb
+++ b/db/migrate/20260722160615_remove_is_photo_govbox_enabled_from_affiliates.rb
@@ -1,0 +1,5 @@
+class RemoveIsPhotoGovboxEnabledFromAffiliates < ActiveRecord::Migration[7.1]
+  def change
+    remove_column :affiliates, :is_photo_govbox_enabled, :boolean
+  end
+end

--- a/db/migrate/20260722160615_remove_is_photo_govbox_enabled_from_affiliates.rb
+++ b/db/migrate/20260722160615_remove_is_photo_govbox_enabled_from_affiliates.rb
@@ -1,5 +1,0 @@
-class RemoveIsPhotoGovboxEnabledFromAffiliates < ActiveRecord::Migration[7.1]
-  def change
-    remove_column :affiliates, :is_photo_govbox_enabled, :boolean
-  end
-end

--- a/spec/controllers/admin/affiliates_controller_spec.rb
+++ b/spec/controllers/admin/affiliates_controller_spec.rb
@@ -107,7 +107,7 @@ describe Admin::AffiliatesController do
         let(:enable_disable_columns) do
           %i[ dap_enabled gets_blended_results gets_commercial_results_on_blended_search
               is_federal_register_document_govbox_enabled gets_results_from_all_domains
-              is_medline_govbox_enabled is_photo_govbox_enabled is_related_searches_enabled
+              is_medline_govbox_enabled is_related_searches_enabled
               is_rss_govbox_enabled is_sayt_enabled is_video_govbox_enabled jobs_enabled raw_log_access_enabled ]
         end
 


### PR DESCRIPTION
## Summary
Removed `is_photo_govbox_enabled` checkbox from Affiliates setting in Admin portal. This is just the UI change and not dropping the column from database itself. 

We will address the migration separately in [SRCH-6648](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6648) when we have removed handful of such unused settings from the UI.
 
#### Functionality Checks
 
- [x]  You have merged the latest changes from the target branch (usually `main`) into your branch.
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".


[SRCH-6648]: https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6648