### PR TITLE
fix(deploy): clear stale CodeDeploy staging root before Install

### DIFF
--- a/cicd-scripts/before_install.sh
+++ b/cicd-scripts/before_install.sh
@@ -35,6 +35,24 @@ fi
 touch "$SHARED_DIR/log/puma_access.log" "$SHARED_DIR/log/puma_error.log"
 
 # Keep CodeDeploy staging root available and writable for this deployment.
+# Actively clear any leftover contents from a previous deploy before
+# CodeDeploy's Install step copies the new bundle in. Without this, a stale
+# file left behind by an earlier deploy (e.g. one that ran against a
+# different/separate deployment group, or was aborted partway through) can
+# collide with the new bundle's file of the same name. The deployment
+# group's fileExistsBehavior is DISALLOW, so CodeDeploy refuses to overwrite
+# an existing file and fails the whole Install step outright rather than
+# silently overwriting -- this happened in production on 2026-07-23 when
+# /home/search/cicd_temp/Gemfile.lock was left over from an earlier,
+# separate deployment group's run and blocked the next deploy through the
+# regular group. Cleaning here makes each deploy's staging area
+# deterministic regardless of what a previous, possibly unrelated,
+# deployment left behind.
+if [ -d "$STAGING_ROOT" ]; then
+  log "Clearing existing staging root contents: $STAGING_ROOT"
+  rm -rf "${STAGING_ROOT:?}"/* "${STAGING_ROOT:?}"/.[!.]* 2>/dev/null || true
+fi
 mkdir -p "$STAGING_ROOT"
 
 log "BeforeInstall hook completed"
+


### PR DESCRIPTION
## Problem

CodeDeploy's `Install` lifecycle step can fail with:

```
The deployment failed because a specified file already exists at this location: /home/search/cicd_temp/Gemfile.lock
```

Hit this in production when crawler-green instances (previously deployed via a separate CodeDeploy deployment group) were merged into the regular `prod_searchgov_dg` deployment group. That deployment group's `fileExistsBehavior` is `DISALLOW`, so CodeDeploy refuses to overwrite any file that already exists at the staging destination (`/home/search/cicd_temp`, per `appspec.yml`). A prior deploy — run against the separate deployment group before the merge — had left a `Gemfile.lock` behind in that directory. `before_install.sh` only ever `mkdir -p`'d the staging root; it never cleared existing contents, so the leftover file collided with the new bundle's file of the same name and failed the `Install` step outright, before any of our custom hooks (including `fetch_env_vars.sh`) ever ran.

## Fix

`before_install.sh` now actively clears both regular and hidden files in the staging root before re-creating it, so every deploy's `Install` step always starts from a clean destination — regardless of what a previous, possibly unrelated, deployment left behind.

## Verification

- Reproduced and fixed live on production (2026-07-23): manually cleared the stale files, re-triggered the deployment, confirmed it succeeded end-to-end (migration gate, tier gate, Puma service, Resque, asset upload, HTTP health — all verified across app/cron/crawler-green tiers).
- Ran a subsequent full pipeline deployment on production after this fix; succeeded without any manual intervention.
- `bash -n cicd-scripts/before_install.sh` — syntax valid.

Cherry-picked from production PR #2103 onto `main` for testing in dev before rolling forward to staging/production via the normal promotion flow.