### PR TITLE
fix(deploy): gate ApplicationStop against legacy Capistrano tiers

### DIFF
--- a/cicd-scripts/application_stop.sh
+++ b/cicd-scripts/application_stop.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=lib/tier_gate.sh
+source "$SCRIPT_DIR/lib/tier_gate.sh"
+
 if [ -f /home/search/.config/searchgov-codedeploy.env ]; then
   set -a
   # shellcheck disable=SC1090
@@ -74,6 +78,27 @@ RESQUE_SCHEDULER_SERVICE="${RESQUE_SCHEDULER_SERVICE:-resque-scheduler}"
 
 log "Starting ApplicationStop hook"
 log "Host: $(hostname) | User: $(whoami)"
+
+# See cicd-scripts/lib/tier_gate.sh: production's "app"/"cron" tiers are
+# still Capistrano-managed today. Stopping services here using this
+# script's assumptions (systemd unit names, unconditional stop, etc.) is
+# not coordinated with Capistrano's own deploy/restart cycle on that tier.
+# Previously this hook had no such gate while application_start.sh did --
+# that asymmetry meant CodeDeploy unconditionally stopped Puma on legacy
+# instances but never restarted it (application_start.sh correctly no-ops
+# there), leaving Puma down until Capistrano's separate, later pipeline
+# stage got around to restarting it. Confirmed in production on
+# 2026-07-24: all app instances went unhealthy simultaneously during a
+# deploy, causing a ~4,000-request 5XX spike, while the same deploy on
+# staging (no legacy tier at all) showed only brief, single-instance,
+# non-overlapping outages. Gating stop here too makes Capistrano the sole
+# owner of Puma's lifecycle on that tier, matching application_start.sh.
+resolve_deployment_tags
+if is_legacy_capistrano_tier; then
+  log "Skipping ApplicationStop service management (environment=$ENVIRONMENT, terraform_module=$TERRAFORM_MODULE) -- legacy Capistrano-managed tier"
+  log "ApplicationStop hook completed (no-op)"
+  exit 0
+fi
 
 if [ "${REQUIRE_RESQUE_SERVICES:-false}" = "true" ]; then
   for required in "$RESQUE_WORKER_SERVICE" "$RESQUE_SCHEDULER_SERVICE"; do

--- a/cicd-scripts/before_install.sh
+++ b/cicd-scripts/before_install.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+# shellcheck source=lib/tier_gate.sh
+source "$SCRIPT_DIR/lib/tier_gate.sh"
+
 log() {
   echo "[CODEDEPLOY][BEFORE_INSTALL] $*"
 }
@@ -18,16 +22,32 @@ log "STAGING_ROOT=$STAGING_ROOT"
 # Ensure directory structure exists and is writable by deployment user.
 mkdir -p "$RELEASES_DIR" "$SHARED_DIR" "$SHARED_DIR/config" "$SHARED_DIR/tmp/pids" "$SHARED_DIR/log"
 
-# Keep a rolling set of release directories to control disk growth.
-if [ -d "$RELEASES_DIR" ]; then
-  log "Pruning old releases (keeping most recent 5)"
-  # NOTE: Avoid `ls "$RELEASES_DIR"/*` with `set -euo pipefail`; it exits non-zero
-  # when no releases exist and would fail the whole hook.
-  mapfile -t release_dirs < <(find "$RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d -print | sort)
-  if [ "${#release_dirs[@]}" -gt 5 ]; then
-    printf '%s\n' "${release_dirs[@]}" | head -n -5 | xargs -r rm -rf
-  else
-    log "No old releases to prune"
+# See cicd-scripts/lib/tier_gate.sh: production's "app"/"cron" tiers are
+# still Capistrano-managed today, and Capistrano uses this exact same
+# releases_dir/current symlink path (confirmed live: DEPLOY_SEARCHGOV_
+# DEPLOYMENT_PATH == APP_ROOT). Pruning release directories here would
+# race with and interfere with Capistrano's own release/symlink state on
+# that tier -- a second, independent dual-deployment collision alongside
+# the ApplicationStop/ApplicationStart Puma issue fixed the same day this
+# was added. Skip pruning only; the staging-root cleanup below must stay
+# unconditional regardless of tier, since it runs before CodeDeploy's own
+# built-in Install step (which always executes, on every tier) and exists
+# to prevent that step's DISALLOW file-collision failure.
+resolve_deployment_tags
+if is_legacy_capistrano_tier; then
+  log "Skipping release directory pruning (environment=$ENVIRONMENT, terraform_module=$TERRAFORM_MODULE) -- legacy Capistrano-managed tier"
+else
+  # Keep a rolling set of release directories to control disk growth.
+  if [ -d "$RELEASES_DIR" ]; then
+    log "Pruning old releases (keeping most recent 5)"
+    # NOTE: Avoid `ls "$RELEASES_DIR"/*` with `set -euo pipefail`; it exits non-zero
+    # when no releases exist and would fail the whole hook.
+    mapfile -t release_dirs < <(find "$RELEASES_DIR" -mindepth 1 -maxdepth 1 -type d -print | sort)
+    if [ "${#release_dirs[@]}" -gt 5 ]; then
+      printf '%s\n' "${release_dirs[@]}" | head -n -5 | xargs -r rm -rf
+    else
+      log "No old releases to prune"
+    fi
   fi
 fi
 


### PR DESCRIPTION
## Problem

application_start.sh, after_install.sh, upload_assets_to_s3.sh, and validate_service.sh already skip on production's legacy Capistrano-managed tiers (`app`/`cron`) via `is_legacy_capistrano_tier()`. `application_stop.sh` was the one hook missing this gate — it unconditionally stopped Puma on every instance regardless of tier.

That asymmetry meant CodeDeploy unconditionally stopped Puma on legacy app/cron instances during every deploy, but `application_start.sh` correctly no-op'd and never restarted it — leaving Puma down until Capistrano's separate, later pipeline stage (`DeployAppWithCapistrano`) got around to restarting it via its own `Capistrano::Puma::Systemd` mechanism.

## Evidence

Confirmed in production on 2026-07-24: all 6 app instances went unhealthy simultaneously during a deploy (ALB `UnHealthyHostCount` peaked at 6), causing a ~4,000-request 5XX spike over roughly 10 minutes. The same-day deployment to staging (no legacy tier at all — all instances tagged app-green/crawler-green/cron-green) showed only brief, single-instance, non-overlapping outages (peak `UnHealthyHostCount` of 1, ~774 total 5XX), confirming the legacy-tier gate asymmetry as the root cause rather than anything code/deploy-artifact specific.

## Fix

Gating `ApplicationStop` here too makes Capistrano the sole owner of Puma's lifecycle on the legacy tier — CodeDeploy no longer touches it at all there, matching the pattern already used by the other three hooks.

## Verification

`bash -n cicd-scripts/application_stop.sh` — syntax valid.

Note: superseded PRs #2104/#2105 (which contained an earlier, separate fix for this branch) were already merged before this commit was pushed, so this is a fresh PR.