### PR TITLE
SRCH-6596: Adds assets from active_scaffold gem to our project.

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -3179,7 +3179,7 @@ noscript.active-scaffold {
 .active-scaffold a.inline-adapter-close {
   float: right;
   text-indent: -4000px;
-  background: url("/assets/active_scaffold/close.png") no-repeat;
+  background: image-url("active_scaffold/close.png") no-repeat;
   width: 16px;
   height: 17px;
 }
@@ -3489,7 +3489,7 @@ noscript.active-scaffold {
 
 .active-scaffold .refresh-link {
   text-indent: 26px;
-  background-image: url("/assets/active_scaffold/refresh.png");
+  background-image: image-url("active_scaffold/refresh.png");
   background-position: 5px;
   background-repeat: no-repeat;
   width: 25px;
@@ -3585,7 +3585,7 @@ li.ui-draggable-disabled, li.ui-draggable-disabled label {
 
 .active-scaffold .sub-form .association-record a.destroy {
   text-indent: -4000px;
-  background: url("/assets/active_scaffold/cross.png") no-repeat;
+  background: image-url("active_scaffold/cross.png") no-repeat;
   width: 16px;
   height: 16px;
   padding: 0;
@@ -3619,7 +3619,7 @@ li.ui-draggable-disabled, li.ui-draggable-disabled label {
 }
 
 .as_touch a.inline-adapter-close {
-  background: url("/assets/active_scaffold/close_touch.png") no-repeat;
+  background: image-url("active_scaffold/close_touch.png") no-repeat;
   width: 25px;
   height: 27px;
 }
@@ -3669,31 +3669,31 @@ li.ui-draggable-disabled, li.ui-draggable-disabled label {
 }
 
 .active-scaffold-header div.actions div.action_group div {
-  background-image: url("/assets/active_scaffold/gears.png");
+  background-image: image-url("active_scaffold/gears.png");
 }
 
 .active-scaffold-header div.actions a.show_config_list {
-  background-image: url("/assets/active_scaffold/config.png");
+  background-image: image-url("active_scaffold/config.png");
 }
 
 .active-scaffold-header div.actions a.new, .active-scaffold-header div.actions a.new_existing {
-  background-image: url("/assets/active_scaffold/add.png");
+  background-image: image-url("active_scaffold/add.png");
 }
 
 .active-scaffold-header div.actions a.show_search {
-  background-image: url("/assets/active_scaffold/magnifier.png");
+  background-image: image-url("active_scaffold/magnifier.png");
 }
 
 .active-scaffold th.asc a {
-  background-image: url("/assets/active_scaffold/arrow_up.png");
+  background-image: image-url("active_scaffold/arrow_up.png");
 }
 
 .active-scaffold th.desc a {
-  background-image: url("/assets/active_scaffold/arrow_down.png");
+  background-image: image-url("active_scaffold/arrow_down.png");
 }
 
 .active-scaffold th.loading a {
-  background-image: url("/assets/active_scaffold/indicator-small.gif");
+  background-image: image-url("active_scaffold/indicator-small.gif");
 }
 
 .active-scaffold th, .active-scaffold th a, .active-scaffold th p {

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -18,3 +18,12 @@ Rails.application.config.assets.precompile += %w(*.png *.gif)
 Rails.application.config.assets.precompile += %w(application.css searches.css sites.css)
 Rails.application.config.assets.precompile += Dir.entries("#{Rails.root}/app/assets/javascripts/").select { |e| e =~ /^(?!application\.js).+\.js$/ }
 Rails.application.config.assets.precompile += Dir.entries("#{Rails.root}/app/assets/stylesheets/").select { |e| e =~ /^(?!application\.css).+\.css$/ }
+
+# Precompile ActiveScaffold assets. It drops all images in `https://github.com/activescaffold/active_scaffold/tree/master/app/assets/images/active_scaffold` into public/assets/active_scaffold. 
+# This is necessary because ActiveScaffold uses `image_path` to reference images, which will not work if the images are not in the public/assets directory.
+active_scaffold_images_path = ActiveScaffold::Engine.root.join("app/assets/images")
+Rails.application.config.assets.precompile += Dir.glob(active_scaffold_images_path.join("active_scaffold/**/*")).select do |path|
+  File.file?(path)
+end.map do |path|
+  Pathname.new(path).relative_path_from(active_scaffold_images_path).to_s
+end

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -18,12 +18,3 @@ Rails.application.config.assets.precompile += %w(*.png *.gif)
 Rails.application.config.assets.precompile += %w(application.css searches.css sites.css)
 Rails.application.config.assets.precompile += Dir.entries("#{Rails.root}/app/assets/javascripts/").select { |e| e =~ /^(?!application\.js).+\.js$/ }
 Rails.application.config.assets.precompile += Dir.entries("#{Rails.root}/app/assets/stylesheets/").select { |e| e =~ /^(?!application\.css).+\.css$/ }
-
-# Precompile ActiveScaffold assets. It drops all images in `https://github.com/activescaffold/active_scaffold/tree/master/app/assets/images/active_scaffold` into public/assets/active_scaffold. 
-# This is necessary because ActiveScaffold uses `image_path` to reference images, which will not work if the images are not in the public/assets directory.
-active_scaffold_images_path = ActiveScaffold::Engine.root.join("app/assets/images")
-Rails.application.config.assets.precompile += Dir.glob(active_scaffold_images_path.join("active_scaffold/**/*")).select do |path|
-  File.file?(path)
-end.map do |path|
-  Pathname.new(path).relative_path_from(active_scaffold_images_path).to_s
-end


### PR DESCRIPTION
## Summary
In Super Admin, the delete icon next to Excluded domains were missing because they were statically referenced and got ignored by asset-pipeline. As a result of this, the admin view in production lacked the cross icon; giving a false impression that the functionality was broken

### Solution:
Dynamically reference the assets from active_scaffold that gets used in the project. This process involved:
- Rename `admin.css` to `admin.scss` so ActiveScaffold image paths can use the Sprockets `image-url` helper.
- replaced `url("/assets/active_scaffold/<image_name>")` with `image-url("active_scaffold/<image_name>")`

### Testing:
- Turned off asset compile locally by adding `config.assets.compile = false` to `config/environments/development.rb`
- Ran `bundle exec rails assets:precompile`
- Navigating to http://localhost:3000/admin/affiliates; I could see the close icon served via `http://localhost:3000/assets/active_scaffold/cross-7633b8f14262dc9de8f39095cb3d14926295e4911e2ed53714bbd4a7c39a9cc9.png`
- For Production, `config.asset_host` has been properly set; so should work without an issue.

### Checklist
#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [x] PR title is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
  - Not run locally.

#### Process Checks

- [x] You have specified at least one "Reviewer".
