### PR TITLE
SRCH-5155 Remove leftover codeclimate.com VCR ignore rules

### DIFF
--- a/spec/support/shared_vcr_setup.rb
+++ b/spec/support/shared_vcr_setup.rb
@@ -35,10 +35,7 @@ VCR.configure do |config|
     http_message.body.encoding.name == 'ASCII-8BIT' || !http_message.body.valid_encoding?
   end
 
-  config.ignore_hosts 'example.com', 'codeclimate.com', '127.0.0.1', 'googlechromelabs.github.io'
-  config.ignore_request do |request|
-    /codeclimate.com/ ===  URI(request.uri).host
-  end
+  config.ignore_hosts 'example.com', '127.0.0.1', 'googlechromelabs.github.io'
 
   config.ignore_request { |request| URI(request.uri).port.between?(9200, 9399) } # Elasticsearch and OpenSearch
   config.ignore_request { |request| URI(request.uri).port == 9998 } # Tika


### PR DESCRIPTION
## Summary
- Jira: [SRCH-5155](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-5155) (code half)
- Removes the two leftover `codeclimate.com` VCR ignore rules from `spec/support/shared_vcr_setup.rb`.
- Code Climate Quality API was shut off 2025-07-18; these hosts are no longer contacted.
- **Out of scope for this PR (GitHub org admin):** removing the Code Climate GitHub App/OAuth from the GSA org — tracked as [SRCH-6690](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6690).
- **Coverage decision recorded:** continue relying on Rubocop, Brakeman, and bundler-audit already in CI rather than adopting Qlty, unless product decides otherwise.

### Checklist

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".

[SRCH-5155]: https://gsa-stage1.atlassian-us-gov-mod.net/browse/SRCH-5155

[SRCH-6690]: https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6690