### PR TITLE
SRCH-6704 Bump rack, erb, httparty, and aws-sdk-s3 on current main

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,10 +32,11 @@ gem 'resque-scheduler', '~> 4.10.2'
 # Paperclip is deprecated: https://cm-jira.usa.gov/browse/SRCH-702
 # Using a third-party fork as an interim measure.
 gem 'kt-paperclip', '~> 7.1.0'
-gem 'aws-sdk-s3', '~> 1.102.0'
+gem 'aws-sdk-s3', '~> 1.102'
 gem 'googlecharts', '~> 1.6.12'
 gem 'flickraw', '~> 0.9.9'
 gem 'mutex_m', '~> 0.2.0'
+gem 'erb', '~> 4.0.4'
 gem 'bigdecimal', '~> 3.1', '>= 3.1.8'
 gem 'rexml', '>= 3.4.2'
 gem 'csv', '~> 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -181,20 +181,21 @@ GEM
       request_store (~> 1.0)
     aws-eventstream (1.4.0)
     aws-partitions (1.1134.0)
-    aws-sdk-core (3.227.0)
+    aws-sdk-core (3.254.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
+      bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
     aws-sdk-kms (1.107.0)
       aws-sdk-core (~> 3, >= 3.227.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.102.0)
-      aws-sdk-core (~> 3, >= 3.120.0)
+    aws-sdk-s3 (1.229.0)
+      aws-sdk-core (~> 3, >= 3.254.1)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.4)
+      aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     axe-core-api (4.10.3)
@@ -258,7 +259,7 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
-    cgi (0.5.0)
+    cgi (0.5.2)
     chronic (0.10.2)
     cld3 (3.6.0)
     climate_control (0.2.0)
@@ -361,7 +362,7 @@ GEM
       launchy (>= 2.1, < 4.0)
       mail (~> 2.7)
     equalizer (0.0.11)
-    erb (4.0.4)
+    erb (4.0.4.1)
       cgi (>= 0.3.3)
     erubi (1.13.1)
     et-orbi (1.2.11)
@@ -443,7 +444,7 @@ GEM
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    httparty (0.23.1)
+    httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -582,7 +583,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.22)
+    rack (2.2.24)
     rack-contrib (2.5.0)
       rack (< 4)
     rack-cors (1.1.1)
@@ -913,7 +914,7 @@ DEPENDENCIES
   amazing_print (~> 1.4)
   american_date (~> 1.1.1)
   authlogic (~> 6.4, >= 6.4.3)
-  aws-sdk-s3 (~> 1.102.0)
+  aws-sdk-s3 (~> 1.102)
   axe-core-capybara
   axe-core-cucumber
   bigdecimal (~> 3.1, >= 3.1.8)
@@ -941,6 +942,7 @@ DEPENDENCIES
   elasticsearch-persistence
   elasticsearch-xpack (~> 7.4.0)
   email_spec (~> 2.2)
+  erb (~> 4.0.4)
   exception_notification (~> 4.5)
   faker (~> 1.8)
   faraday_middleware


### PR DESCRIPTION
## Summary
- Recreates the green Ruby Dependabot patches on current GSA `main` (`81bfa1357`) for [SRCH-6704](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6704) (from spike [SRCH-6520](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6520)).
- Bumps: rack 2.2.22 → 2.2.24 (stay on 2.2.x), erb 4.0.4 → 4.0.4.1, httparty 0.23.1 → 0.24.2, aws-sdk-s3 1.102.0 → 1.229.0 (and aws-sdk-core 3.227.0 → 3.254.1).
- Loosened the `aws-sdk-s3` Gemfile pin from `'~> 1.102.0'` to `'~> 1.102'` so the 1.x bump can resolve. Pinned `erb` to `'~> 4.0.4'` so Bundler does not jump to erb 6.
- Stale Dependabot PRs this supersedes: #2007, #2019, #1946, #1931. Already closed as obsolete: #1868 (rexml already 3.4.4), #1778 (`uri` no longer locked).

S3 unit specs are mocked; please smoke-test S3 upload/download in a lower env after deploy.

### Checklist

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".


[SRCH-6704]: https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6704
[SRCH-6520]: https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6520