### PR TITLE
SRCH-6653 Return empty Federal Register results when custom indices are disabled

### DIFF
--- a/app/models/elastic_federal_register_document_results.rb
+++ b/app/models/elastic_federal_register_document_results.rb
@@ -5,7 +5,7 @@ class ElasticFederalRegisterDocumentResults < ElasticResults
   def initialize(result)
     @offset = result['hits']['offset']
     @aggregations = extract_aggregations(result['aggregations']) if result['aggregations']
-    hits = @aggregations.map { |bucket| bucket.rows.map(&:value) }.flatten
+    hits = Array(@aggregations).map { |bucket| bucket.rows.map(&:value) }.flatten
     @results = extract_results(hits.first(3))
     @total = hits.present? ? hits.count : 0
   end

--- a/spec/models/elastic_federal_register_document_spec.rb
+++ b/spec/models/elastic_federal_register_document_spec.rb
@@ -91,4 +91,19 @@ describe ElasticFederalRegisterDocument do
       end
     end
   end
+
+  describe '.search_for when custom indices are disabled' do
+    before do
+      allow(Es).to receive(:custom_indices_enabled?).and_return(false)
+    end
+
+    it 'returns empty results without raising' do
+      search = described_class.search_for(federal_register_agency_ids: [fr_noaa.id],
+                                          language: 'en',
+                                          q: 'fish')
+
+      expect(search.total).to eq 0
+      expect(search.results).to eq([])
+    end
+  end
 end


### PR DESCRIPTION
## Summary
Backport of the Federal Register nil-safe constructor from [MtoS #2125](https://github.com/GSA/search-gov/pull/2125) onto `main`.

When `CUSTOM_INDICES_ENABLED` is off, `Indexable#search_for` returns `NO_HITS` with no aggregations. `ElasticFederalRegisterDocumentResults` then called `@aggregations.map` and raised `undefined method map for nil`. Staging already has `Array(@aggregations)` plus a spec; `main` did not, so later MtoS from `main` could reintroduce a govbox 500.

No production deploy in this PR.

### Checklist
#### Functionality Checks
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
- [x] Your primary commit message is of the format **SRCH-#### \** matching the associated Jira ticket.
- [x] PR title is either of the format **SRCH-#### \** matching the associated Jira ticket, or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
- [ ] Automated checks pass.

#### Process Checks
- [x] You have specified at least one "Reviewer".
