### PR TITLE
SRCH-6719 Remove leftover ASIS_HOST and oasis rubocop paths

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -54,7 +54,6 @@ USAJOBS_HOST=https://data.usajobs.gov
 USAJOBS_AUTHORIZATION_KEY=your_usajobs_api_key
 USAJOBS_USER_AGENT=your_email
 USAJOBS_ADAPTER=net_http_persistent
-ASIS_HOST=http://localhost:8080
 TIKA_HOST=localhost
 TIKA_PORT=9998
 YOUTUBE_KEY=youtubeapikeygoeshere

--- a/.env.test
+++ b/.env.test
@@ -54,7 +54,6 @@ USAJOBS_HOST=https://data.usajobs.gov
 USAJOBS_AUTHORIZATION_KEY=your_usajobs_api_key
 USAJOBS_USER_AGENT=your_email
 USAJOBS_ADAPTER=net_http_persistent
-ASIS_HOST=http://localhost:8080
 TIKA_HOST=localhost
 TIKA_PORT=9998
 YOUTUBE_KEY=youtubeapikeygoeshere

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -685,7 +685,6 @@ Lint/IneffectiveAccessModifier:
     - 'lib/importers/federal_register_agency_data.rb'
     - 'lib/importers/hint_data.rb'
     - 'lib/importers/youtube_profile_data.rb'
-    - 'lib/oasis.rb'
     - 'lib/youtube_adapter.rb'
 
 # Offense count: 3
@@ -744,7 +743,6 @@ Lint/RescueException:
     - 'app/models/indexed_document.rb'
     - 'app/models/news_item.rb'
     - 'lib/importers/site_feed_url_data.rb'
-    - 'lib/oasis.rb'
     - 'lib/tasks/reports.rake'
 
 # Offense count: 1
@@ -829,7 +827,6 @@ Lint/UselessAccessModifier:
     - 'lib/importers/federal_register_agency_data.rb'
     - 'lib/importers/hint_data.rb'
     - 'lib/importers/youtube_profile_data.rb'
-    - 'lib/oasis.rb'
     - 'lib/youtube_adapter.rb'
 
 # Offense count: 11
@@ -1052,7 +1049,6 @@ Performance/RedundantMatch:
 # Configuration parameters: MaxKeyValuePairs.
 Performance/RedundantMerge:
   Exclude:
-    - 'app/engines/oasis_search.rb'
     - 'app/helpers/form_helper.rb'
     - 'app/helpers/mobile_helper.rb'
     - 'app/helpers/spelling_suggestions_helper.rb'
@@ -2247,7 +2243,6 @@ Style/ClassEqualityComparison:
 # Offense count: 16
 Style/ClassVars:
   Exclude:
-    - 'app/engines/oasis_search.rb'
     - 'app/jobs/legacy/news_items_checker.rb'
     - 'app/models/affiliate.rb'
     - 'app/models/boosted_content.rb'

--- a/config/initializers/log_subscriber.rb
+++ b/config/initializers/log_subscriber.rb
@@ -1,8 +1,6 @@
 module Instrumentation
   class LogSubscriber < ActiveSupport::LogSubscriber
-    # The only methods that work as of 2023 are oasis_search and elastic_search. The others
-    # should be removed when we remove those old search classes. The Bing methods need to
-    # be updated to support BingV7.
+    # Bing methods are leftover instrumentation and should be removed with those search classes.
     def bing_image_search(event)
       generic_logging('Bing Image Query', event, YELLOW)
     end


### PR DESCRIPTION
## Summary
- Drop leftover `ASIS_HOST` from local env examples. The ASIS service is retired and nothing in the app reads this anymore.
- Remove stale `lib/oasis.rb` / `app/engines/oasis_search.rb` paths from `.rubocop_todo.yml` (those files are already gone).
- Update the log subscriber comment so it no longer refers to `oasis_search`.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [ ] You have specified at least one "Reviewer".

## Test plan
- [ ] Confirm `ASIS_HOST` is gone from `.env.development` and `.env.test`
- [ ] Confirm no remaining `oasis.rb` / `oasis_search.rb` entries in `.rubocop_todo.yml`
- [ ] App still boots locally without `ASIS_HOST`