### PR TITLE
SRCH-6249: Added logging to rake task update_not_active_approval_status

### DIFF
--- a/lib/tasks/user.rake
+++ b/lib/tasks/user.rake
@@ -14,7 +14,11 @@ namespace :usasearch do
 
     desc 'Set accounts that are not active for more than 90 days to timed_out'
     task update_not_active_approval_status: :environment do
-      User.mark_inactive_as_timed_out!
+      Rails.logger.info('[usasearch:user:update_not_active_approval_status] started')
+      updated = User.mark_inactive_as_timed_out!
+      Rails.logger.info(
+        "[usasearch:user:update_not_active_approval_status] completed: timed out #{updated} user(s)"
+      )
     end
 
     desc 'Warns not active users account will be deactivated'

--- a/spec/lib/tasks/user_spec.rb
+++ b/spec/lib/tasks/user_spec.rb
@@ -76,10 +76,15 @@ describe 'User rake tasks' do
       expect(not_active_user.reload.timed_out?).to be true
     end
 
-    it 'does not log not_approved change anymore' do
-      @rake[task_name].invoke
+    it 'logs start and how many users were timed out' do
       allow(Rails.logger).to receive(:info)
-      expect(Rails.logger).not_to receive(:info).with(/has been not active for 90 days.*"not_approved"/)
+      expect(Rails.logger).to receive(:info).with(
+        '[usasearch:user:update_not_active_approval_status] started'
+      )
+      expect(Rails.logger).to receive(:info).with(
+        /\[usasearch:user:update_not_active_approval_status\] completed: timed out \d+ user\(s\)/
+      )
+      @rake[task_name].invoke
     end
   end
 


### PR DESCRIPTION
## Summary
- Adds logging to investigate why `update_not_active_approval_status` is not getting invoked

## QA Steps:
- As the branch gets deployed to dev, manually trigger the rake task by running `/bin/bash -l -c 'cd /home/search/searchgov/current && RAILS_ENV=production bundle exec rake update_not_active_approval_status` from the cron EC2
- Check for the log in `/home/search/searchgov/current/log/production.log`
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks
- [x] You have specified at least one "Reviewer".
