### PR TITLE
SRCH-6374 Keep SitemapMonitorJob on crawler resque-scheduler as source of truth

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,13 @@ When in doubt, just use Resque.enqueue() instead of Resque.enqueue_with_priority
 (Note: newer jobs inherit from ActiveJob, using the resque queue adapter. We are in the process of migrating the older jobs to ActiveJob.)
 
 ### Scheduled jobs
-We use the [resque-scheduler](https://github.com/resque/resque-scheduler) gem to schedule delayed jobs. Use [ActiveJob](http://api.rubyonrails.org/classes/ActiveJob/Core/ClassMethods.html)'s `:wait` or `:wait_until` options to enqueue delayed jobs, or schedule them in `config/resque_schedule.yml`.
+
+There are two Rails schedule files. Do not list the same job in both.
+
+- `config/resque_schedule.yml` — recurring Resque cron on **crawler** hosts via systemd `resque-scheduler.service` (`rake resque:scheduler`). Production currently schedules `SitemapMonitorJob` every 4 hours. This is the source of truth for that job. Each crawler that runs the scheduler process will enqueue it.
+- `config/schedule.rb` — whenever crontab on **cron** hosts (Capistrano `roles: [:cron]`). Rake/runner jobs only.
+
+The resque-scheduler **process** must keep running even if the YAML file is empty: delayed jobs use ActiveJob `:wait` / `:wait_until` (for example `SearchgovDomainIndexerJob.set(wait: delay.seconds)`).
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ When in doubt, just use Resque.enqueue() instead of Resque.enqueue_with_priority
 There are two Rails schedule files. Do not list the same job in both.
 
 - `config/resque_schedule.yml` — recurring Resque cron on **crawler** hosts via systemd `resque-scheduler.service` (`rake resque:scheduler`). Production currently schedules `SitemapMonitorJob` every 4 hours. This is the source of truth for that job. Each crawler that runs the scheduler process will enqueue it.
-- `config/schedule.rb` — whenever crontab on **cron** hosts (Capistrano `roles: [:cron]`). Rake/runner jobs only.
+- `config/schedule.rb` — whenever crontab on **cron** hosts (Capistrano `roles: [:cron]`). Use `rake`, `runner`, or `command`. Do not add Resque cron job classes here.
 
 The resque-scheduler **process** must keep running even if the YAML file is empty: delayed jobs use ActiveJob `:wait` / `:wait_until` (for example `SearchgovDomainIndexerJob.set(wait: delay.seconds)`).
 

--- a/config/resque_schedule.yml
+++ b/config/resque_schedule.yml
@@ -1,3 +1,8 @@
+# Recurring Resque cron. Loaded by resque-scheduler on crawler hosts
+# (systemd resque-scheduler.service). Do not duplicate these jobs in
+# config/schedule.rb (whenever crontab on cron hosts).
+# Delayed/wait jobs still require the scheduler process even if this file
+# has no entries.
 production:
   SitemapMonitorJob:
     cron: "0 */4 * * *"

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,3 +1,7 @@
+# Whenever crontab for Capistrano :cron hosts.
+# Recurring Resque jobs live in config/resque_schedule.yml on crawler hosts.
+# Do not add them here.
+
 every 1.month, roles: [:cron] do
   rake 'search:reports:email_monthly_reports'
 end

--- a/lib/tasks/resque.rake
+++ b/lib/tasks/resque.rake
@@ -19,7 +19,8 @@ namespace :resque do
     # be a hash.  YAML is usually the easiest.
     yaml_schedule = Rails.application.config_for('resque_schedule')
     Resque.schedule = ActiveScheduler::ResqueWrapper.wrap yaml_schedule
-    Resque.logger = Logger.new('new_resque_log_file')
+    Resque.logger = Logger.new(Rails.root.join('log', 'resque.log'))
+    Resque.logger.level = Logger::INFO
   end
 
   task :scheduler => :setup_schedule

--- a/spec/config/scheduled_jobs_spec.rb
+++ b/spec/config/scheduled_jobs_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe 'scheduled jobs configuration' do
+  let(:resque_schedule) do
+    YAML.safe_load(Rails.root.join('config/resque_schedule.yml').read)
+  end
+
+  it 'schedules SitemapMonitorJob only via resque-scheduler in production' do
+    production = resque_schedule.fetch('production')
+    expect(production.keys).to eq(['SitemapMonitorJob'])
+    expect(production.fetch('SitemapMonitorJob')).to eq('cron' => '0 */4 * * *')
+  end
+
+  it 'does not schedule SitemapMonitorJob via whenever' do
+    schedule = Rails.root.join('config/schedule.rb').read
+    expect(schedule).not_to match(/runner ['"]SitemapMonitorJob/)
+    expect(schedule).not_to match(/rake ['"][^'"]*SitemapMonitor/)
+  end
+end

--- a/spec/config/scheduled_jobs_spec.rb
+++ b/spec/config/scheduled_jobs_spec.rb
@@ -7,15 +7,28 @@ describe 'scheduled jobs configuration' do
     YAML.safe_load(Rails.root.join('config/resque_schedule.yml').read)
   end
 
-  it 'schedules SitemapMonitorJob only via resque-scheduler in production' do
-    production = resque_schedule.fetch('production')
-    expect(production.keys).to eq(['SitemapMonitorJob'])
-    expect(production.fetch('SitemapMonitorJob')).to eq('cron' => '0 */4 * * *')
+  let(:whenever_source) do
+    Rails.root.join('config/schedule.rb').read.
+      lines.reject { |line| line.match?(/^\s*#/) }.join
   end
 
-  it 'does not schedule SitemapMonitorJob via whenever' do
-    schedule = Rails.root.join('config/schedule.rb').read
-    expect(schedule).not_to match(/runner ['"]SitemapMonitorJob/)
-    expect(schedule).not_to match(/rake ['"][^'"]*SitemapMonitor/)
+  let(:yaml_job_classes) { resque_schedule.fetch('production').keys }
+
+  let(:whenever_job_classes) do
+    whenever_source.scan(/\b([A-Z][A-Za-z0-9]*Job)\b/).flatten.uniq
+  end
+
+  it 'schedules SitemapMonitorJob via resque-scheduler in production' do
+    expect(resque_schedule.fetch('production').fetch('SitemapMonitorJob')).
+      to eq('cron' => '0 */4 * * *')
+  end
+
+  it 'does not list the same job class in resque_schedule.yml and schedule.rb' do
+    expect(yaml_job_classes & whenever_job_classes).to eq([])
+  end
+
+  it 'limits whenever entries to rake, runner, or command' do
+    job_methods = whenever_source.scan(/^\s+(rake|runner|command|job|script)\b/).flatten.uniq
+    expect(job_methods - %w[rake runner command]).to eq([])
   end
 end


### PR DESCRIPTION
## Summary
- Production inventory (2026-08-31) shows `SitemapMonitorJob` is already firing from crawler YAML cron, not whenever: `resque-scheduler.service` is **active** on crawler-prod-green-instance-1 (`i-0492fae2b3d3c1b47`) and crawler-prod-green-instance-2 (`i-017b564ba68226544`), and **inactive** on cron-prod-search-instance-1 (`i-0fc2b61d11476b2f1`). Moving the job to `schedule.rb` would double-schedule it.
- Document the two Rails schedule files as separate sources of truth (`config/resque_schedule.yml` on crawlers vs `config/schedule.rb` on cron hosts) and keep the resque-scheduler process (needed for ActiveJob `:wait` / `:wait_until`).
- Point resque-scheduler logs at `log/resque.log` instead of a cwd-relative `new_resque_log_file`.
- Add a spec that `SitemapMonitorJob` stays YAML-only in production and is not listed in whenever.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [ ] You have specified at least one "Reviewer". :warning: Please assign a reviewer; I did not pick one.

## Test plan
- [x] `search-services` Docker MySQL (`:3306`), Redis (`:6379`), and OpenSearch (`:9300`) running
- [x] `bundle exec rake db:test:prepare` against Docker MySQL
- [x] `bundle exec rspec spec/config/scheduled_jobs_spec.rb spec/jobs/sitemap_monitor_job_spec.rb` — 5 examples, 0 failures
- [ ] CircleCI green
- [ ] Confirm after deploy that crawler `resque-scheduler` still enqueues `SitemapMonitorJob` every 4 hours and cron crontab still does not list it