### PR TITLE
SRCH-6249: Update crontab manually by running Whenever script for dev/staging EC2's

### DIFF
--- a/cicd-scripts/after_install.sh
+++ b/cicd-scripts/after_install.sh
@@ -217,4 +217,15 @@ mv -Tf "$TMP_LINK" "$CURRENT_LINK"
 NEW_CURRENT=$(readlink -f "$CURRENT_LINK")
 log "Current symlink now: $NEW_CURRENT"
 
+# Capistrano used to run `whenever --update-crontab` on :cron hosts as part of deployment.
+# As, cron tiers are now CodeDeploy-only (dev and staging for now), it must be manually triggered.
+if is_cron_tier; then
+  log "Updating crontab via whenever (environment=$ENVIRONMENT, terraform_module=$TERRAFORM_MODULE)"
+  cd "$CURRENT_LINK"
+  bundle exec whenever --update-crontab searchgov --roles cron --set environment=production
+  log "Whenever crontab updated successfully"
+else
+  log "Skipping whenever crontab update (environment=$ENVIRONMENT, terraform_module=$TERRAFORM_MODULE -- not a cron tier"
+fi
+
 log "AfterInstall hook completed"

--- a/cicd-scripts/lib/tier_gate.sh
+++ b/cicd-scripts/lib/tier_gate.sh
@@ -174,3 +174,16 @@ is_legacy_capistrano_tier() {
       ;;
   esac
 }
+
+# Returns success (0) if this instance is a cron tier.
+# Production's "cron" is still Capistrano-managed today, so it returns 1.
+is_cron_tier() {
+  case "${TERRAFORM_MODULE:-unknown}" in
+    cron|cron-green)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}


### PR DESCRIPTION
Update crontab manually by running Whenever script for dev/staging EC2's instances as deployment there isn't done by Capistrano. 

As production app and cron deployment are still done by capistrano, no need to manually run it there as Capistrano handles it.

## Summary
- Brief summary of the changes included in this PR
- Any additional information or context which may help the reviewer
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
 
#### Process Checks

- [x] You have specified at least one "Reviewer".
