### PR TITLE
SRCH-6517: Replaced inner <a> with <span> for best-bet tiles

### DIFF
--- a/app/javascript/components/Results/BestBets/TextBestBet.tsx
+++ b/app/javascript/components/Results/BestBets/TextBestBet.tsx
@@ -31,7 +31,8 @@ export const TextBestBet = ({ affiliate, title, url, description, position, quer
               <h2 className='result-title-label'>
                 <ResultTitle 
                   url={url}  
-                  className='result-title-link'>
+                  className='result-title-link'
+                  elementType='span'>
                   {parse(title)}
                 </ResultTitle>
               </h2>

--- a/app/javascript/components/Results/ResultGrid/ResultTitle.tsx
+++ b/app/javascript/components/Results/ResultGrid/ResultTitle.tsx
@@ -5,16 +5,18 @@ interface ResultTitleProps {
   className?: string;
   clickTracking?: () => void;
   children: ReactNode;
+  elementType?: 'anchor' | 'span';
 }
 
-const ResultTitle = ({ url, clickTracking, className, children }: ResultTitleProps) => {
-  return (
-    <a 
-      href={url}
-      className={className}
-      onClick={() => clickTracking && clickTracking()}>
+const ResultTitle = ({ url, clickTracking, className, children, elementType = 'anchor' }: ResultTitleProps) => {
+  return elementType === 'anchor' ? (
+    <a href={url} className={className} onClick={() => clickTracking && clickTracking()}>
       {children}
     </a>
+  ) : (
+    <span className={className} onClick={() => clickTracking && clickTracking()}>
+      {children}
+    </span>
   );
 };
 


### PR DESCRIPTION
## Summary
- Replaces original <a> with <span> as the wrapper element is itself an <a>
- This is a followup for [PR#2134](https://github.com/GSA/search-gov/pull/2134) (refer [CommentId=3164832](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6517?focusedCommentId=3164832))
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
#### Process Checks
- [x] You have specified at least one "Reviewer".
