### PR TITLE
SRCH-6750: Remove obsolete Federal Register "custom indices disabled" spec

### DIFF
--- a/spec/models/elastic_federal_register_document_spec.rb
+++ b/spec/models/elastic_federal_register_document_spec.rb
@@ -91,21 +91,6 @@ describe ElasticFederalRegisterDocument do
       end
     end
   end
-
-  describe '.search_for when custom indices are disabled' do
-    before do
-      allow(Es).to receive(:custom_indices_enabled?).and_return(false)
-    end
-
-    it 'returns empty results without raising' do
-      search = described_class.search_for(federal_register_agency_ids: [fr_noaa.id],
-                                          language: 'en',
-                                          q: 'fish')
-
-      expect(search.total).to eq 0
-      expect(search.results).to eq([])
-    end
-  end
 end
 
 describe ElasticFederalRegisterDocumentResults do


### PR DESCRIPTION
## Summary
Removes the `.search_for when custom indices are disabled` example. It stubbed `Es.custom_indices_enabled?`, which no longer exists after the Elasticsearch removal in https://github.com/GSA/search-gov/pull/2061.
 
### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.
 
#### Functionality Checks
 
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
- [x] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:
#### Process Checks
- [x] You have specified at least one "Reviewer".
