### PR TITLE
SRCH-5329 Enable Redis session TLS when REDIS_SSL=true

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+ssl_enabled = ENV['REDIS_SSL'].to_s.downcase == 'true'
+
 Rails.application.config.session_store :redis_store,
   expires_in: 7200,
   secure: Rails.application.config.ssl_options[:secure_cookies],
@@ -6,5 +8,6 @@ Rails.application.config.session_store :redis_store,
     host: ENV['REDIS_SESSION_HOST'],
     port: ENV['REDIS_SESSION_PORT'],
     db: 2,
-    key_prefix: 'usasearch:session'
+    key_prefix: 'usasearch:session',
+    ssl: ssl_enabled
   }


### PR DESCRIPTION
## Summary
- Session Redis now uses TLS when `REDIS_SSL=true`, so admin sessions can talk to ElastiCache after in-transit encryption is enabled.
- Safe to deploy while Redis is still on **preferred** (plaintext + TLS). Do not flip staging/dev back to **required** until this is out.

### Checklist
#### Functionality Checks
- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.
- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.
- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.
- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks
- [ ] You have specified at least one "Reviewer".

## Test plan
- [ ] Deploy to **dev**, confirm admin `/sites` still reaches login (no Redis fatal)
- [ ] Confirm `REDIS_SSL=true` is on the box and sessions work
- [ ] Repeat on staging after dev looks good
- [ ] Leave prod Redis on **preferred** until this ships