### PR TITLE
SRCH-6628: Delete "updated on..." in search results (#2142)

### DIFF
--- a/app/javascript/components/Results/ResultGrid/ResultGrid.tsx
+++ b/app/javascript/components/Results/ResultGrid/ResultGrid.tsx
@@ -86,7 +86,6 @@ export const ResultGrid = ({ result, affiliate, query, position, vertical, facet
           */}
           <Grid col={true} className='result-meta-data'>
             {result.publishedDate && <span className='published-date'>{result.publishedDate}</span>}
-            {result.updatedDate   && <span className='published-date'>{' '}&#40;Updated on {result.updatedDate}&#41;</span>}
             {result.publishedAt   && <span className='published-date'>{result.publishedAt}</span>}
             <div className='result-title'>
               <h2 className='result-title-label'>

--- a/app/javascript/test/SearchResultsLayout.test.tsx
+++ b/app/javascript/test/SearchResultsLayout.test.tsx
@@ -78,7 +78,7 @@ describe('SearchResultsLayout', () => {
   it('renders search results', () => {
     const results : any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
     for (let counter = 0; counter < 20; counter += 1) {
-      results.push({ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', fileType: 'PDF', publishedDate: 'May 9th, 2023', updatedDate: 'May 10th, 2023' });
+      results.push({ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', fileType: 'PDF', publishedDate: 'May 9th, 2023' });
     }
     const resultsData = { totalPages: 2, unboundedResults: true, results };
     render(<SearchResultsLayout affiliate={affiliate} page={page} params={{ query: 'foo' }} resultsData={resultsData} vertical='web' translations={translations} extendedHeader={true} fontsAndColors={fontsAndColors} navigationLinks={navigationLinks} facetsEnabled={false} />);
@@ -86,37 +86,33 @@ describe('SearchResultsLayout', () => {
     const resultUrl = screen.getAllByText(/www.search.gov/i);
     const resultBody = screen.getAllByText(/result body/i);
     const publishedDate = screen.getAllByText(/May 9th, 2023/i);
-    const updatedDate = screen.getAllByText(/Updated on May 10th, 2023/i);
     const fileType = screen.getAllByText(/PDF/i);
     expect(resultTitle).toHaveLength(20);
     expect(resultUrl).toHaveLength(20);
     expect(resultBody).toHaveLength(20);
     expect(publishedDate).toHaveLength(20);
-    expect(updatedDate).toHaveLength(20);
     expect(fileType).toHaveLength(20);
   });
 
   it('renders search results with no description and no file type', () => {
     const results : any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
     for (let counter = 0; counter < 20; counter += 1) {
-      results.push({ title: 'test result 1', url: 'https://www.search.gov', publishedDate: 'May 9th, 2023', updatedDate: 'May 10th, 2023' });
+      results.push({ title: 'test result 1', url: 'https://www.search.gov', publishedDate: 'May 9th, 2023' });
     }
     const resultsData = { totalPages: 2, unboundedResults: true, results };
     render(<SearchResultsLayout affiliate={affiliate} page={page} params={{ query: 'foo' }} resultsData={resultsData} vertical='web' translations={translations} extendedHeader={true} fontsAndColors={fontsAndColors} navigationLinks={navigationLinks} facetsEnabled={false} />);
     const resultTitle = screen.getAllByText(/test result 1/i);
     const resultUrl = screen.getAllByText(/www.search.gov/i);
     const publishedDate = screen.getAllByText(/May 9th, 2023/i);
-    const updatedDate = screen.getAllByText(/Updated on May 10th, 2023/i);
     expect(resultTitle).toHaveLength(20);
     expect(resultUrl).toHaveLength(20);
     expect(publishedDate).toHaveLength(20);
-    expect(updatedDate).toHaveLength(20);
   });
 
   it('renders text best bets', () => {
     const results : any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
     for (let counter = 0; counter < 2; counter += 1) {
-      results.push({ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', publishedDate: 'May 9th, 2023', updatedDate: 'May 10th, 2023' });
+      results.push({ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', publishedDate: 'May 9th, 2023' });
     }
     const additionalResults = { recommendedBy: 'USAgov', textBestBets: [{ title: 'A best bet', description: 'This is the best bet', url: 'http://www.example.com' }] };
     const resultsData = { totalPages: 2, unboundedResults: true, results };
@@ -134,7 +130,7 @@ describe('SearchResultsLayout', () => {
   it('renders graphics best bets when there is one link in the best bet', () => {
     const results : any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
     for (let counter = 0; counter < 2; counter += 1) {
-      results.push({ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', publishedDate: 'May 9th, 2023', updatedDate: 'May 10th, 2023' });
+      results.push({ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', publishedDate: 'May 9th, 2023' });
     }
     const additionalResults = { recommendedBy: 'USAgov', textBestBets: [], graphicsBestBet: { title: 'Search support', titleUrl: 'https://search.gov/support.html', imageUrl: 'https://search.gov/support.jpg', imageAltText: 'support alt text', links: [{ title: 'Learning', url: 'https://search.gov/learn' }] } };
     const resultsData = { totalPages: 2, unboundedResults: true, results };
@@ -150,7 +146,7 @@ describe('SearchResultsLayout', () => {
   it('renders graphics best bets when there are more than two links in the best bet', () => {
     const results : any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
     for (let counter = 0; counter < 2; counter += 1) {
-      results.push({ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', publishedDate: 'May 9th, 2023', updatedDate: 'May 10th, 2023' });
+      results.push({ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', publishedDate: 'May 9th, 2023' });
     }
     const additionalResults = { recommendedBy: 'USAgov', textBestBets: [], graphicsBestBet: { title: 'Search support', titleUrl: 'https://search.gov/support.html', imageUrl: 'https://search.gov/support.jpg', imageAltText: 'support alt text', links: [{ title: 'Learning', url: 'https://search.gov/learn' }, { title: 'The homepage', url: 'https://search.gov' }, { title: 'Another link', url: 'https://www.google.com' }] } };
     const resultsData = { totalPages: 2, unboundedResults: true, results };
@@ -168,14 +164,14 @@ describe('SearchResultsLayout', () => {
   });
 
   it('renders image search results', () => {
-    const resultsData = { totalPages: 2, unboundedResults: true, results: [{ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', thumbnailUrl: 'https://www.search.gov/test_image.png', publishedDate: 'May 9th, 2023', updatedDate: 'May 10th, 2023' }] };
+    const resultsData = { totalPages: 2, unboundedResults: true, results: [{ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', thumbnailUrl: 'https://www.search.gov/test_image.png', publishedDate: 'May 9th, 2023' }] };
     render(<SearchResultsLayout affiliate={affiliate} page={page} params={{ query: 'foo' }} resultsData={resultsData} vertical='image' translations={translations} extendedHeader={true} fontsAndColors={fontsAndColors} navigationLinks={navigationLinks} facetsEnabled={false} />);
     const resultTitle = screen.getByText(/test result 1/i);
     expect(resultTitle).toBeInTheDocument();
   });
 
   it('renders image page results', () => {
-    const resultsData = { totalPages: 2, unboundedResults: true, results: [{ altText: 'Heritage Tourism | GSA', url: 'https://18f.gsa.gov/2015/06/22/avoiding-cloudfall/', thumbnailUrl: 'https://plus.unsplash.com/premium_photo-1664303499312-917c50e4047b?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8dG9ybmFkb3xlbnwwfHwwfHx8MA%3D%3D&auto=format&fit=crop&w=800&q=60', image: true, title: 'test result 1', description: 'result body', publishedDate: 'May 9th, 2023', updatedDate: 'May 10th, 2023' }] };
+    const resultsData = { totalPages: 2, unboundedResults: true, results: [{ altText: 'Heritage Tourism | GSA', url: 'https://18f.gsa.gov/2015/06/22/avoiding-cloudfall/', thumbnailUrl: 'https://plus.unsplash.com/premium_photo-1664303499312-917c50e4047b?ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MXx8dG9ybmFkb3xlbnwwfHwwfHx8MA%3D%3D&auto=format&fit=crop&w=800&q=60', image: true, title: 'test result 1', description: 'result body', publishedDate: 'May 9th, 2023' }] };
     render(<SearchResultsLayout affiliate={affiliate} page={page} params={{ query: 'foo' }} resultsData={resultsData} vertical='image' translations={translations} extendedHeader={true} fontsAndColors={fontsAndColors} navigationLinks={navigationLinks} facetsEnabled={false} />);
   });
 
@@ -209,7 +205,7 @@ describe('SearchResultsLayout', () => {
   it('renders search with results styles properly', () => {
     const results : any[] = []; // eslint-disable-line @typescript-eslint/no-explicit-any
     for (let counter = 0; counter < 20; counter += 1) {
-      results.push({ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', publishedDate: 'May 9th, 2023', updatedDate: 'May 10th, 2023' });
+      results.push({ title: 'test result 1', url: 'https://www.search.gov', description: 'result body', publishedDate: 'May 9th, 2023' });
     }
     const resultsData = { totalPages: 2, unboundedResults: true, results };
 

--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,3 +1,5 @@
+ssl_enabled = ENV['REDIS_SSL'].to_s.downcase == 'true'
+
 Rails.application.config.session_store :redis_store,
   expires_in: 7200,
   secure: Rails.application.config.ssl_options[:secure_cookies],
@@ -6,5 +8,6 @@ Rails.application.config.session_store :redis_store,
     host: ENV['REDIS_SESSION_HOST'],
     port: ENV['REDIS_SESSION_PORT'],
     db: 2,
-    key_prefix: 'usasearch:session'
+    key_prefix: 'usasearch:session',
+    ssl: ssl_enabled
   }


### PR DESCRIPTION
## Main-to-Staging:
- [SRCH-6628](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6628) / [PR#2142](https://github.com/GSA/search-gov/pull/2142) - Drops "updated on <Timestapm>" from search results
- [SRCH-5329](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-5329) / [PR#2148](https://github.com/GSA/search-gov/pull/2148) - Enable Redis session TLS when REDIS_SSL=true

[SRCH-5329]: https://gsa-stage1.atlassian-us-gov-mod.net/browse/SRCH-5329

[SRCH-6628]: https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6628