### PR TITLE
SRCH-6770 Upgrade Rack to 3.2 so 2.2.x Nessus Highs stop repeating

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,7 +14,9 @@ gem 'will_paginate', '~> 3.3.1'
 gem 'nokogiri', '~> 1.19'
 gem 'authlogic', '~> 6.4', '>= 6.4.3'
 gem 'omniauth_login_dot_gov', git: 'https://github.com/18f/omniauth_login_dot_gov', ref: '6e117a9c68b19a1fbc70533613b74b0d8affd641'
-gem 'rack', '~> 2.2'
+gem 'rack', '~> 3.2'
+gem 'rack-session', '~> 2.1'
+gem 'rackup', '~> 2.2'
 
 # It's not clear that this gem is still required. I'm leaving it for the time being,
 # but we may be able to remove it in the future:
@@ -145,7 +147,7 @@ gem 'bootsnap', require: false
 gem 'rails_semantic_logger', '~> 4.14'
 gem 'whenever', '~> 1.0', require: false
 gem 'fugit', '~> 1.8'
-gem 'puma', '~> 5.6'
+gem 'puma', '~> 6.6'
 gem 'htmlbeautifier', '~> 1.4', '>= 1.4.3'
 
 # Bundle gems for the local environment. Make sure to
@@ -162,7 +164,7 @@ group :development do
   gem 'capistrano-rails',  require: false
   gem 'capistrano-rbenv',  require: false
   gem 'capistrano-resque', require: false
-  gem 'capistrano3-puma',  '~> 5.2',  require: false
+  gem 'capistrano3-puma',  '~> 6.0',  require: false
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -171,7 +171,7 @@ GEM
     after_commit_action (1.1.0)
       activerecord (>= 3.0.0)
       activesupport (>= 3.0.0)
-    airbrussh (1.5.3)
+    airbrussh (1.6.2)
       sshkit (>= 1.6.1, != 1.7.0)
     amazing_print (1.8.1)
     american_date (1.1.1)
@@ -228,12 +228,12 @@ GEM
       msgpack (~> 1.2)
     builder (3.3.0)
     byebug (12.0.0)
-    capistrano (3.19.2)
+    capistrano (3.20.1)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
       sshkit (>= 1.9.0)
-    capistrano-bundler (2.1.1)
+    capistrano-bundler (2.2.0)
       capistrano (~> 3.1)
     capistrano-rails (1.7.0)
       capistrano (~> 3.1)
@@ -245,10 +245,10 @@ GEM
       capistrano
       resque
       resque-scheduler
-    capistrano3-puma (5.2.0)
+    capistrano3-puma (6.2.0)
       capistrano (~> 3.7)
       capistrano-bundler
-      puma (>= 4.0, < 6.0)
+      puma (>= 5.1, < 7.0)
     capybara (3.40.0)
       addressable
       matrix
@@ -276,7 +276,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     colorize (0.8.1)
-    concurrent-ruby (1.3.5)
+    concurrent-ruby (1.3.8)
     connection_pool (2.5.3)
     counter_culture (2.9.0)
       activerecord (>= 4.2)
@@ -440,7 +440,7 @@ GEM
       multi_xml (>= 0.5.2)
     httpclient (2.9.0)
       mutex_m
-    i18n (1.14.7)
+    i18n (1.15.2)
       concurrent-ruby (~> 1.0)
     i18n-tasks (0.9.37)
       activesupport (>= 4.0.2)
@@ -513,8 +513,7 @@ GEM
     multi_xml (0.7.1)
       bigdecimal (~> 3.1)
     multipart-post (2.4.1)
-    mustermann (3.0.3)
-      ruby2_keywords (~> 0.0.1)
+    mustermann (3.1.1)
     mutex_m (0.2.0)
     mysql2 (0.5.7)
       bigdecimal
@@ -532,9 +531,9 @@ GEM
       net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.1)
       net-protocol
-    net-ssh (7.3.0)
+    net-ssh (7.3.3)
     newrelic_rpm (9.19.0)
-    nio4r (2.7.4)
+    nio4r (2.7.5)
     nokogiri (1.19.4)
       mini_portile2 (~> 2.8.2)
       racc (~> 1.4)
@@ -570,27 +569,28 @@ GEM
       date
       stringio
     public_suffix (6.0.2)
-    puma (5.6.9)
+    puma (6.6.1)
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.24)
+    rack (3.2.7)
     rack-contrib (2.5.0)
       rack (< 4)
     rack-cors (1.1.1)
       rack (>= 2.0.0)
-    rack-protection (3.2.0)
+    rack-protection (4.2.1)
       base64 (>= 0.1.0)
-      rack (~> 2.2, >= 2.2.4)
+      logger (>= 1.6.0)
+      rack (>= 3.0.0, < 4)
     rack-proxy (0.7.7)
       rack
-    rack-session (1.0.2)
-      rack (< 3)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.3.1)
+      rack (>= 3)
     rails (7.1.6)
       actioncable (= 7.1.6)
       actionmailbox (= 7.1.6)
@@ -763,7 +763,6 @@ GEM
       lint_roller (~> 1.1)
       rubocop (~> 1.72, >= 1.72.1)
     ruby-progressbar (1.13.0)
-    ruby2_keywords (0.0.5)
     rubyzip (2.4.1)
     rufus-scheduler (3.9.2)
       fugit (~> 1.1, >= 1.11.1)
@@ -808,10 +807,12 @@ GEM
       json (>= 1.8, < 3)
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.2)
-    sinatra (3.2.0)
+    sinatra (4.2.1)
+      logger (>= 1.6.0)
       mustermann (~> 3.0)
-      rack (~> 2.2, >= 2.2.4)
-      rack-protection (= 3.2.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.2.1)
+      rack-session (>= 2.0.0, < 3)
       tilt (~> 2.0)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
@@ -821,7 +822,7 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sshkit (1.24.0)
+    sshkit (1.25.1)
       base64
       logger
       net-scp (>= 1.1.2)
@@ -838,7 +839,7 @@ GEM
       climate_control (>= 0.0.3, < 1.0)
     thor (1.4.0)
     thread_safe (0.3.6)
-    tilt (2.6.1)
+    tilt (2.9.0)
     timeout (0.4.3)
     trailblazer-option (0.1.2)
     truncator (0.1.7)
@@ -878,7 +879,7 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.1)
+    webrick (1.9.2)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -918,7 +919,7 @@ DEPENDENCIES
   capistrano-rails
   capistrano-rbenv
   capistrano-resque
-  capistrano3-puma (~> 5.2)
+  capistrano3-puma (~> 6.0)
   capybara (~> 3.40)
   capybara-screenshot
   cld3 (~> 3.6.0)
@@ -974,10 +975,12 @@ DEPENDENCIES
   opensearch-dsl
   pry-byebug (~> 3.5)
   pry-rails (~> 0.3.6)
-  puma (~> 5.6)
-  rack (~> 2.2)
+  puma (~> 6.6)
+  rack (~> 3.2)
   rack-contrib (~> 2.5.0)
   rack-cors (~> 1.1.0)
+  rack-session (~> 2.1)
+  rackup (~> 2.2)
   rails (~> 7.1.4)
   rails-controller-testing (~> 1.0)
   rails-observers (~> 0.1.5)

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid for current version and patch releases of Capistrano
-lock '~> 3.19.1'
+lock '~> 3.20.0'
 
 require 'securerandom'
 require 'shellwords'
@@ -18,6 +18,7 @@ set :puma_bind,               'tcp://0.0.0.0:3000'
 set :puma_error_log,          "#{release_path}/log/puma.error.log"
 set :puma_threads,            [ENV.fetch('SEARCHGOV_MIN_THREADS', SEARCHGOV_THREADS), SEARCHGOV_THREADS]
 set :puma_workers,            ENV.fetch('SEARCHGOV_WORKERS') { 0 }
+set :puma_systemctl_user,     :system
 set :rails_env,               'production'
 set :rbenv_type,              :user
 set :repo_url,                'https://github.com/GSA/search-gov'


### PR DESCRIPTION
## Summary
- Moves the app off the Rack 2.2 line (`2.2.24` → `3.2.7`) so the next 2.2.x CVE does not become another Nessus High.
- Unlocks the gems that were pinning us to Rack 2: `rack-session` 2.1.2, `rackup` 2.3.1, `sinatra` 4.2.1, `rack-protection` 4.2.1.
- Puma 5 cannot boot Rack 3, so this also takes Puma `5.6.9` → `6.6.1` and `capistrano3-puma` `5.2` → `6.2`. Capistrano lock is `~> 3.20.0` to match the resolved gem. `puma_systemctl_user` stays `:system`.
- This is for `main` only. Tracked as [SRCH-6770](https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6770). The production 2.2.24 release is [PR #2155](https://github.com/GSA/search-gov/pull/2155). Do not merge this onto `production` until that ships and this soaks on staging.

## Test plan
- [x] `bundle update` inside the search-gov Docker container
- [x] App boots with Puma 6.6.1 / Rack 3.2.7 on `localhost:3000`
- [x] `/up` and `/healthcheck` return 200
- [x] Playwright against local Docker: `test_affiliate` SERP, `spanish_affiliate` SERP, advanced search (5/5 pass)
- [ ] CI green
- [ ] First staging deploy: confirm systemd still uses the system unit (`cap staging puma:install` if capistrano3-puma 6 requires it)
- [ ] After staging soak, `bundle show rack` is 3.2.7 and leftover 2.2.x gemspecs are gone

### Checklist

#### Functionality Checks
- [x] Merged latest `main` into this branch (branched from current `upstream/main`)
- [x] Primary commit message is `SRCH-6765: Upgrade Rack to 3.2 so 2.2.x Nessus Highs stop repeating`
- [x] PR title matches SRCH-6770
- [ ] Automated checks pass

#### Process Checks
- [x] Reviewer specified (`selfdanielj`)

[SRCH-6770]: https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6770
[SRCH-6765]: https://gsa-standard.atlassian-us-gov-mod.net/browse/SRCH-6765