### PR TITLE
Release - SRCH-6704, SRCH-6765

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,10 +32,11 @@ gem 'resque-scheduler', '~> 4.10.2'
 # Paperclip is deprecated: https://cm-jira.usa.gov/browse/SRCH-702
 # Using a third-party fork as an interim measure.
 gem 'kt-paperclip', '~> 7.1.0'
-gem 'aws-sdk-s3', '~> 1.102.0'
+gem 'aws-sdk-s3', '~> 1.102'
 gem 'googlecharts', '~> 1.6.12'
 gem 'flickraw', '~> 0.9.9'
 gem 'mutex_m', '~> 0.2.0'
+gem 'erb', '~> 4.0.4'
 gem 'bigdecimal', '~> 3.1', '>= 3.1.8'
 gem 'rexml', '>= 3.4.2'
 gem 'csv', '~> 3.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -191,20 +191,21 @@ GEM
       request_store (~> 1.0)
     aws-eventstream (1.4.0)
     aws-partitions (1.1134.0)
-    aws-sdk-core (3.227.0)
+    aws-sdk-core (3.254.1)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
       base64
+      bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
     aws-sdk-kms (1.107.0)
       aws-sdk-core (~> 3, >= 3.227.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.102.0)
-      aws-sdk-core (~> 3, >= 3.120.0)
+    aws-sdk-s3 (1.229.0)
+      aws-sdk-core (~> 3, >= 3.254.1)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.4)
+      aws-sigv4 (~> 1.5)
     aws-sigv4 (1.12.1)
       aws-eventstream (~> 1, >= 1.0.2)
     axe-core-api (4.10.3)
@@ -268,7 +269,7 @@ GEM
     capybara-screenshot (1.0.26)
       capybara (>= 1.0, < 4)
       launchy
-    cgi (0.5.0)
+    cgi (0.5.2)
     chronic (0.10.2)
     cld3 (3.6.0)
     climate_control (0.2.0)
@@ -371,7 +372,7 @@ GEM
       launchy (>= 2.1, < 4.0)
       mail (~> 2.7)
     equalizer (0.0.11)
-    erb (4.0.4)
+    erb (4.0.4.1)
       cgi (>= 0.3.3)
     erubi (1.13.1)
     et-orbi (1.2.11)
@@ -453,7 +454,7 @@ GEM
     http-cookie (1.0.8)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
-    httparty (0.23.1)
+    httparty (0.24.2)
       csv
       mini_mime (>= 1.0.0)
       multi_xml (>= 0.5.2)
@@ -593,7 +594,7 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.22)
+    rack (2.2.24)
     rack-contrib (2.5.0)
       rack (< 4)
     rack-cors (1.1.1)
@@ -924,7 +925,7 @@ DEPENDENCIES
   amazing_print (~> 1.4)
   american_date (~> 1.1.1)
   authlogic (~> 6.4, >= 6.4.3)
-  aws-sdk-s3 (~> 1.102.0)
+  aws-sdk-s3 (~> 1.102)
   axe-core-capybara
   axe-core-cucumber
   bigdecimal (~> 3.1, >= 3.1.8)
@@ -952,6 +953,7 @@ DEPENDENCIES
   elasticsearch-persistence
   elasticsearch-xpack (~> 7.4.0)
   email_spec (~> 2.2)
+  erb (~> 4.0.4)
   exception_notification (~> 4.5)
   faker (~> 1.8)
   faraday_middleware


### PR DESCRIPTION
## Summary
- Dedicated production release so prod leaves Rack 2.2.22 (Nessus High, plugin 3059599). Not mixed into Batch 4 or the Rack 3 / Puma 6 PR.
- Rebased onto current `production` (Batch 3, `b5b718462`). Same two-file bump: Rack 2.2.22 → 2.2.24, plus the SRCH-6704 erb / httparty / aws-sdk-s3 set.
- Staging already runs 2.2.24. Leftover `rack-2.2.22.gemspec` files must be removed after deploy so Nessus does not keep seeing the old file.

Merging this PR deploys production (`prod_app_searchgov_pipeline`). After Succeeded, confirm all 6 Pumas boot the new release dir before calling it done.

### Checklist
Please ensure you have addressed all concerns below before marking a PR "ready for review" or before requesting a re-review. If you cannot complete an item below, replace the checkbox with the ⚠️ `:warning:` emoji and explain why the step was not completed.

#### Functionality Checks

- [x] You have merged the latest changes from the target branch (usually `main`) into your branch.

- [x] Your primary commit message is of the format **SRCH-#### \<description\>** matching the associated Jira ticket.

- [x] PR title is either of the format **SRCH-#### \<description\>** matching the associated Jira ticket (i.e. "SRCH-123 implement feature X"), or **Release - SRCH-####, SRCH-####, SRCH-####** matching the Jira ticket numbers in the release.

- [ ] Automated checks pass. If Code Climate checks do not pass, explain reason for failures:

#### Process Checks

- [x] You have specified at least one "Reviewer".

## Test plan
- [x] Staging app + crawl lockfile and installed gem are `rack (2.2.24)`
- [ ] CI green against this branch
- [ ] After prod deploy: `bundle show rack` is 2.2.24 on app and crawl
- [ ] After prod deploy: no `rack-2.2.22.gemspec` under `/home/search/.rbenv` or `/home/search/searchgov/shared/bundle`
- [ ] All 6 apps: Puma `[dir]` matches `basename $(readlink -f current)`